### PR TITLE
Kill the emoji so Latex builds again

### DIFF
--- a/admin_manual/maintenance/mysql_4byte_support.rst
+++ b/admin_manual/maintenance/mysql_4byte_support.rst
@@ -4,7 +4,7 @@ Enabling MySQL 4-byte support
 
 .. note:: This feature is currently **experimental**.
 
-In order to use Emojis on your Nextcloud server with a MySQL database, the
+In order to use Emojis (textbased smilies) on your Nextcloud server with a MySQL database, the
 installation needs to be tweaked a bit.
 
 1. Update your Nextcloud server to Nextcloud 11 or later.
@@ -28,7 +28,7 @@ installation needs to be tweaked a bit.
 
     $ sudo -u www-data occ maintenance:repair
 
-Now you should be able to use emojis like ``🎉`` in your file names, calendar events, comments and many more.
+Now you should be able to use Emojis in your file names, calendar events, comments and many more.
 
 MariaDB support
 ===============


### PR DESCRIPTION
With the emoji most environments can not build the pdf anymore.
Even our docs machine, try the `Download PDF` link on the `Administration Manual` of 11 and 12: https://docs.nextcloud.com/

Removing the emoji should work for now.

Fix #285 