### PR TITLE
Admin manuel -> nginx config: Fixed fastcgi_split_path_info regex

### DIFF
--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -277,7 +277,7 @@ Add *inside* the ``server{}`` block, as an example of a configuration::
    fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
    
    location ~ \.php(?:$/) {
-         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+         fastcgi_split_path_info ^(.+\.php)(/.*)$;
        
          include fastcgi_params;
          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/admin_manual/installation/nginx_nextcloud_9x.rst
+++ b/admin_manual/installation/nginx_nextcloud_9x.rst
@@ -100,7 +100,7 @@ your nginx installation.
   
       location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
           include fastcgi_params;
-          fastcgi_split_path_info ^(.+\.php)(/.+)$;
+          fastcgi_split_path_info ^(.+\.php)(/.*)$;
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_param PATH_INFO $fastcgi_path_info;
           fastcgi_param HTTPS on;
@@ -238,7 +238,7 @@ your nginx installation.
 
           location ~ ^/nextcloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
               include fastcgi_params;
-              fastcgi_split_path_info ^(.+\.php)(/.+)$;
+              fastcgi_split_path_info ^(.+\.php)(/.*)$;
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               fastcgi_param PATH_INFO $fastcgi_path_info;
               fastcgi_param HTTPS on;


### PR DESCRIPTION
While installing nextcloud on my server with nginx i ran into the issue of not being able to open the installation wizard because the regex for the fastcgi_split_path_info didn't catch the installation url (`/index.php/`). The previous regex required something behind the `/`, which doesn't work for the installation url.

If you access `/index.php/` on an already running nextcloud version it just redirects you to `/apps/files/` so that's probably the reason it never was a problem.