### PR TITLE
Remove docs about migration simulation

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -1238,13 +1238,9 @@ List all options, like this example on CentOS Linux::
 
  sudo -u apache php occ upgrade -h
  Usage:
- upgrade [--skip-migration-test] [--dry-run] [--no-app-disable]
+ upgrade [--no-app-disable]
 
  Options:
- --skip-migration-test  skips the database schema migration simulation and 
-    update directly
- --dry-run              only runs the database schema migration simulation, do 
-   not actually update
  --no-app-disable       skips the disable of third party apps
  --help (-h)            Display this help message.
  --quiet (-q)           Do not output any message.
@@ -1303,19 +1299,6 @@ or to use in a bug report::
  ServerNotAvailableException: LDAP server is not available
  Update failed
  Turned off maintenance mode
-
-Before completing the upgrade, Nextcloud first runs a simulation by copying all 
-database tables to new tables, and then performs the upgrade on them, to ensure 
-that the upgrade will complete correctly. The copied tables are deleted after 
-the upgrade. This takes twice as much time, which on large installations can be 
-many hours, so you can omit this step with the ``--skip-migration-test`` 
-option::
-
- sudo -u www-data php occ upgrade --skip-migration-test
-
-You can perform this simulation manually with the ``--dry-run`` option::
-
- sudo -u www-data php occ upgrade --dry-run
 
 .. _two_factor_auth_label:
 

--- a/admin_manual/maintenance/package_upgrade.rst
+++ b/admin_manual/maintenance/package_upgrade.rst
@@ -47,9 +47,7 @@ using Snappy Base 16.04 as it's currently unreleased.
 
 * Make a :doc:`fresh backup <backup>`.
 * Upgrade your Nextcloud snap: sudo snap refresh nextcloud
-* Run :ref:`occ upgrade <command_line_upgrade_label>` (optionally disabling the 
-  :ref:`migration test   
-  <migration_test_label>`).
+* Run :ref:`occ upgrade <command_line_upgrade_label>`.
 * :ref:`Apply strong permissions <strong_perms_label>` to your 
   Nextcloud directories.
 * Take your Nextcloud server out of :ref:`maintenance mode 
@@ -80,20 +78,6 @@ user. This example is for Debian/Ubuntu::
 This example is for CentOS/RHEL/Fedora::
 
  sudo -u apache php occ upgrade 
-
-.. _migration_test_label:
-
-Migration Test
---------------
-
-Before completing the upgrade, Nextcloud first runs a simulation by copying all 
-database tables to new tables, and then performs the upgrade on them, to ensure 
-that the upgrade will complete correctly. The copied tables are deleted after 
-the upgrade. This takes twice as much time, which on large installations can be 
-many hours, so you can omit this step with the ``--skip-migration-test`` 
-option, like this example on CentOS::
-
- $ sudo -u apache php occ upgrade --skip-migration-test
 
 Setting Strong Directory Permissions
 ------------------------------------

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -74,15 +74,6 @@ steps:
 This example is for Ubuntu Linux::
 
      $ sudo -u www-data php occ upgrade
- 
-Before completing the upgrade, Nextcloud first runs a simulation by copying all 
-database tables to new tables, and then performs the upgrade on them, to ensure 
-that the upgrade will complete correctly. The copied tables are deleted after 
-the upgrade. This takes twice as much time, which on large installations can be 
-many hours, so you can omit this step with the ``--skip-migration-test`` 
-option, like this example on Ubuntu::
-
- $ sudo -u www-data php occ upgrade --skip-migration-test 
 
 See :doc:`../configuration_server/occ_command` to learn more.
 


### PR DESCRIPTION
@MorrisJobke should backport this to 11 right? Or did we remove this earlier?

Fix https://github.com/nextcloud/server/issues/3616