### PR TITLE
Add .drone.yml for basic documentation build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 build:
-    image: nextcloudci/documentation
+    image: nextcloudci/documentation:1.0.11
     commands:
         - (cd user_manual && make html-all)
         - (cd admin_manual && make html-all)

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,6 @@
+build:
+    image: nextcloudci/documentation
+    commands:
+        - (cd user_manual && make html-all)
+        - (cd admin_manual && make html-all)
+        - (cd developer_manual && make html-all)


### PR DESCRIPTION
https://github.com/nextcloud/documentation/issues/3

By now this is just running make html-all for admin_manual, developer_manual, user_manual
Requires: https://github.com/nextcloud/docker-ci/pull/8

Maybe adding further steps like linkcheck / rst-lint would also make sense? @MorrisJobke 
