### PR TITLE
Fix importance of headlines

### DIFF
--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -155,41 +155,41 @@ ocsid
 The app's id on the app store, e.g.: https://apps.owncloud.com/content/show.php/QOwnNotes?content=168497 would have the ocsid **168497**. If given helps users to install and update the same app from the app store
 
 Dependencies
-============
+------------
 All tags within the dependencies tag define a set of requirements which have to be fulfilled in order to operate
 properly. As soon as one of these requirements is not met the app cannot be installed.
 
 php
----
+===
 Defines the minimum and the maximum version of php which is required to run this app.
 
 database
---------
+========
 Each supported database has to be listed in here. Valid values are sqlite, mysql, pgsql, oci and mssql. In the future
 it will be possible to specify versions here as well.
 In case no database is specified it is assumed that all databases are supported.
 
 command
--------
+=======
 Defines a command line tool to be available. With the attribute 'os' the required operating system for this tool can be
 specified. Valid values for the 'os' attribute are as returned by the php function `php_uname <http://php.net/manual/en/function.php-uname.php>`_.
 
 lib
----
+===
 Defines a required php extension with required minimum and/or maximum version. The names for the libraries have to match the result as returned by the php function  `get_loaded_extensions <http://php.net/manual/en/function.get-loaded-extensions.php>`_.
 The explicit version of an extension is read from `phpversion <http://php.net/manual/de/function.phpversion.php>`_ - with some exception as to be read up in the `code base <https://github.com/owncloud/core/blob/master/lib/private/app/platformrepository.php#L45>`_
 
 os
---
+==
 Defines the required target operating system the app can run on. Valid values are as returned by the php function `php_uname <http://php.net/manual/en/function.php-uname.php>`_.
 
 owncloud
---------
+========
 Defines minimum and maximum versions of the ownCloud core. In case undefined the values will be taken from the tag 'requiremin'.
 
 
 Deprecated
-==========
+----------
 
 The following sections are just listed for reference and should not be used because
 
@@ -197,7 +197,7 @@ The following sections are just listed for reference and should not be used beca
 * **standalone/default_enable**: They tell core what do on setup, you will not be able to even activate your app if it has those entries. This should be replaced by a config file inside core.
 
 public
-------
+======
 Used to provide a public interface (requires no login) for the app. The id is appended to the URL **/owncloud/index.php/public**. Example with id set to 'calendar'::
 
     /owncloud/index.php/public/calendar
@@ -205,7 +205,7 @@ Used to provide a public interface (requires no login) for the app. The id is ap
 Also take a look at :doc:`../core/externalapi`.
 
 remote
-------
+======
 Same as public but requires login. The id is appended to the URL **/owncloud/index.php/remote**. Example with id set to 'calendar'::
 
     /owncloud/index.php/remote/calendar
@@ -214,15 +214,15 @@ Also take a look at :doc:`../core/externalapi`.
 
 
 standalone
-----------
+==========
 Can be set to true to indicate that this app is a webapp. This can be used to tell GNOME Web for instance to treat this like a native application.
 
 default_enable
---------------
+==============
 **Core apps only**: Used to tell ownCloud to enable them after the installation.
 
 shipped
--------
+=======
 **Core apps only**: Used to tell ownCloud that the app is in the standard release.
 
 Please note that if this attribute is set to *FALSE* or not set at all, every time you disable the application, all the files of the application itself will be *REMOVED* from the server!


### PR DESCRIPTION
`-` is h2 and `=` is h3

### Before
![app_metadata_ _nextcloud_developer_manual_9 0_documentation_-_2016-07-11_09 38 56](https://cloud.githubusercontent.com/assets/213943/16723124/6103acd8-474b-11e6-8c9c-03c0894058a1.png)

### After
![app_metadata_ _owncloud_developer_manual_9 1_documentation_-_2016-07-11_09 39 23](https://cloud.githubusercontent.com/assets/213943/16723125/613c5588-474b-11e6-884b-bfbd135b74ca.png)


@MorrisJobke 