### PR TITLE
Update documentation to work without ncdev

### DIFF
--- a/developer_manual/app/container.rst
+++ b/developer_manual/app/container.rst
@@ -146,7 +146,7 @@ The container works in the following way:
 * The **database connection** is returned from the server container
 * Now **AuthorMapper** has all of its dependencies and the object is returned
 * **AuthorService** gets the **AuthorMapper** and returns the object
-* **AuthorController** gets the **AuthorService** and finally the controller can be ``new``ed and the object is returned
+* **AuthorController** gets the **AuthorService** and finally the controller can be instantiated and the object is returned
 
 So basically the container is used as a giant factory to build all the classes that are needed for the application. Because it centralizes all the creation of objects (the **new Class()** lines), it is very easy to add new constructor parameters without breaking existing code: only the **__construct** method and the container line where the **new** is being called need to be changed.
 

--- a/developer_manual/app/startapp.rst
+++ b/developer_manual/app/startapp.rst
@@ -4,17 +4,11 @@ Create an app
 
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
 
-After :doc:`you've set up the development environment and installed the dev tool <../general/devenv>` change into the Nextcloud apps directory::
+After :doc:`you've set up the development environment <../general/devenv>` change into the Nextcloud apps directory::
 
     cd /var/www/nextcloud/apps
 
-Then run::
-
-    ncdev startapp MyApp --email mail@example.com --author "Your Name" --description "My first app" --owncloud 8
-
-This will create all the needed files in the current directory. For more information on how to customize the generated app, see the `Project's GitHub page <https://github.com/nexcloud/ncdev>`_ or run::
-
-    ncdev startapp -h
+Then create a skeleton app in the `app store <https://apps.nextcloud.com/developer/apps/generate>`_.
 
 Enable the app
 --------------
@@ -27,7 +21,6 @@ The following directories have now been created:
 * **appinfo/**: Contains app metadata and configuration
 * **css/**: Contains the CSS
 * **js/**: Contains the JavaScript files
-* **lib/Controller/**: Contains the controllers
-* **lib/**: Contains the other class files of your app
+* **lib/**: Contains the php class files of your app
 * **templates/**: Contains the templates
 * **tests/**: Contains the tests

--- a/developer_manual/app/testing.rst
+++ b/developer_manual/app/testing.rst
@@ -10,7 +10,7 @@ All PHP classes can be tested with `PHPUnit <http://phpunit.de/>`_, JavaScript c
 
 PHP
 ===
-The PHP tests go into the **tests/** directory. Unfortunately the classloader in core requires a running server (as in fully configured and setup up with a database connection). This is unfortunately too complicated and slow so a separate classloader has to be provided. If the app has been generated with the **ncdev startapp** command, the classloader is already present in the the **tests/** directory and PHPUnit can be run with::
+The PHP tests go into the **tests/** directory and PHPUnit can be run with::
 
     phpunit tests/
 

--- a/developer_manual/app/theming.rst
+++ b/developer_manual/app/theming.rst
@@ -21,9 +21,10 @@ When the theming app is enabled, it provides the **OCA.Theming** object. It can
 be used to handle themed instances differently.
 
 .. code-block:: javascript
-    if(OCA.Theming) {
-        $('.myapp-element').animate({backgroundColor:OCA.Theming.color});
-    }
+
+  if(OCA.Theming) {
+    $('.myapp-element').animate({backgroundColor:OCA.Theming.color});
+  }
 
 The following information is available:
 

--- a/developer_manual/app/tutorial.rst
+++ b/developer_manual/app/tutorial.rst
@@ -12,8 +12,7 @@ Setup
 First the :doc:`development environment <../general/devenv>` needs to be set up. This can be done by either `downloading the zip from the website <https://nextcloud.com/install/>`_ or cloning it directly from GitHub::
 
    git clone git@github.com:nextcloud/server.git --branch $BRANCH
-   git submodule init
-   git submodule update
+   git submodule update --init
 
 .. note:: ``$BRANCH`` is the desired Nextcloud branch (e.g. ``stable9`` for Nextcloud 9, ``stable10`` for Nextcloud 10, ..., ``master`` for the upcoming release)
 

--- a/developer_manual/app/tutorial.rst
+++ b/developer_manual/app/tutorial.rst
@@ -9,11 +9,13 @@ This tutorial will outline how to create a very simple notes app. The finished a
 
 Setup
 =====
-After the `development tool <https://github.com/nextcloud/ncdev/blob/master/README.rst#installation>`_ has been installed the :doc:`development environment needs to be set up <../general/devenv>`. This can be done by either `downloading the zip from the website <https://nextcloud.com/install/>`_ or cloning it directly from GitHub::
+First the :doc:`development environment <../general/devenv>` needs to be set up. This can be done by either `downloading the zip from the website <https://nextcloud.com/install/>`_ or cloning it directly from GitHub::
 
-    ncdev setup core --dir nextcloud  --branch $BRANCH
+   git clone git@github.com:nextcloud/server.git --branch $BRANCH
+   git submodule init
+   git submodule update
 
-.. note:: $BRANCH is the desired Nextcloud branch (e.g. stable9 for Nextcloud 9, stable10 for Nextcloud 10, etc)
+.. note:: ``$BRANCH`` is the desired Nextcloud branch (e.g. ``stable9`` for Nextcloud 9, ``stable10`` for Nextcloud 10, ..., ``master`` for the upcoming release)
 
 First you want to enable debug mode to get proper error messages. To do that set ``debug`` to ``true`` in the **nextcloud/config/config.php** file::
 
@@ -30,14 +32,11 @@ Now open another terminal window and start the development server::
     cd nextcloud
     php -S localhost:8080
 
-Afterwards the app can be created in the **apps** folder::
+Afterwards a skeleton app can be created in the `app store <https://apps.nextcloud.com/developer/apps/generate>`_.
 
-    cd apps
-    ncdev startapp OwnNotes
+Download the extracted the downloaded file and move it into your ``apps/`` directory. Afterwards the application can be disabled on the `apps page <http://localhost:8080/index.php/settings/apps>`_.
 
-This creates a new folder called **ownnotes**. Now access and set up Nextcloud through the webinterface at `http://localhost:8080 <http://localhost:8080>`_ and enable the OwnNotes application on the `apps page <http://localhost:8080/index.php/settings/apps>`_.
-
-The first basic app is now available at `http://localhost:8080/index.php/apps/ownnotes/ <http://localhost:8080/index.php/apps/ownnotes/>`_
+The first basic app is now available at ``http://localhost:8080/index.php/apps/yourappid/``
 
 Routes & Controllers
 ====================

--- a/developer_manual/bugtracker/triaging.rst
+++ b/developer_manual/bugtracker/triaging.rst
@@ -108,8 +108,6 @@ An important step of bug triaging is trying to reproduce the bugs, this means, u
 
 This is needed in order to differentiate random/race condition bugs of reproducible ones (which may be reproduced by developers too; and they can fix them).
 
-To reproduce an issue, please refer to our testing documents: :doc:`../testing/index`
-
 If you can't reproduce an issue in a newer version of Nextcloud, it is most likely fixed and can be closed. Comment that you failed to reproduce the problem, and if the reporter can confirm (or doesn't respond for a long time), you can close the issue. Also, be sure to add what exactly you tested with - the Nextcloud Master or a branch (and if so, when), or did you use a release, and if so - what version?
 
 Finalizing and tagging

--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -55,8 +55,7 @@ After the development tool installation make the directory writable::
 Then install Nextcloud from git::
 
   git clone git@github.com:nextcloud/server.git --branch $BRANCH /var/www/<folder>
-  git submodule init
-  git submodule update
+  git submodule update --init
 
 where <folder> is the folder where you want to install Nextcloud.
 

--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -48,15 +48,15 @@ Check out the code
 
 The following commands are using **/var/www** as the Web server's directory and **www-data** as user name and group.
 
-Install the `development tool <https://github.com/nextcloud/ncdev>`_
-
 After the development tool installation make the directory writable::
 
   sudo chmod o+rw /var/www
 
 Then install Nextcloud from git::
 
-  ncdev setup --dir /var/www/<folder> server
+  git clone git@github.com:nextcloud/server.git --branch $BRANCH /var/www/<folder>
+  git submodule init
+  git submodule update
 
 where <folder> is the folder where you want to install Nextcloud.
 


### PR DESCRIPTION
ncdev has been killed and replaced with git + https://apps.nextcloud.com/developer/apps/generate

Please review @MariusBluem @BernhardPosselt 