### PR TITLE
Update prerequisites to php >=5.6 for NC 11

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -40,7 +40,7 @@ If you get a result, the module is present.
 
 Required:
 
-* php5 (>= 5.4)
+* php5 (>= 5.6)
 * PHP module ctype
 * PHP module dom
 * PHP module GD


### PR DESCRIPTION
backport of https://github.com/nextcloud/documentation/pull/292