### PR TITLE
Updated GPG key and {own,next}cloud references

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -2,16 +2,16 @@
 Manual Installation on Linux
 ============================
 
-Installing ownCloud on Linux from our Open Build Service packages is the 
+Installing Nextcloud on Linux from our Open Build Service packages is the 
 preferred method (see :doc:`linux_installation`). These are maintained by 
-ownCloud engineers, and you can use your package manager to keep your ownCloud 
-server up-to-date.
+Nextcloud engineers, and you can use your package manager to keep your 
+Nextcloud server up-to-date.
 
 .. note:: Enterprise customers should refer to  
    :doc:`../enterprise_installation/linux_installation`
 
 If there are no packages for your Linux distribution, or you prefer installing 
-from the source tarball, you can setup ownCloud from scratch using a classic 
+from the source tarball, you can setup Nextcloud from scratch using a classic 
 LAMP stack (Linux, Apache, MySQL/MariaDB, PHP). This document provides a 
 complete walk-through for installing Nextcloud on Ubuntu 14.04 LTS Server with 
 Apache and MariaDB, using `the Nextcloud .tar archive 
@@ -32,15 +32,15 @@ Apache and MariaDB, using `the Nextcloud .tar archive
 
 .. note:: Admins of SELinux-enabled distributions such as CentOS, Fedora, and 
    Red Hat Enterprise Linux may need to set new rules to enable installing 
-   ownCloud. See :ref:`selinux_tips_label` for a suggested configuration.
+   Nextcloud. See :ref:`selinux_tips_label` for a suggested configuration.
 
 .. _prerequisites_label:
 
 Prerequisites
 -------------
 
-The ownCloud .tar archive contains all of the required PHP modules. This section 
-lists all required and optional PHP modules.  Consult the `PHP manual 
+The Nextcloud .tar archive contains all of the required PHP modules. This 
+section lists all required and optional PHP modules.  Consult the `PHP manual 
 <http://php.net/manual/en/extensions.php>`_ for more information on modules. 
 Your Linux distribution should have packages for all required modules. You can 
 check the precense of a module by typing ``php -m | grep -i <module_name>``. 
@@ -114,8 +114,9 @@ For command line processing (*optional*):
 * PHP module pcntl (enables command interruption by pressing ``ctrl-c``)
 
 You don’t need the WebDAV module for your Web server (i.e. Apache’s 
-``mod_webdav``), as ownCloud has a built-in WebDAV server of its own, SabreDAV. 
-If ``mod_webdav`` is enabled you must disable it for ownCloud. (See 
+``mod_webdav``), as Nextcloud has a built-in WebDAV server of its own,
+SabreDAV.
+If ``mod_webdav`` is enabled you must disable it for Nextcloud. (See 
 :ref:`apache_configuration_label` for an example configuration.)
   
 .. _ubuntu_installation_label:  
@@ -124,14 +125,14 @@ Example Installation on Ubuntu 14.04 LTS Server
 -----------------------------------------------
 
 On a machine running a pristine Ubuntu 14.04 LTS server, install the
-required and recommended modules for a typical ownCloud installation, using
+required and recommended modules for a typical Nextcloud installation, using
 Apache and MariaDB, by issuing the following commands in a terminal::
 
     apt-get install apache2 mariadb-server libapache2-mod-php5
     apt-get install php5-gd php5-json php5-mysql php5-curl
     apt-get install php5-intl php5-mcrypt php5-imagick
 
-* This installs the packages for the ownCloud core system. 
+* This installs the packages for the Nextcloud core system. 
   ``libapache2-mod-php5`` provides the following PHP extensions: ``bcmath bz2 
   calendar Core ctype date dba dom ereg exif fileinfo filter ftp gettext hash 
   iconv libxml mbstring mhash openssl pcre Phar posix Reflection session shmop 
@@ -142,9 +143,9 @@ Apache and MariaDB, by issuing the following commands in a terminal::
 
 * At the installation of the MySQL/MariaDB server, you will be prompted to 
   create a root password. Be sure to remember your password as you will need it 
-  during ownCloud database setup.
+  during Nextcloud database setup.
 
-Now download the archive of the latest ownCloud version:
+Now download the archive of the latest Nextcloud version:
 
 * Go to the `Nextcloud Download Page <https://nextcloud.com/install>`_.
 * Go to **Download Nextcloud Server > Download > Archive file for 
@@ -163,8 +164,8 @@ Now download the archive of the latest ownCloud version:
 * You may also verify the PGP signature::
     
     wget https://download.nextcloud.com/server/releases/nextcloud-x.y.z.tar.bz2.asc
-    wget https://owncloud.org/owncloud.asc
-    gpg --import owncloud.asc
+    wget https://nextcloud.com/nextcloud.asc
+    gpg --import nextcloud.asc
     gpg --verify nextcloud-x.y.z.tar.bz2.asc nextcloud-x.y.z.tar.bz2
   
 * Now you can extract the archive contents. Run the appropriate unpacking 
@@ -175,7 +176,7 @@ Now download the archive of the latest ownCloud version:
 
 * This unpacks to a single ``nextcloud`` directory. Copy the Nextcloud directory 
   to its final destination. When you are running the Apache HTTP server you may 
-  safely install ownCloud in your Apache document root::
+  safely install Nextcloud in your Apache document root::
 
     cp -r nextcloud /path/to/webserver/document-root
 
@@ -184,7 +185,7 @@ Now download the archive of the latest ownCloud version:
     
     cp -r nextcloud /var/www
 
-On other HTTP servers it is recommended to install ownCloud outside of the 
+On other HTTP servers it is recommended to install Nextcloud outside of the 
 document root.
 
 .. _binlog_format_label:
@@ -192,7 +193,7 @@ document root.
 BINLOG_FORMAT = STATEMENT
 -------------------------
 
-If your ownCloud installation fails and you see this in your ownCloud log::
+If your Nextcloud installation fails and you see this in your Nextcloud log::
 
  An unhandled exception has been thrown: exception ‘PDOException’ with message 
  'SQLSTATE[HY000]: General error: 1665 Cannot execute statement: impossible to 
@@ -235,8 +236,8 @@ Then create a symlink to :file:`/etc/apache2/sites-enabled`::
 Additional Apache Configurations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* For ownCloud to work correctly, we need the module ``mod_rewrite``. Enable it 
-  by running::
+* For Nextcloud to work correctly, we need the module ``mod_rewrite``. Enable
+  it by running::
 
     a2enmod rewrite
   
@@ -251,25 +252,25 @@ Additional Apache Configurations
   
     a2enmod setenvif
 
-* You must disable any server-configured authentication for ownCloud, as it 
+* You must disable any server-configured authentication for Nextcloud, as it 
   uses Basic authentication internally for DAV services. If you have turned on 
-  authentication on a parent folder (via e.g. an ``AuthType Basic``
-  directive), you can turn off the authentication specifically for the ownCloud 
-  entry. Following the above example configuration file, add the following line 
-  in the ``<Directory`` section::
+  authentication on a parent folder (via e.g. an ``AuthType Basic`` 
+  directive), you can turn off the authentication specifically for the 
+  Nextcloud entry. Following the above example configuration file, add the 
+  following line in the ``<Directory`` section::
 
     Satisfy Any
 
-* When using SSL, take special note of the ServerName. You should specify one in 
-  the  server configuration, as well as in the CommonName field of the 
-  certificate. If you want your ownCloud to be reachable via the internet, then 
-  set both of these to the domain you want to reach your ownCloud server.
+* When using SSL, take special note of the ServerName. You should specify one 
+  in the server configuration, as well as in the CommonName field of the 
+  certificate. If you want your Nextcloud to be reachable via the internet, 
+  then set both of these to the domain you want to reach your Nextcloud server.
 
 * Now restart Apache::
 
      service apache2 restart
 
-* If you're running ownCloud in a subdirectory and want to use CalDAV or 
+* If you're running Nextcloud in a subdirectory and want to use CalDAV or 
   CardDAV clients make sure you have configured the correct 
   :ref:`service-discovery-label` URLs.
   
@@ -287,8 +288,8 @@ HTTP user, ``mod_env`` and ``mod_rewrite`` are installed, and
 Enabling SSL
 ------------
 
-.. note:: You can use ownCloud over plain HTTP, but we strongly encourage you to
-          use SSL/TLS to encrypt all of your server traffic, and to protect 
+.. note:: You can use Nextcloud over plain HTTP, but we strongly encourage you 
+          to use SSL/TLS to encrypt all of your server traffic, and to protect 
           user's logins and data in transit.
 
 Apache installed under Ubuntu comes already set-up with a simple
@@ -300,8 +301,8 @@ the default site. Open a terminal and run::
      service apache2 reload
 
 .. note:: Self-signed certificates have their drawbacks - especially when you
-          plan to make your ownCloud server publicly accessible. You might want
-          to consider getting a certificate signed by a commercial signing
+          plan to make your Nextcloud server publicly accessible. You might 
+          want to consider getting a certificate signed by a commercial signing
           authority. Check with your domain name registrar or hosting service 
           for good deals on commercial certificates.   
     
@@ -312,14 +313,14 @@ Installation Wizard
 
 After restarting Apache you must complete your installation by running either 
 the graphical Installation Wizard, or on the command line with the ``occ`` 
-command. To enable this, temporarily change the ownership on your ownCloud 
+command. To enable this, temporarily change the ownership on your Nextcloud 
 directories to your HTTP user (see :ref:`strong_perms_label` to learn how to 
 find your HTTP user)::
 
  chown -R www-data:www-data /var/www/nextcloud/
  
 .. note:: Admins of SELinux-enabled distributions may need to write new SELinux 
-   rules to complete their ownCloud installation; see 
+   rules to complete their Nextcloud installation; see 
    :ref:`selinux_tips_label`. 
 
 To use ``occ`` see :doc:`command_line_installation`. 
@@ -330,10 +331,10 @@ Setting Strong Directory Permissions
 ------------------------------------
 
 After completing installation, you must immediately set the directory 
-permissions in your ownCloud installation as strictly as possible for stronger 
+permissions in your Nextcloud installation as strictly as possible for stronger 
 security. Please refer to :ref:`strong_perms_label`.
 
-Now your ownCloud server is ready to use.
+Now your Nextcloud server is ready to use.
 
 .. _selinux_tips_label:
 
@@ -359,7 +360,7 @@ ini file. This can be the case, for example, for the ``date.timezone`` setting.
    /etc/php5/fpm/php.ini
  or ...
 
-**php.ini - used by the php-cli and so by ownCloud CRON jobs:**
+**php.ini - used by the php-cli and so by Nextcloud CRON jobs:**
 ::
 
   /etc/php5/cli/php.ini
@@ -414,10 +415,10 @@ confirm your paths, for example::
 If any of your system environment variables are not present in the file then 
 you must add them.
 
-When you are using shared hosting or a control panel to manage your ownCloud VM 
-or server, the configuration files are almost certain to be located somewhere 
-else, for security and flexibility reasons, so check your documentation for the 
-correct locations.
+When you are using shared hosting or a control panel to manage your Nextcloud 
+VM or server, the configuration files are almost certain to be located 
+somewhere else, for security and flexibility reasons, so check your 
+documentation for the correct locations.
 
 Please keep in mind that it is possible to create different settings for 
 ``php-cli`` and ``php-fpm``, and for different domains and Web sites. 
@@ -432,9 +433,9 @@ server in order for these changes to be applied.
 
 **.htaccess notes for Apache**
 
-Nextcloud comes with its own ``nextcloud/.htaccess`` file. Because ``php-fpm`` can't 
-read PHP settings in ``.htaccess`` these settings and permissions must be set
-in the ``nextcloud/.user.ini`` file.
+Nextcloud comes with its own ``nextcloud/.htaccess`` file. Because ``php-fpm`` 
+can't read PHP settings in ``.htaccess`` these settings and permissions must 
+be set in the ``nextcloud/.user.ini`` file.
 
 .. _other_HTTP_servers_label:
 
@@ -444,8 +445,8 @@ Other Web Servers
 :doc:`nginx_examples`
 
 
-`Other HTTP servers (ownCloud)
-<https://github.com/owncloud/documentation/wiki/Alternate-Web-server-notes>`_
+`Other HTTP servers (Nextcloud)
+<https://github.com/nextcloud/documentation/wiki/Alternate-Web-server-notes>`_
 
 `Univention Corporate Server installation (ownCloud)
 <https://github.com/owncloud/documentation/wiki/UCS-Installation>`_


### PR DESCRIPTION
The GPG path was still pointing to owncloud server.

Also ownCloud was still mentioned.