### PR TITLE
Updated for changes from ownCloud to Nextcloud

### DIFF
--- a/admin_manual/enterprise_clients/index.rst
+++ b/admin_manual/enterprise_clients/index.rst
@@ -1,6 +1,6 @@
-===================================================
-Creating Branded ownCloud Clients (Enterprise only)
-===================================================
+==================================
+Creating Branded Nextcloud Clients
+==================================
 
 .. toctree::
    :maxdepth: 3

--- a/admin_manual/enterprise_installation/index.rst
+++ b/admin_manual/enterprise_installation/index.rst
@@ -1,5 +1,5 @@
 ===============================
-Enterprise Edition Installation
+Enterprise Installation
 ===============================
 
 .. toctree::

--- a/admin_manual/index.rst
+++ b/admin_manual/index.rst
@@ -1,27 +1,24 @@
 ============================================================
-ownCloud |version| Server Administration Manual Introduction
+Nextcloud |version| Server Administration Manual Introduction
 ============================================================
 
 Introduction
 ------------
 
-Welcome to the ownCloud Server Administration Guide. This guide describes 
-administration tasks for ownCloud, the flexible open source file synchronization 
-and sharing solution. ownCloud includes the ownCloud server, which runs on 
+Welcome to the Nextcloud Server Administration Guide. This guide describes 
+administration tasks for Nextcloud, the flexible open source file synchronization 
+and sharing solution. Nextcloud includes the Nextcloud server, which runs on 
 Linux, client applications for Microsoft Windows, Mac OS X and Linux, and mobile 
 clients for the Android and Apple iOS operating systems.
 
-Current editions of ownCloud manuals are always available online at 
-`doc.owncloud.org <https://doc.owncloud.org/>`_ and `doc.owncloud.com 
+Current editions of Nextcloud manuals are always available online at 
+`doc.owncloud.org <https://docs.nextcloud.org/>`_ and `doc.owncloud.com 
 <https://doc.owncloud.com/>`_.
 
-ownCloud server is available in three editions:
+Nextcloud server is available:
 
-* The free community-supported Server. This is the core server for all editions.
-* The Standard Subscription for customers who want paid support for the core 
-  Server, without Enterprise applications.
-* The Enterprise Subscription provides paid support for the Enterprise Edition. 
-  This includes the core Server and Enterprise apps.
+* As a free, full featured community-supported server, with all enterprise features.
+* Or with full enterprise support, including phone and email access to Nextcloud developers.
   
 See :doc:`../whats_new_admin` for more information on the different ownCloud 
 editions.
@@ -29,28 +26,27 @@ editions.
 ownCloud Videos and Blogs
 -------------------------
 
-See the `official ownCloud channel 
-<https://www.youtube.com/channel/UC_4gez4lsWqciH-otOlXo5w>`_ and `ownClouders 
-community channel <https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw>`_ 
+See the `official Nextcloud channel 
+<https://www.youtube.com/channel/UCQjN5Fs5QSz1loJqLb5bkew>`_ 
 on YouTube for tutorials, overviews, and conference videos.
 
-Visit `ownCloud Planet <https://owncloud.org/news/>`_ for news and developer 
+Visit `Nextcloud Planet <https://nextcloud.com/news/>`_ for news and developer 
 blogs.
 
 Target Audience
 ---------------
 
 This guide is for users who want to install, administer, and
-optimize their ownCloud servers. To learn more about the ownCloud Web
+optimize their Nextcloud servers. To learn more about the Nextcloud Web
 user interface, and desktop and mobile clients, please refer to their 
 respective manuals:
 
-* `ownCloud User Manual`_
-* `ownCloud Desktop Client`_
-* `ownCloud Android App`_
-* `ownCloud iOS App`_ 
+* `Nextcloud User Manual`_
+* `Nextcloud Desktop Client`_
+* `Nextcloud Android App`_
+* `Nextcloud iOS App`_ 
 
-.. _`ownCloud User Manual`: https://doc.owncloud.org/server/9.0/user_manual/
-.. _`ownCloud Desktop Client`: https://doc.owncloud.org/desktop/2.1/
-.. _`ownCloud Android App`: https://doc.owncloud.org/android/
-.. _`ownCloud iOS App`: https://doc.owncloud.org/ios/
+.. _`Nextcloud User Manual`: https://docs.nextcloud.org/server/9.0/user_manual/
+.. _`Nextcloud/ownCloud Desktop Client`: https://doc.owncloud.org/desktop/2.2/
+.. _`Nextcloud Android App`: https://docs.nextcloud.org/android/
+.. _`Nextcloud iOS App`: https://docs.nextcloud.org/ios/

--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -1,18 +1,19 @@
 ===================
-Backing up ownCloud
+Backing up Nextcloud
 ===================
 
-To backup an ownCloud installation there are three main things you need to retain:
+To backup an Nextcloud installation there are four main things you need to retain:
 
 #. The config folder
 #. The data folder
 #. The database
+#. The theme folder
 
 Backup Folders
 --------------
 
-Simply copy your config and data folder (or even your whole ownCloud install and data folder) to a place outside of
-your ownCloud environment. You could use this command::
+Simply copy your config, data and theme folders (or even your whole Nextcloud install and data folder) to a place outsid of
+your Nextcloud environment. You could use this command::
 
     rsync -Aax nextcloud/ nextcloud-dirbkp_`date +"%Y%m%d"`/
 

--- a/admin_manual/maintenance/enable_maintenance.rst
+++ b/admin_manual/maintenance/enable_maintenance.rst
@@ -2,7 +2,7 @@
 Maintenance Mode Configuration
 ==============================
 
-You must put your ownCloud server into maintenance mode before performing 
+You must put your Nextcloud server into maintenance mode before performing 
 upgrades, and for performing troubleshooting and maintenance. Please 
 see :doc:`../configuration_server/occ_command` to learn how to put your server into 
 the various maintenance modes (``maintenance:mode, maintenance:singleuser``, 

--- a/admin_manual/maintenance/manual_upgrade.rst
+++ b/admin_manual/maintenance/manual_upgrade.rst
@@ -1,5 +1,5 @@
 =======================
-Manual ownCloud Upgrade
+Manual Nextcloud Upgrade
 =======================
 
 Always start by making a fresh backup and disabling all 3rd party apps.
@@ -15,37 +15,35 @@ your HTTP user. This example is for Ubuntu Linux::
 The other way is by entering your ``config.php`` file and changing 
 ``'maintenance' => false,`` to ``'maintenance' => true,``. 
 
-1. Back up your existing ownCloud Server database, data directory, and 
+1. Back up your existing Nextcloud Server database, data directory, and 
    ``config.php`` file. (See :doc:`backup`.)
-2. Download and unpack the latest ownCloud Server release (Archive file) from 
-   `owncloud.org/install/`_ into an empty directory outside 
+2. Download and unpack the latest Nextcloud Server release (Archive file) from 
+   `nextcloud.org/install/`_ into an empty directory outside 
    of your current installation.
    
    .. note:: To unpack your new tarball, run:
-      tar xjf owncloud-[version].tar.bz2
+      tar xjf nextcloud-[version].tar.bz2
     
-.. note:: Enterprise users must download their new ownCloud archives from 
-   their accounts on `<https://customer.owncloud.com/owncloud/>`_
-   
+
 3. Stop your Web server.
 
-4. Rename your current ownCloud directory, for example ``owncloud-old``.
+4. Rename your current Nextcloud directory, for example ``nextcloud-old``.
 
-5. Unpacking the new archive creates a new ``owncloud`` directory populated 
+5. Unpacking the new archive creates a new ``nextcloud`` directory populated 
    with your new server files. Copy this directory and its contents to the 
    original location of your old server, for example ``/var/www/``, so that 
-   once again you have ``/var/www/owncloud``.
+   once again you have ``/var/www/nextcloud``.
 
-6. Copy the ``config.php`` file from your old ownCloud directory to your new 
-   ownCloud directory.
+6. Copy the ``config.php`` file from your old Nextcloud directory to your new 
+   Nextcloud directory.
 
-7. If you keep your ``data/`` directory in your ``owncloud/`` directory, copy 
-   it from your old version of ownCloud to your new ``owncloud/``. If you keep 
-   it outside of ``owncloud/`` then you don't have to do anything with it, 
+7. If you keep your ``data/`` directory in your ``nextcloud/`` directory, copy 
+   it from your old version of Nextcloud to your new ``nextcloud/``. If you keep 
+   it outside of ``nextcloud/`` then you don't have to do anything with it, 
    because its location is configured in your original ``config.php``, and 
    none of the upgrade steps touch it.
 
-8. If you are using 3rd party applications, look in your new ``owncloud/apps/`` 
+8. If you are using 3rd party applications, look in your new ``nextcloud/apps/`` 
    directory to see if they are there. If not, copy them from your old ``apps/``
    directory to your new one. Make sure the directory permissions of your third
    party application directories are the same as for the other ones.
@@ -69,13 +67,13 @@ Login and take a look at the bottom of your Admin page to
 verify the version number. Check your other settings to make sure they're 
 correct. Go to the Apps page and review the core apps to make sure the right 
 ones are enabled. Re-enable your third-party apps. Then apply strong 
-permissions to your ownCloud directories (:ref:`strong_perms_label`).
+permissions to your Nextcloud directories (:ref:`strong_perms_label`).
 
-Previous ownCloud Releases
+Previous Nextcloud Releases
 --------------------------
 
-You'll find previous ownCloud releases in the `ownCloud Server Changelog 
-<https://owncloud.org/changelog/>`_.
+You'll find previous Nextcloud releases in the `Nextcloud Server Changelog 
+<https://nextcloud.com/changelog/>`_.
 
 Reverse Upgrade
 ---------------
@@ -104,10 +102,10 @@ help::
 
  sudo -u www-data php console.php files:scan --all
 
-See `the owncloud.org support page <https://owncloud.org/support>`_ for further
-resources for both home and enterprise users.
+See `the nextcloud.com support page <https://nextcloud.com/support/>`_ for further
+resources.
 
-Sometimes, ownCloud can get *stuck in a upgrade*. This is usually due to the 
+Sometimes, Nextcloud can get *stuck in a upgrade*. This is usually due to the 
 process taking too long and encountering a PHP time-out. Stop the upgrade 
 process this way::
 
@@ -122,6 +120,6 @@ If this does not work properly, try the repair function::
  sudo -u www-data php occ maintenance:repair
 
 
-.. _owncloud.org/install/:
-   https://owncloud.org/install/  
+.. _nextcloud.com/install/:
+   https://nextcloud.com/install/  
   

--- a/admin_manual/maintenance/migrating.rst
+++ b/admin_manual/maintenance/migrating.rst
@@ -3,52 +3,52 @@ Migrating to a Different Server
 ===============================
 
 
-If the need arises ownCloud can be migrated to a different server. A typical
+If the need arises Nextcloud can be migrated to a different server. A typical
 use case would be a hardware change or a migration from the virtual Appliance
-to a physical server. All migrations have to be performed with ownCloud
+to a physical server. All migrations have to be performed with Nextcloud
 offline and no accesses being made. Online migration is supported by
-ownCloud only when implementing industry standard clustering and HA solutions
-before ownCloud is installed for the first time.
+Nextcloud only when implementing industry standard clustering and HA solutions
+before Nextcloud is installed for the first time.
 
-To start let us be specific about the use case. A configured ownCloud
+To start let us be specific about the use case. A configured Nextcloud
 instance runs reliably on one machine. For some reason (e.g. more powerful
 machine is available but a move to a clustered environment not yet needed)
 the instance needs to be moved to a new machine. Depending on the size of
-the ownCloud instance the migration might take several hours. As a
-prerequisite it is assumed that the end users reach the ownCloud instance
+the Nextcloud instance the migration might take several hours. As a
+prerequisite it is assumed that the end users reach the Nextcloud instance
 via a virtual hostname (a ``CNAME`` record in DNS) which can be pointed at
 the new location. It is also assumed that the authentication method
 (e.g. LDAP) remains the same after the migration.
 
 
 .. warning:: At NO TIME any changes to the **ORIGINAL** system are required
-    **EXCEPT** putting ownCloud into maintenance mode.
+    **EXCEPT** putting Nextcloud into maintenance mode.
 
     This ensures, should anything unforseen happen you can go
     back to your existing installation and provide your users
-    with a running ownCloud while debugging the problem.
+    with a running Nextcloud while debugging the problem.
 
 
 #.  Set up the new machine with the desired OS, install and configure the
-    Web server as well as PHP for ownCloud (e.g. permissions or file upload size
+    Web server as well as PHP for Nextcloud (e.g. permissions or file upload size
     limits) and make sure the PHP version matches ownCloud supported
     configuration and all relevant PHP extensions are installed. Also set up
-    the database and make sure it is an ownCloud supported configuration. If
+    the database and make sure it is an Nextcloud supported configuration. If
     your original machine was installed recently just copying that base
     configuration is a safe best practice.
 
 
-#.  On the original machine then stop ownCloud. First activate the
+#.  On the original machine then stop Nextcloud. First activate the
     maintenance mode. After waiting for 6-7 minutes for all sync clients to
     register the server as in maintenance mode stop the application and/or
-    Web server that serves ownCloud.
+    Web server that serves Nextcloud.
 
 
 #.  Create a dump from the database and copy it to the new machine. There
     import it in the database (See :doc:`backup` and :doc:`restore`).
 
 
-#.  Copy all files from your ownCloud instance, the ownCloud program files, the
+#.  Copy all files from your Nextcloud instance, the Nextcloud program files, the
     data files, the log files and the configuration files, to the new
     machine (See :doc:`backup` and :doc:`restore`). The data files should keep
     their original timestamp (can be done by using ``rsync`` with ``-t`` option)
@@ -56,18 +56,18 @@ the new location. It is also assumed that the authentication method
     Depending on the original installation method and the OS the files are
     located in different locations. On the new system make sure to pick the
     appropriate locations. If you change any paths, make sure to adopt the paths
-    in the ownCloud config.php file. Note: This step might take several hours,
+    in the Nextcloud config.php file. Note: This step might take several hours,
     depending on your installation.
 
 
-#.  While still having ownCloud in maintenance mode (confirm!) and **BEFORE**
+#.  While still having Nextcloud in maintenance mode (confirm!) and **BEFORE**
     changing the ``CNAME`` record in the DNS start up the database, Web server /
     application server on the new machine and point your web browser to the
-    migrated ownCloud instance. Confirm that you see the maintenance mode
+    migrated Nextcloud instance. Confirm that you see the maintenance mode
     notice, that a logfile entry is written by both the Web server and
-    ownCloud and that no error messages occur. Then take ownCloud out of
+    Nextcloud and that no error messages occur. Then take Nextcloud out of
     maintenance mode and repeat. Log in as admin and confirm normal function
-    of ownCloud.
+    of Nextcloud.
 
 
 #.  Change the ``CNAME`` entry in the DNS to point your users to the new

--- a/admin_manual/maintenance/package_upgrade.rst
+++ b/admin_manual/maintenance/package_upgrade.rst
@@ -1,63 +1,72 @@
 ==============================
-Upgrade ownCloud From Packages
+Upgrade Nextcloud From Packages
 ==============================
 
-.. note:: Starting with ownCloud 8.2 the Linux package repositories have 
-   changed, and **you must configure your system to use these new 
-   repositories** to install or upgrade ownCloud 8.2+. The new repositories are 
-   at our `Open Build Service`_.
    
 Upgrade Quickstart
 ------------------
 
-The best method for keeping ownCloud current on Linux servers is by configuring 
-your system to use ownCloud's `Open Build Service`_ repository. Then stay 
-current by using your Linux package manager to install fresh ownCloud packages. 
-After installing upgraded packages you must run a few more steps to complete 
-the 
-upgrade. These are the basic steps to upgrading ownCloud:
+One effective, if unofficial method for keeping Nextcloud current on Linux servers is by configuring 
+your system to use Nextcloud via a self contained "Snap" package, A technology allowing users to 
+always have the latest version of an "app".
 
-* :doc:`Disable <../installation/apps_management_installation>` all third-party 
-  apps.
+That version from Canonical is quite restrictive. It is not aimed at developers or advanced users 
+who would want to tune their configuration by installing extra features. It is aimed at end-users 
+who want a no-brainer solution. Install it, use it. No need to worry about updating Nextcloud any 
+more.
+
+It will work for as long as Canonical pushes releases, just like with any other Linux package 
+maintained independently of Nextcloud.
+
+Installation
+------------
+
+**Ubuntu**
+$ sudo snap install nextcloud
+
+**All other distros**
+Go to http://snapcraft.io/71
+Type the command to install snapd
+Install Nextcloud $ sudo snap install nextcloud
+
+1st login
+---------
+
+After a successful install, assuming you and the device on which it was installed are on the 
+same network, you should be able to reach the Nextcloud installation by visiting .local in 
+your browser. If your hostname is localhost or localhost.localdomain, like on an Ubuntu Base 
+device (IoT), nextcloud.local will be used instead.
+
+You will be asked to create a password for "admin" and your favourite cloud will be ready
+
+**Note**
+
+Do not use on IoT devices yet. You probably don't need these instructions anyway if you're 
+using Snappy Base 16.04 as it's currently unreleased.
+
+
 * Make a :doc:`fresh backup <backup>`.
-* Upgrade your ownCloud packages.
+* Upgrade your Nextcloud snap: sudo snap refresh nextcloud
 * Run :ref:`occ upgrade <command_line_upgrade_label>` (optionally disabling the 
   :ref:`migration test   
   <migration_test_label>`).
 * :ref:`Apply strong permissions <strong_perms_label>` to your 
-  ownCloud directories.
-* Take your ownCloud server out of :ref:`maintenance mode 
+  Nextcloud directories.
+* Take your Nextcloud server out of :ref:`maintenance mode 
   <maintenance_commands_label>`.  
 * Re-enable third-party apps.
 
 Upgrade Tips
 ------------
 
-Upgrading ownCloud from our `Open Build Service`_ repository is just like any 
-normal Linux upgrade. For example, on Debian or Ubuntu Linux this is the 
-standard system upgrade command::
+Upgrading Nextcloud from a Snap is just like upgrading any snap package.
+For example:
 
- apt-get update && apt-get upgrade
+ sudo snap refresh nextcloud
  
-Or you can upgrade just ownCloud with this command::
-
- apt-get update && apt-get install owncloud
- 
-On Fedora, CentOS, and Red Hat Linux use ``yum`` to see all available updates::
-
- yum check-update
- 
-You can apply all available updates with this command::
- 
- yum update
- 
-Or update only ownCloud::
- 
- yum update owncloud
- 
-Your Linux package manager only downloads the current ownCloud packages. Then 
+Your Snap package manager only upgrades the current Nextcloud Snap. Then 
 your ownCloud server is immediately put into maintenance mode. You may not see 
-this until you refresh your ownCloud page.
+this until you refresh your Nextcloud page.
 
 .. figure:: images/upgrade-1.png
    :scale: 75%
@@ -77,7 +86,7 @@ This example is for CentOS/RHEL/Fedora::
 Migration Test
 --------------
 
-Before completing the upgrade, ownCloud first runs a simulation by copying all 
+Before completing the upgrade, Nextcloud first runs a simulation by copying all 
 database tables to new tables, and then performs the upgrade on them, to ensure 
 that the upgrade will complete correctly. The copied tables are deleted after 
 the upgrade. This takes twice as much time, which on large installations can be 
@@ -89,32 +98,34 @@ option, like this example on CentOS::
 Setting Strong Directory Permissions
 ------------------------------------
 
-After upgrading, verify that your ownCloud directory permissions are set 
+After upgrading, verify that your Nextcloud directory permissions are set 
 according to :ref:`strong_perms_label`.
 
 If the upgrade fails, then you must try a manual upgrade.
 
-.. _Open Build Service: 
-   https://download.owncloud.org/download/repositories/stable/owncloud/
    
 .. _skipped_release_upgrade_label:  
    
 Upgrading Across Skipped Releases
 ---------------------------------
 
-It is best to update your ownCloud installation with every new point release, 
-and to never skip any major releases. If you have skipped any major releases you 
-can bring your ownCloud current with these steps:
+It is best to update your Nextcloud installation with every new point release, 
+and to never skip any major releases. While this requirement is being worked on, 
+for the moment If you have skipped any major releases you can bring your 
+Nextcloud current with these steps:
 
-#. Add the repository of your current version
+If you are using a Snap package:
+sudo snap refresh nextcloud
+
+If you did **not** install via a SNap package:
+
 #. Upgrade your current version to the latest point release
-#. Add the repo of the next major release
 #. Upgrade your current version to the next major release
 #. Run upgrade routine
-#. Repeat from step 3 until you reach the last available major release
+#. Repeat from step 2 until you reach the last available major release
 
-You'll find previous ownCloud releases in the `ownCloud Server Changelog 
-<https://owncloud.org/changelog/>`_.
+You'll find previous Nextcloud releases in the `Nextcloud Server Changelog 
+<https://nextcloud.com/changelog/>`_.
 
-If upgrading via your package manager fails, then you must perform a 
+If upgrading via your Snap package manager fails, then you must perform a 
 :doc:`manual_upgrade`.

--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -1,13 +1,14 @@
 ==================
-Restoring ownCloud
+Restoring Nextcloud
 ==================
 
-To restore an ownCloud installation there are three main things you need to 
+To restore a Nextcloud installation there are four main things you need to 
 restore:
 
 #. The configuration directory
 #. The data directory
 #. The database
+# The theme directory
 
 .. note:: You must have both the database and data directory. You cannot 
    complete restoration unless you have both of these.
@@ -21,35 +22,34 @@ Restore Folders
 .. note:: This guide assumes that your previous backup is called 
    "owncloud-dirbkp"
 
-Simply copy your configuration and data folder (or even your whole ownCloud 
-install and 
-data folder) to your ownCloud environment. You could use this command::
+Simply copy your configuration and data folder (or even your whole Nextcloud 
+install and data folder) to your Nextcloud environment. You could use this command::
 
-    rsync -Aax owncloud-dirbkp/ owncloud/
+    rsync -Aax nextcloud-dirbkp/ nextcloud/
 
 Restore Database
 ----------------
 
 .. note:: This guide assumes that your previous backup is called 
-   "owncloud-sqlbkp.bak"
+   "nextcloud-sqlbkp.bak"
 
 MySQL
 ^^^^^
 
 MySQL is the recommended database engine. To restore MySQL::
 
-    mysql -h [server] -u [username] -p[password] [db_name] < owncloud-sqlbkp.bak
+    mysql -h [server] -u [username] -p[password] [db_name] < nextcloud-sqlbkp.bak
 
 SQLite
 ^^^^^^
 ::
 
     rm data/owncloud.db
-    sqlite3 data/owncloud.db < owncloud-sqlbkp.bak
+    sqlite3 data/owncloud.db < nextcloud-sqlbkp.bak
 
 PostgreSQL
 ^^^^^^^^^^
 ::
 
-    PGPASSWORD="password" pg_restore -c -d owncloud -h [server] -U [username] 
-    owncloud-sqlbkp.bak
+    PGPASSWORD="password" pg_restore -c -d nextcloud -h [server] -U [username] 
+    nextcloud-sqlbkp.bak

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -1,29 +1,19 @@
-=======================================
-Upgrading ownCloud with the Updater App
-=======================================
+==========================================
+Upgrading Nextcloud with the Nextcloud App
+==========================================
 
-The Updater app automates many of the steps of upgrading an ownCloud 
+The Updater app automates many of the steps of upgrading an Nextcloud 
 installation. It is useful for installations that do not have root access, 
 such as shared hosting, for installations with a smaller number of users 
 and data, and it automates updating 
 :doc:`manual installations <../installation/source_installation>`.
 
-New in 9.0, the Updater app has :ref:`command-line options <updater_cli_label>`.
-
-.. note:: The Updater app is **not enabled and not supported** in ownCloud 
-   Enterprise edition. 
-   
-   The Updater app is **not included** in the 
-   `Linux packages on our Open Build Service 
-   <https://download.owncloud.org/download/repositories/stable/owncloud/>`_, 
-   but only in the `tar and zip archives 
-   <https://owncloud.org/install/#instructions-server>`_. When you install 
-   ownCloud from packages you should keep it updated with your package manager.
+The Updater app has :ref:`command-line options <updater_cli_label>`.
    
    **Downgrading** is not supported and risks corrupting your data! If you want 
-   to revert to an older ownCloud version, install it from scratch and then 
+   to revert to an older Nextcloud version, install it from scratch and then 
    restore your data from backup. Before doing this, file a support ticket (if 
-   you have paid support) or ask for help in the ownCloud forums to see if your 
+   you have paid support) or ask for help in the Nextcloud forums to see if your 
    issue can be resolved without downgrading.
 
 You should maintain regular backups (see :doc:`backup`), and make a backup 
@@ -32,10 +22,10 @@ directory.
 
 The Updater app performs these operations:
 
-* Creates an ``updater_backup`` directory under your ownCloud data directory
+* Creates an ``updater_backup`` directory under your Nextcloud data directory
 * Downloads and extracts updated package content into the 
   ``updater_backup/packageVersion`` directory
-* Makes a copy of your current ownCloud instance, except for your data 
+* Makes a copy of your current Nextcloud instance, except for your data 
   directory, to ``updater_backup/currentVersion-randomstring``
 * Moves all directories except ``data``, ``config`` and ``themes`` from the 
   current instance to ``updater_backup/tmp``
@@ -43,16 +33,16 @@ The Updater app performs these operations:
   version
 * Copies your old ``config.php`` to the new ``config/`` directory
 
-Using the Updater app to update your ownCloud installation is just a few 
+Using the Updater app to update your Nextcloud installation is just a few 
 steps:
 
-1.  You should see a notification at the top of any ownCloud page when there is 
+1.  You should see a notification at the top of any Nextcloud page when there is 
     a new update available.
    
 2.  Even though the Updater app backs up important directories, you should 
     always have your own current backups (See :doc:`backup` for details.)
    
-3.  Verify that the HTTP user on your system can write to your whole ownCloud 
+3.  Verify that the HTTP user on your system can write to your whole Nextcloud 
     directory; see the :ref:`set_updating_permissions_label` section below.
    
 4.  Navigate to your Admin page and click the **Update Center** button under 
@@ -60,7 +50,7 @@ steps:
 
 5.  Click Update, and carefully read the messages. If there are any problems it 
     will tell you. The most common issue is directory permissions; your HTTP 
-    user needs write permissions to your whole ownCloud directory. (See 
+    user needs write permissions to your whole Nextcloud directory. (See 
     :ref:`strong_perms_label`.) Another common issue is SELinux rules 
     (see :ref:`selinux-config-label`.) Otherwise you will see messages 
     about checking your installation and making backups.
@@ -69,14 +59,14 @@ steps:
     minutes.
 
 7.  If your directory permissions are correct, a backup was made, and 
-    downloading the new ownCloud archive succeeded you will see the following 
+    downloading the new Nextcloud archive succeeded you will see the following 
     screen. Click the Start Update button to complete your update:
 
 .. figure:: images/upgrade-2.png
    :scale: 75%
    :alt: ownCloud upgrade wizard screen.
 
-..  note:: If you have a large ownCloud installation and have shell access,
+..  note:: If you have a large Nextcloud installation and have shell access,
     you should use the ``occ upgrade`` command, running it as your HTTP user, 
     instead of clicking the Start Update button, in order to avoid PHP 
     timeouts.
@@ -85,7 +75,7 @@ This example is for Ubuntu Linux::
 
      $ sudo -u www-data php occ upgrade
  
-Before completing the upgrade, ownCloud first runs a simulation by copying all 
+Before completing the upgrade, Nextcloud first runs a simulation by copying all 
 database tables to new tables, and then performs the upgrade on them, to ensure 
 that the upgrade will complete correctly. The copied tables are deleted after 
 the upgrade. This takes twice as much time, which on large installations can be 
@@ -101,7 +91,7 @@ See :doc:`../configuration_server/occ_command` to learn more.
 
 Refresh your Admin page to verify your new version number. In the Updater 
 section of your Admin page you can see the current status and backups. These 
-are backups of your old and new ownCloud installations, and do not contain your 
+are backups of your old and new Nextcloud installations, and do not contain your 
 data files. If your update works and there are no problems you can delete the 
 backups from this screen.
 
@@ -114,20 +104,20 @@ Setting Permissions for Updating
 --------------------------------
    
 For hardened security we  highly recommend setting the permissions on your 
-ownCloud directory as strictly as possible. These commands should be executed 
+Nextcloud directory as strictly as possible. These commands should be executed 
 immediately after the initial installation. Please follow the steps in 
 :ref:`strong_perms_label`.
     
 These strict permissions will prevent the Updater app from working, as it needs 
-your whole ownCloud directory to be owned by the HTTP user. Run this script to 
+your whole Nextcloud directory to be owned by the HTTP user. Run this script to 
 set the appropriate permissions for updating. Replace the ``ocpath`` variable 
-with the path to your ownCloud directory, and replace the ``htuser`` and 
+with the path to your Nextcloud directory, and replace the ``htuser`` and 
 ``htgroup`` variables with your HTTP user and group.::
 
     #!/bin/bash
-    # Sets permissions of the owncloud instance for updating
+    # Sets permissions of the Nextcloud instance for updating
     
-    ocpath='/var/www/owncloud'
+    ocpath='/var/www/nextcloud'
     htuser='www-data'
     htgroup='www-data'
     
@@ -166,8 +156,8 @@ You can display a help summary::
  
 When you run it without options it runs a system check:: 
 
- sudo -u www-data php owncloud/updater/application.php
- ownCloud updater 1.0 - CLI based ownCloud server upgrades
+ sudo -u www-data php nextcloud/updater/application.php
+ Nextcloud updater 1.0 - CLI based ownCloud server upgrades
  Checking system health.
  - file permissions are ok.
  Current version is 9.0.0.12
@@ -185,12 +175,12 @@ List checkpoints::
  
 Restore an earlier checkpoint::
 
- sudo -u www-data php owncloud/updater/application.php upgrade:checkpoint 
+ sudo -u www-data php nextcloud/updater/application.php upgrade:checkpoint 
   --restore=9.0.0.12-56d5e4e004964
 
 Add a line like this to your crontab to automatically create daily 
 checkpoints::
 
- 2 15 * * * sudo -u www-data php /path/to/owncloud/updater/application.php 
+ 2 15 * * * sudo -u www-data php /path/to/nextcloud/updater/application.php 
  upgrade:checkpoint --create > /dev/null 2>&1
  

--- a/developer_manual/commun/index.rst
+++ b/developer_manual/commun/index.rst
@@ -5,21 +5,21 @@ Help and Communication
 .. toctree::
    :maxdepth: 2
 
-Mailing lists
+Forums
 -------------
-Communicate via mail on our `mailing lists <https://mailman.owncloud.org>`_.
+Communicate via our `forums <https://help.nextcloud.com>`_.
 
 IRC channels
 ------------
 Chat with us on `IRC <http://www.irchelp.org/>`_. All channels are on **irc.freenode.net**
 
-* Setup: **#owncloud**
-* Testing: **#owncloud-testing**
-* Development: **#owncloud-dev**
+* Setup: **#nextcloud**
+* Development: **#nextcloud-dev**
 * Design: **#owncloud-design**
+* Mobile: **#nextcloud-mobile**
 
 
 Maintainers
 -----------
-* `Contact <https://owncloud.org/contact/>`_ a maintainer of a certain app or division
+* `Contact <https://nextcloud.com/contact/>`_ a maintainer of a certain app or division
 

--- a/user_manual/index.rst
+++ b/user_manual/index.rst
@@ -1,28 +1,28 @@
 .. _index:
 
 ===========================================
-ownCloud |version| User Manual Introduction
+Nextcloud |version| User Manual Introduction
 ===========================================
 
-**Welcome to ownCloud: your self-hosted file sync and share solution.**
+**Welcome to Nextcloud: A safe home for all your data.**
 
-ownCloud is open source file sync and share software for everyone from
-individuals operating the free ownCloud Server edition, to large enterprises
-and service providers operating the ownCloud Enterprise Subscription. ownCloud
-provides a safe, secure, and compliant file synchronization and sharing
-solution on servers that you control.
+Nextcloud is open source file sync and share software for everyone from
+individuals operating the free Nextcloud Server in the privacy of their own 
+home, to large enterprises and service providers supported by the Nextcloud
+Enterprise Subscription. Nextcloud provides a safe, secure, and compliant 
+file synchronization and sharing solution on servers that you control.
 
 You can share one or more files and folders on your computer, and synchronize 
-them with your ownCloud server. Place files in your local shared directories, 
+them with your Nextcloud server. Place files in your local shared directories, 
 and those files are immediately synchronized to the server and to other devices 
-using the ownCloud Desktop Sync Client, Android app, or iOS app. To learn more 
-about the ownCloud desktop and mobile clients, please refer to their respective 
-manuals:
+using the ownCloud / Nextcloud Desktop Sync Client, Android app, or iOS app. To
+learn more about the Nextcloud desktop and mobile clients, please refer to 
+their respective manuals:
 
 * `ownCloud Desktop Client`_
 * `ownCloud Android App`_
 * `ownCloud iOS App`_ 
 
-.. _`ownCloud Desktop Client`: https://doc.owncloud.org/desktop/2.1/
-.. _`ownCloud Android App`: https://doc.owncloud.org/android/
-.. _`ownCloud iOS App`: https://doc.owncloud.org/ios/
+.. _`ownCloud / Nextcloud Desktop Client`: https://docs.Nextcloud.org/desktop/2.2/
+.. _`Nextcloud Android App`: https://docs.nextcloud.org/android/
+.. _`Nextcloud iOS App`: https://docs.nextcloud.org/ios/


### PR DESCRIPTION
This includes replacing the name in many places, but also:

Removing references to an Enterprise Edition
Updating instructions about using OBS repos to tarballs / Snap packages
Updating links from ownCloud websites / accounts to Nextcloud ones

There are still some references to ownCloud left intentionally, such as:
* Screenshots that need updating
* References to owncloud.db, a filename we still use
* References to occ which we still use as a filename

While I'm not experienced with a couple of the technical issues such as the differences between the old enterprise version and the regular version, or using Snap packages, I've tried to leave detailed notes in the commit description to point out where possible inaccuracies may be. Either way, these updated versions should be much more accurate than what we had.