### PR TITLE
hide anchors in headers

### DIFF
--- a/_shared_assets/themes/nextcloud_com/static/styles.css
+++ b/_shared_assets/themes/nextcloud_com/static/styles.css
@@ -1076,3 +1076,13 @@ img.desaturate {
 .youtube i:hover {
     color: #CC181E;
 }
+
+h1:hover a.headerlink,
+h2:hover a.headerlink,
+h3:hover a.headerlink,
+h4:hover a.headerlink {
+    display: inline;
+}
+a.headerlink {
+    display: none;
+}


### PR DESCRIPTION
Looks like this:
![bildschirmfoto 2016-07-10 um 10 50 48](https://cloud.githubusercontent.com/assets/245432/16712593/36674120-468c-11e6-80c5-1e816e3448d6.png)


Instead of this:
![bildschirmfoto 2016-07-10 um 10 50 51](https://cloud.githubusercontent.com/assets/245432/16712594/3bc7628a-468c-11e6-914a-4bf38d082688.png)


@jancborchardt Or did you add this by intention? I don't know if this is needed that much on mobile. So I dropped it there (because hover doesn't exist there)