### PR TITLE
Update user_provisioning_api.rst

### DIFF
--- a/admin_manual/configuration_user/user_provisioning_api.rst
+++ b/admin_manual/configuration_user/user_provisioning_api.rst
@@ -13,6 +13,8 @@ listed above. The Provisioning API app is enabled by default.
 
 The base URL for all calls to the share API is **nextcloud_base_url/ocs/v1.php/cloud**.
 
+All POST requests require the ``Content-Type: application/x-www-form-urlencoded`` header. (Note: Some libraries like Curl set this header automatically, other require to set the header explicitly)
+
 Instruction Set For Users
 =========================
 


### PR DESCRIPTION
Mention that the content type "application/x-www-form-urlencoded" is needed for POST request, see https://secure.php.net/manual/en/reserved.variables.post.php

backport of https://github.com/nextcloud/documentation/pull/272

cc @nickvergessen 