### PR TITLE
Add a warning about the removed feature

### DIFF
--- a/admin_manual/configuration_server/js_css_asset_management_configuration.rst
+++ b/admin_manual/configuration_server/js_css_asset_management_configuration.rst
@@ -1,6 +1,11 @@
 JavaScript and CSS Asset Management
 ===================================
 
+.. warning:: The asset pipelining feature has been remove in Nextcloud 10, because it broke several
+             apps, calendar and gallery being two of them. In order to remove traces, you can manually
+             remove the ``asset-pipeline.enabled`` config from your config file and delete the
+             ``assets/`` folder.
+
 In production environments, JavaScript and CSS files should be delivered in a concatenated and compressed format.
 
 Nextcloud can automatically collect all JavaScript and CSS files, aggregate and compress them to then save the result in a folder called 'assets' which can be found in the folder where Nextcloud has been installed. 

--- a/admin_manual/configuration_server/js_css_asset_management_configuration.rst
+++ b/admin_manual/configuration_server/js_css_asset_management_configuration.rst
@@ -3,8 +3,8 @@ JavaScript and CSS Asset Management
 
 .. warning:: The asset pipelining feature has been remove in Nextcloud 10, because it broke several
              apps, calendar and gallery being two of them. In order to remove traces, you can manually
-             remove the ``asset-pipeline.enabled`` config from your config file and delete the
-             ``assets/`` folder.
+             remove the ``asset-pipeline.enabled`` and ``assetdirectory`` configs from your config
+             file and delete the ``assets/`` folder.
 
 In production environments, JavaScript and CSS files should be delivered in a concatenated and compressed format.
 


### PR DESCRIPTION
Added a warning in 10, so people find the info how to remove it on the old link.

> ![javascript_and_css_asset_management_ _nextcloud_10_server_administration_manual_10_documentation_-_2016-09-07_09 07 46](https://cloud.githubusercontent.com/assets/213943/18302895/9b4d0710-74da-11e6-9137-27b0f229da04.png)
