### PR TITLE
Small typo

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -121,7 +121,7 @@ Apache and MariaDB, by issuing the following commands in a terminal::
 
     apt-get install apache2 mariadb-server libapache2-mod-php7.0
     apt-get install php7.0-gd php7.0-json php7.0-mysql php7.0-curl php7.0-mbstring
-    apt-get install php7.0-intl php7.0-mcrypt php-imagick php7.0-xml php7.0-zip
+    apt-get install php7.0-intl php7.0-mcrypt php7.0-imagick php7.0-xml php7.0-zip
 
 * This installs the packages for the Nextcloud core system. 
   ``libapache2-mod-php7.0`` provides the following PHP extensions: ``bcmath bz2 


### PR DESCRIPTION
Small typo in "Example Installation on Ubuntu 16.04 LTS Server" section.
php-imagick > php7.0-imagick