### PR TITLE
Explicitly type $userManager

### DIFF
--- a/developer_manual/app/hooks.rst
+++ b/developer_manual/app/hooks.rst
@@ -48,12 +48,13 @@ The hook logic should be in a separate class that is being registered in the :do
 
     <?php
     namespace OCA\MyApp\Hooks;
+    use OCP\IUserManager;
 
     class UserHooks {
 
         private $userManager;
 
-        public function __construct($userManager){
+        public function __construct(IUserManager $userManager){
             $this->userManager = $userManager;
         }
 


### PR DESCRIPTION
Hi, I'm getting started on NC apps. On my app, the dependency injection only worked after declaring the type of UserManager explicitly.

I'm not 100% sure, but it worked here.

best,
alan