### PR TITLE
Remove trailing / to reduce the risk of running find on /

### DIFF
--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -157,11 +157,11 @@ replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
  mkdir -p $ncpath/updater
 
  printf "chmod Files and Directories\n"
- find ${ncpath}/ -type f -print0 | xargs -0 chmod 0640
- find ${ncpath}/ -type d -print0 | xargs -0 chmod 0750
+ find ${ncpath} -type f -print0 | xargs -0 chmod 0640
+ find ${ncpath} -type d -print0 | xargs -0 chmod 0750
 
  printf "chown Directories\n"
- chown -R ${rootuser}:${htgroup} ${ncpath}/
+ chown -R ${rootuser}:${htgroup} ${ncpath}
  chown -R ${htuser}:${htgroup} ${ncpath}/apps/
  chown -R ${htuser}:${htgroup} ${ncpath}/assets/
  chown -R ${htuser}:${htgroup} ${ncpath}/config/


### PR DESCRIPTION
Removed trailing slash, if someone runs these commands without setting `$ncpath` this doesn't break the whole system.