### PR TITLE
Remove recommendation to change permissions

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -162,7 +162,4 @@ To be able to use this input box you need to make sure that:
 * your Web server is able to use the ``.htaccess`` file shipped by Nextcloud (Apache only)
 * the user your Web server is running as has write permissions to the files ``.htaccess`` and ``.user.ini``
 
-:ref:`strong_perms_label` might prevent write access to these files. As an admin you need
-to decide between the ability to use the input box and a more secure Nextcloud installation
-where you need to manually modify the upload limits in the ``.htaccess`` and ``.user.ini``
-files described above.
+

--- a/admin_manual/configuration_files/external_storage/local.rst
+++ b/admin_manual/configuration_files/external_storage/local.rst
@@ -15,9 +15,6 @@ are on Ubuntu Linux::
  sudo -u www-data chown -R www-data:www-data /localdir
  sudo -u www-data chmod -R 0750 /localdir
  
-See :ref:`strong_perms_label` for information on correct file permissions, and 
-find your HTTP user :ref:`label-phpinfo`.
- 
 In the **Folder name** field enter the folder name that you want to appear on 
 your Nextcloud Files page.
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -44,8 +44,7 @@ occ Command Directory
 Run occ As Your HTTP User
 -------------------------
 
-The HTTP user is different on the various Linux distributions. See 
-:ref:`strong_perms_label` to learn how to find your HTTP user.
+The HTTP user is different on the various Linux distributions:
    
 * The HTTP user and group in Debian/Ubuntu is www-data.
 * The HTTP user and group in Fedora/CentOS is apache.
@@ -1132,9 +1131,7 @@ You can install Nextcloud entirely from the command line. After downloading the
 tarball and copying Nextcloud into the appropriate directories you can use ``occ`` 
 commands in place of running the graphical Installation Wizard.
 
-Apply correct permissions to your Nextcloud directories; see 
-:ref:`strong_perms_label`. Then choose your ``occ`` options. This lists your 
-available options::
+Then choose your ``occ`` options. This lists your available options::
 
  sudo -u www-data php /var/www/nextcloud/occ
  Nextcloud is not installed - only a limited number of commands are available

--- a/admin_manual/installation/command_line_installation.rst
+++ b/admin_manual/installation/command_line_installation.rst
@@ -38,11 +38,6 @@ Supported databases are::
  
 See :ref:`command_line_installation_label` for more information.
 
-Finally, apply the correct strong permissions to your Nextcloud files and 
-directories (see :ref:`strong_perms_label`). This is an extremely important 
-step. It helps protect your Nextcloud installation, and ensures that it will run 
-correctly.
-
 BINLOG_FORMAT = STATEMENT
 -------------------------
 

--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -22,14 +22,11 @@ You're finished and can start using your new Nextcloud server.
 
 Of course, there is much more that you can do to set up your Nextcloud server for 
 best performance and security. In the following sections we will cover important 
-installation and post-installation steps. Note that you must follow the 
-instructions in :ref:`Setting Strong Permissions <strong_perms_label>` in order 
-to use the :doc:`occ Command <../configuration_server/occ_command>`.
+installation and post-installation steps.
 
 * :ref:`Data Directory Location <data_directory_location_label>`
 * :ref:`Database Choice <database_choice_label>`
 * :ref:`Trusted Domains <trusted_domains_label>`
-* :ref:`Setting Strong Permissions <strong_perms_label>`
 
 .. _data_directory_location_label:
 
@@ -49,8 +46,7 @@ Nextcloud data in a different location for other reasons (e.g. on a storage
 server). It is best to configure your data directory location at installation, 
 as it is difficult to move after installation. You may put it anywhere; in this 
 example is it located in ``/var/oc_data``. This directory must already exist, 
-and must be owned by your HTTP user (see 
-:ref:`strong_perms_label`).
+and must be owned by your HTTP user.
 
 .. _database_choice_label:
 
@@ -113,94 +109,3 @@ is not whitelisted the following error appears:
 .. figure:: images/install-wizard-a4.png
    :scale: 75%
    :alt: Error message when URL is not whitelisted
-  
-.. _strong_perms_label:
- 
-Setting Strong Directory Permissions
-------------------------------------
-
-For hardened security we recommend setting the permissions on your Nextcloud
-directories as strictly as possible. This should be done immediately after the
-initial installation and before running the setup. Your HTTP user must own the
-``config/``, ``data/`` and ``apps/`` directories so that you can configure
-Nextcloud, create, modify and delete your data files, and install apps via the
-Nextcloud Web interface.
-
-You can find your HTTP user in your HTTP server configuration files. Or you can 
-use :ref:`label-phpinfo` (Look for the **User/Group** line).
-
-* The HTTP user and group in Debian/Ubuntu is ``www-data``.
-* The HTTP user and group in Fedora/CentOS is ``apache``.
-* The HTTP user and group in Arch Linux is ``http``.
-* The HTTP user in openSUSE is ``wwwrun``, and the HTTP group is ``www``.
-
-.. note:: When using an NFS mount for the data directory, do not change its 
-   ownership from the default. The simple act of mounting the drive will set 
-   proper permissions for Nextcloud to write to the directory. Changing 
-   ownership as above could result in some issues if the NFS mount is 
-   lost.
-
-The easy way to set the correct permissions is to copy and run this script. 
-Replace the ``ocpath`` variable with the path to your Nextcloud directory, and 
-replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
-
- #!/bin/bash
- ocpath='/var/www/nextcloud'
- datapath='/var/www/nextcloud/data'
- htuser='www-data'
- htgroup='www-data'
- rootuser='root'
-
- printf "Creating possible missing Directories\n"
- mkdir -p $ocpath/data
- mkdir -p $ocpath/updater
-
- printf "chmod Files and Directories\n"
- find ${ocpath}/ -type f -print0 | xargs -0 chmod 0640
- find ${ocpath}/ -type d -print0 | xargs -0 chmod 0750
-
- printf "chown Directories\n"
- chown -R ${rootuser}:${htgroup} ${ocpath}/
- chown -R ${htuser}:${htgroup} ${ocpath}/apps/
- chown -R ${htuser}:${htgroup} ${ocpath}/config/
- chown -R ${htuser}:${htgroup} ${datapath}
- chown -R ${htuser}:${htgroup} ${ocpath}/themes/
- chown -R ${htuser}:${htgroup} ${ocpath}/updater/
-
- chmod +x ${ocpath}/occ
-
- printf "chmod/chown .htaccess\n"
- if [ -f ${ocpath}/.htaccess ]
-  then
-   chmod 0644 ${ocpath}/.htaccess
-   chown ${rootuser}:${htgroup} ${ocpath}/.htaccess
- fi
- if [ -f ${datapath}/.htaccess ]
-  then
-   chmod 0644 ${datapath}/.htaccess
-   chown ${rootuser}:${htgroup} ${datapath}/.htaccess
- fi
- 
-If you have customized your Nextcloud installation and your filepaths are 
-different than the standard installation, then modify this script accordingly. 
-
-This lists the recommended modes and ownership for your Nextcloud directories 
-and files:
-
-* All files should be read-write for the file owner, read-only for the 
-  group owner, and zero for the world
-* All directories should be executable (because directories always need the 
-  executable bit set), read-write for the directory owner, and read-only for 
-  the group owner
-* The :file:`apps/` directory should be owned by ``[HTTP user]:[HTTP group]``
-* The :file:`config/` directory should be owned by ``[HTTP user]:[HTTP group]``
-* The :file:`themes/` directory should be owned by ``[HTTP user]:[HTTP group]``
-* The :file:`data/` directory should be owned by ``[HTTP user]:[HTTP group]``
-* The :file:`[ocpath]/.htaccess` file should be owned by ``root:[HTTP group]``
-* The :file:`data/.htaccess` file should be owned by ``root:[HTTP group]``
-* Both :file:`.htaccess` files are read-write file owner, read-only group and 
-  world
-
-These strong permissions prevent upgrading your Nextcloud server; 
-see :ref:`set_updating_permissions_label` for a script to quickly change 
-permissions to allow upgrading.

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -16,7 +16,6 @@ Apache and MariaDB, using `the Nextcloud .tar archive
 * :ref:`pretty_urls_label` 
 * :ref:`enabling_ssl_label`
 * :ref:`installation_wizard_label`
-* :ref:`strong_perms_label`
 * :ref:`selinux_tips_label`
 * :ref:`php_ini_tips_label`
 * :ref:`php_fpm_tips_label`
@@ -305,9 +304,8 @@ Installation Wizard
 
 After restarting Apache you must complete your installation by running either 
 the graphical Installation Wizard, or on the command line with the ``occ`` 
-command. To enable this, temporarily change the ownership on your Nextcloud 
-directories to your HTTP user (see :ref:`strong_perms_label` to learn how to 
-find your HTTP user)::
+command. To enable this, change the ownership on your Nextcloud directories to 
+your HTTP user:
 
  chown -R www-data:www-data /var/www/nextcloud/
  
@@ -318,15 +316,6 @@ find your HTTP user)::
 To use ``occ`` see :doc:`command_line_installation`. 
 
 To use the graphical Installation Wizard see :doc:`installation_wizard`.
-
-Setting Strong Directory Permissions
-------------------------------------
-
-After completing installation, you must immediately set the directory 
-permissions in your Nextcloud installation as strictly as possible for stronger 
-security. Please refer to :ref:`strong_perms_label`.
-
-Now your Nextcloud server is ready to use.
 
 .. _selinux_tips_label:
 

--- a/admin_manual/maintenance/manual_upgrade.rst
+++ b/admin_manual/maintenance/manual_upgrade.rst
@@ -72,8 +72,7 @@ Assuming your upgrade succeeded, disable the maintenance mode::
 Login and take a look at the bottom of your Admin page to 
 verify the version number. Check your other settings to make sure they're 
 correct. Go to the Apps page and review the core apps to make sure the right 
-ones are enabled. Re-enable your third-party apps. Then apply strong 
-permissions to your Nextcloud directories (:ref:`strong_perms_label`).
+ones are enabled. Re-enable your third-party apps.
 
 Previous Nextcloud Releases
 ---------------------------

--- a/admin_manual/maintenance/package_upgrade.rst
+++ b/admin_manual/maintenance/package_upgrade.rst
@@ -48,8 +48,6 @@ using Snappy Base 16.04 as it's currently unreleased.
 * Make a :doc:`fresh backup <backup>`.
 * Upgrade your Nextcloud snap: sudo snap refresh nextcloud
 * Run :ref:`occ upgrade <command_line_upgrade_label>`.
-* :ref:`Apply strong permissions <strong_perms_label>` to your 
-  Nextcloud directories.
 * Take your Nextcloud server out of :ref:`maintenance mode 
   <maintenance_commands_label>`.  
 * Re-enable third-party apps.
@@ -78,14 +76,6 @@ user. This example is for Debian/Ubuntu::
 This example is for CentOS/RHEL/Fedora::
 
  sudo -u apache php occ upgrade 
-
-Setting Strong Directory Permissions
-------------------------------------
-
-After upgrading, verify that your Nextcloud directory permissions are set 
-according to :ref:`strong_perms_label`.
-
-If the upgrade fails, then you must try a manual upgrade.
 
    
 .. _skipped_release_upgrade_label:  

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -50,10 +50,9 @@ steps:
 
 5.  Click Update, and carefully read the messages. If there are any problems it 
     will tell you. The most common issue is directory permissions; your HTTP 
-    user needs write permissions to your whole Nextcloud directory. (See 
-    :ref:`strong_perms_label`.) Another common issue is SELinux rules 
-    (see :ref:`selinux-config-label`.) Otherwise you will see messages 
-    about checking your installation and making backups.
+    user needs write permissions to your whole Nextcloud directory. Another common
+    issue is SELinux rules (see :ref:`selinux-config-label`.) Otherwise you will 
+    see  messages about checking your installation and making backups.
 
 6.  Click Proceed, and then it performs the remaining steps, which takes a few 
     minutes.
@@ -88,42 +87,6 @@ backups from this screen.
 
 If the update fails, then you must update manually. (See :doc:`Manually 
 upgrading <manual_upgrade>`.)
-
-.. _set_updating_permissions_label:
-
-Setting Permissions for Updating
---------------------------------
-   
-For hardened security we  highly recommend setting the permissions on your 
-Nextcloud directory as strictly as possible. These commands should be executed 
-immediately after the initial installation. Please follow the steps in 
-:ref:`strong_perms_label`.
-    
-These strict permissions will prevent the Updater app from working, as it needs 
-your whole Nextcloud directory to be owned by the HTTP user. Run this script to 
-set the appropriate permissions for updating. Replace the ``ocpath`` variable 
-with the path to your Nextcloud directory, and replace the ``htuser`` and 
-``htgroup`` variables with your HTTP user and group.::
-
-    #!/bin/bash
-    # Sets permissions of the Nextcloud instance for updating
-    
-    ocpath='/var/www/nextcloud'
-    htuser='www-data'
-    htgroup='www-data'
-    
-    chown -R ${htuser}:${htgroup} ${ocpath}
-
-You can find your HTTP user in your HTTP server configuration files. Or you can 
-use :ref:`label-phpinfo` (Look for the **User/Group** line).
-
-* The HTTP user and group in Debian/Ubuntu is ``www-data``.
-* The HTTP user and group in Fedora/CentOS is ``apache``.
-* The HTTP user and group in Arch Linux is ``http``.
-* The HTTP user in openSUSE is ``wwwrun``, and the HTTP group is ``www``.
-
-After the update is completed, re-apply the strong directory permissions 
-immediately by running the script in :ref:`strong_perms_label`.
 
 .. _updater_cli_label:
 


### PR DESCRIPTION
1. The wording here is really off. We don't really recommend this highly.
2. This is even counterproductive as it disallows updating via the app store. Also makes the updater unusable.
3. Once we have automatic updates this will effectively decrease security from my PoV
4. The script that is there had even some bugs and once destroyed the complete root file system…

Also, an attacker can execute code also using other ways once they have write access to Nextcloud or the data folder.

As we get a ton of bug reports about issues with that, let's kill it. I never liked it anyways…