### PR TITLE
Add documentation on icon theming (closes #233)

### DIFF
--- a/admin_manual/configuration_server/theming.rst
+++ b/admin_manual/configuration_server/theming.rst
@@ -18,3 +18,15 @@ In the administrative settings you can modify the appearance of Nextcloud:
 Log in page   
 
 .. figure:: ../configuration_server/images/theming-log-in-page.png
+
+Theming of icons
+================
+
+Nextcloud will automatically generate favicons and home screen icons
+depending on the current app and theming color. 
+
+This requires the following additional dependencies:
+
+ - PHP module imagick
+ - SVG support for imagick (e.g. `libmagickcore5-extra`)
+

--- a/admin_manual/operations/theming.rst
+++ b/admin_manual/operations/theming.rst
@@ -6,4 +6,7 @@ Theming Nextcloud
     :maxdepth: 2
     :hidden:
 
-The theming is documented in the `developers documentation <../../developer_manual/core/theming.html>`_.
+
+Theming can be done very easily using the shipped `theming app <../configuration_server/theming.html>`_, which is enabled by default.
+
+For more individual theming options please head over to the `developers documentation <../../developer_manual/core/theming.html>`_.

--- a/developer_manual/app/theming.rst
+++ b/developer_manual/app/theming.rst
@@ -34,3 +34,9 @@ The following information is available:
 * **OCA.Theming.slogan** Instance slogan
 * **OCA.Theming.url**  Instance web address
 
+Icons
+=====
+
+The theming app will automatically generate favicons and home screen icons for
+each app by using the icon `img/app.svg` inside of the app folder. Any custom
+favicon set by an app will only be visible when the theming app is disabled.


### PR DESCRIPTION
Documentation for nextcloud/server#840 as stated in #233 

## Rendered

 admin_manual/operations/theming.rst
![2016-12-05-232156_849x140_scrot](https://cloud.githubusercontent.com/assets/3404133/20904922/f21fe67c-bb41-11e6-866d-80ed9cd4a680.png)

admin_manual/configuration_server/theming.rst
![2016-12-05-232221_703x136_scrot](https://cloud.githubusercontent.com/assets/3404133/20904923/f2375eb0-bb41-11e6-90af-5a18dc80d8de.png)

 developer_manual/app/theming.rst
![2016-12-05-232233_862x251_scrot](https://cloud.githubusercontent.com/assets/3404133/20904924/f2472106-bb41-11e6-9644-b67f5e8d5a1c.png)

please review @nextcloud/documentation @MorrisJobke 