### PR TITLE
[stable9] nginx config: Fixed fastcgi_split_path_info regex

### DIFF
--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -280,7 +280,7 @@ Add *inside* the ``server{}`` block, as an example of a configuration::
    fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
    
    location ~ \.php(?:$/) {
-         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+         fastcgi_split_path_info ^(.+\.php)(/.*)$;
        
          include fastcgi_params;
          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/admin_manual/installation/nginx_nextcloud_9x.rst
+++ b/admin_manual/installation/nginx_nextcloud_9x.rst
@@ -100,7 +100,7 @@ your nginx installation.
 
       location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
           include fastcgi_params;
-          fastcgi_split_path_info ^(.+\.php)(/.+)$;
+          fastcgi_split_path_info ^(.+\.php)(/.*)$;
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_param PATH_INFO $fastcgi_path_info;
           fastcgi_param HTTPS on;
@@ -239,7 +239,7 @@ your nginx installation.
 
           location ~ ^/nextcloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
               include fastcgi_params;
-              fastcgi_split_path_info ^(.+\.php)(/.+)$;
+              fastcgi_split_path_info ^(.+\.php)(/.*)$;
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               fastcgi_param PATH_INFO $fastcgi_path_info;
               fastcgi_param HTTPS on;


### PR DESCRIPTION
The previous regex didn't catch `/index.php/` which resulted in PHP-FPM being unable to process that site (required for the installation wizard).

Backport of #133