### PR TITLE
Add note about security scanner to documentation

### DIFF
--- a/admin_manual/configuration_server/security_setup_warnings.rst
+++ b/admin_manual/configuration_server/security_setup_warnings.rst
@@ -8,6 +8,13 @@ might see, and what to do about them.
 
 .. figure:: ../images/security-setup-warning-1.png
 
+You can use the  `Nextcloud Security Scan<https://scan.nextcloud.com>`_ to see
+if your system is up to date and well secured. We have ran this scan over public
+IP addresses in the past to try and reach out to `extremely outdated systems
+<https://nextcloud.com/blog/nextcloud-releases-security-scanner-to-help-protect-private-clouds/>`_
+and might again in the future. Please, protect your privacy and keep your server
+up to date! Privacy means little without security.
+
 Cache Warnings
 --------------
 

--- a/admin_manual/configuration_server/security_setup_warnings.rst
+++ b/admin_manual/configuration_server/security_setup_warnings.rst
@@ -10,8 +10,7 @@ might see, and what to do about them.
 
 You can use the  `Nextcloud Security Scan<https://scan.nextcloud.com>`_ to see
 if your system is up to date and well secured. We have ran this scan over public
-IP addresses in the past to try and reach out to `extremely outdated systems
-<https://nextcloud.com/blog/nextcloud-releases-security-scanner-to-help-protect-private-clouds/>`_
+IP addresses in the past to try and reach out to `extremely outdated systems<https://nextcloud.com/blog/nextcloud-releases-security-scanner-to-help-protect-private-clouds/>`_
 and might again in the future. Please, protect your privacy and keep your server
 up to date! Privacy means little without security.
 


### PR DESCRIPTION
We should tell people we have the scanner so they can use it.

No idea if we ever again would scan systems out there but we should tell people it is possible. Of course, various (both good and bad intentioned) parties can and do scan the web all the time, so this isn't exactly news to any user who knows how the web works :(