### PR TITLE
Improve reache-ablity of settings chapter

### DIFF
--- a/developer_manual/app/index.rst
+++ b/developer_manual/app/index.rst
@@ -137,6 +137,12 @@ Periodically run code in the background:
 
 * :doc:`backgroundjobs`
 
+Settings
+---------------
+An app can register both admin settings as well as personal settings:
+
+* :doc:`settings`
+
 Logging
 -------
 Log to the :file:`data/nextcloud.log`:


### PR DESCRIPTION
The settings chapter was only reachable via the forward / back navigation at the top. It was not linked from inside the index page.

Same as pull request #225