### PR TITLE
Fix typos in developer manual

### DIFF
--- a/developer_manual/android_library/examples.rst
+++ b/developer_manual/android_library/examples.rst
@@ -286,7 +286,7 @@ Read shared items by link
 -------------------------
 
 Get information about what files and folder are shared by link (the object
-mClient contains the information about the server url and account)
+mClient contains the information about the server URL and account)
 
 Code example
 ~~~~~~~~~~~~
@@ -427,4 +427,4 @@ Tips
 * Wrong path: ``https://example.com/nextcloud/remote.php/dav/Pop%20Music/``
 * There are some forbidden characters to be used in folder and file names on the server, same on the Nextcloud Android Library "\","/","<",">",":",""","|","?","*"
 * Upload and download actions may be cancelled thanks to the objects uploadOperation.cancel(), downloadOperation.cancel()
-* Unit tests, before launching unit tests you have to enter your account information (server url, user and password) on TestActivity.java
+* Unit tests, before launching unit tests you have to enter your account information (server URL, user and password) on TestActivity.java

--- a/developer_manual/android_library/examples.rst
+++ b/developer_manual/android_library/examples.rst
@@ -286,7 +286,7 @@ Read shared items by link
 -------------------------
 
 Get information about what files and folder are shared by link (the object
-mClient contains the information about the server URL and account)
+mClient contains the information about the server URL and account).
 
 Code example
 ~~~~~~~~~~~~

--- a/developer_manual/android_library/examples.rst
+++ b/developer_manual/android_library/examples.rst
@@ -425,6 +425,6 @@ Tips
 * Paths must not be on URL Encoding
 * Correct path: ``https://example.com/nextcloud/remote.php/dav/PopMusic``
 * Wrong path: ``https://example.com/nextcloud/remote.php/dav/Pop%20Music/``
-* There are some forbidden characters to be used in folder and files names on the server, same on the Nextcloud Android Library "\","/","<",">",":",""","|","?","*"
+* There are some forbidden characters to be used in folder and file names on the server, same on the Nextcloud Android Library "\","/","<",">",":",""","|","?","*"
 * Upload and download actions may be cancelled thanks to the objects uploadOperation.cancel(), downloadOperation.cancel()
 * Unit tests, before launching unit tests you have to enter your account information (server url, user and password) on TestActivity.java

--- a/developer_manual/android_library/examples.rst
+++ b/developer_manual/android_library/examples.rst
@@ -80,14 +80,14 @@ Code example
 
   private void startFolderCreation(String newFolderPath) {
     CreateRemoteFolderOperation createOperation = new CreateRemoteFolderOperation(newFolderPath, false);
-    createOperation.execute( mClient , this , mHandler);
+    createOperation.execute(mClient, this, mHandler);
   }
 
   @Override
   public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
     if (operation instanceof CreateRemoteFolderOperation) {
       if (result.isSuccess()) {
-      // do your stuff here
+        // do your stuff here
       }
     }
     …
@@ -107,7 +107,7 @@ Code example
 .. code-block:: java
 
   private void startReadRootFolder() {
-    ReadRemoteFolderOperation refreshOperation = new ReadRemoteFolderOperation(FileUtils.PATH_SEPARATOR); 
+    ReadRemoteFolderOperation refreshOperation = new ReadRemoteFolderOperation(FileUtils.PATH_SEPARATOR);
     // root folder
     refreshOperation.execute(mClient, this, mHandler);
   }
@@ -164,7 +164,7 @@ Code example
 
   private void startRemoveFile(String filePath) {
     RemoveRemoteFileOperation removeOperation = new RemoveRemoteFileOperation(remotePath);
-    removeOperation.execute( mClient , this , mHandler);
+    removeOperation.execute(mClient, this, mHandler);
   }
 
   @Override
@@ -197,7 +197,7 @@ Code example
   }
 
   @Override
-  public void onRemoteOperationFinish( RemoteOperation operation, RemoteOperationResult result) {
+  public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
     if (operation instanceof DownloadRemoteFileOperation) {
       if (result.isSuccess()) {
         // do your stuff here
@@ -206,7 +206,7 @@ Code example
   }
 
   @Override
-  public void onTransferProgress( long progressRate, long totalTransferredSoFar, long totalToTransfer, String fileName) {
+  public void onTransferProgress(long progressRate, long totalTransferredSoFar, long totalToTransfer, String fileName) {
   mHandler.post( new Runnable() {
     @Override
     public void run() {
@@ -227,8 +227,8 @@ Code example
 
 .. code-block:: java
 
-  private void startUpload (File fileToUpload, String remotePath, String mimeType) {
-    UploadRemoteFileOperation uploadOperation = new UploadRemoteFileOperation( fileToUpload.getAbsolutePath(), remotePath, mimeType);
+  private void startUpload(File fileToUpload, String remotePath, String mimeType) {
+    UploadRemoteFileOperation uploadOperation = new UploadRemoteFileOperation(fileToUpload.getAbsolutePath(), remotePath, mimeType);
     uploadOperation.addDatatransferProgressListener(this);
     uploadOperation.execute(mClient, this, mHandler);
   }
@@ -244,7 +244,7 @@ Code example
 
   @Override
   public void onTransferProgress(long progressRate, long totalTransferredSoFar, long totalToTransfer, String fileName) {
-    mHandler.post( new Runnable() {
+    mHandler.post(new Runnable() {
       @Override
       public void run() {
         // do your UI updates about progress here
@@ -269,14 +269,14 @@ Code example
 
   private void startFileMove(String filePath, String newFilePath, boolean overwrite) {
     MoveRemoteFileOperation moveOperation = new MoveRemoteFileOperation(filePath, newFilePath, overwrite);
-    moveOperation.execute( mClient , this , mHandler);
+    moveOperation.execute(mClient, this, mHandler);
   }
 
   @Override
   public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
     if (operation instanceof MoveRemoteFileOperation) {
       if (result.isSuccess()) {
-      // do your stuff here
+        // do your stuff here
 	  }
     }
     …
@@ -295,16 +295,16 @@ Code example
 
   private void startAllSharesRetrieval() {
     GetRemoteSharesOperation getSharesOp = new GetRemoteSharesOperation();
-    getSharesOp.execute( mClient , this , mHandler);
+    getSharesOp.execute(mClient, this, mHandler);
   }
 
   @Override
-  public void onRemoteOperationFinish( RemoteOperation operation, RemoteOperationResult result) {
+  public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
     if (operation instanceof GetRemoteSharesOperation) {
       if (result.isSuccess()) {
         ArrayList< OCShare > shares = new ArrayList< OCShare >();
         for (Object obj: result.getData()) {
-          shares.add(( OCShare) obj);
+          shares.add((OCShare) obj);
         }
         // do your stuff here
       }
@@ -327,21 +327,21 @@ Code example
 
   private void startSharesRetrievalForFileOrFolder(String filePath, boolean getReshares) {
     GeteRemoteSharesForFileOperation operation = new GetRemoteSharesForFileOperation(filePath, getReshares, false);
-    operation.execute( mClient, this, mHandler);
+    operation.execute(mClient, this, mHandler);
   }
 
   private void startSharesRetrievalForFilesInFolder(String folderPath, boolean getReshares) {
     GetRemoteSharesForFileOperation operation = new GetRemoteSharesForFileOperation(folderPath, getReshares, true);
-    operation.execute( mClient, this, mHandler);
+    operation.execute(mClient, this, mHandler);
   }
 
   @Override
-  public void onRemoteOperationFinish( RemoteOperation operation, RemoteOperationResult result) {
+  public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
     if (operation instanceof GetRemoteSharesForFileOperation) {
       if (result.isSuccess()) {
         ArrayList< OCShare > shares = new ArrayList< OCShare >();
         for (Object obj: result.getData()) {
-          shares.add(( OCShare) obj);
+          shares.add((OCShare) obj);
         }
         // do your stuff here
      }
@@ -367,7 +367,7 @@ Code example
 
   private void startCreationOfPublicShareForFile(String filePath, String password) {
     CreateRemoteShareOperation operation = new CreateRemoteShareOperation(filePath, ShareType.PUBLIC_LINK, "", false, password, 1);
-    operation.execute( mClient , this , mHandler);
+    operation.execute(mClient, this, mHandler);
   }
 
   private void startCreationOfGroupShareForFile(String filePath, String groupId) {
@@ -381,10 +381,10 @@ Code example
   }
 
   @Override
-  public void onRemoteOperationFinish( RemoteOperation operation, RemoteOperationResult result) {
+  public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
     if (operation instanceof CreateRemoteShareOperation) {
       if (result.isSuccess()) {
-        OCShare share = (OCShare) result.getData ().get(0);
+        OCShare share = (OCShare) result.getData().get(0);
         // do your stuff here
       }
     }
@@ -405,14 +405,14 @@ Code example
 
   private void startShareRemoval(OCShare share) {
     RemoveRemoteShareOperation operation = new RemoveRemoteShareOperation((int) share.getIdRemoteShared());
-    operation.execute( mClient, this, mHandler);
+    operation.execute(mClient, this, mHandler);
   }
 
   @Override
-  public void onRemoteOperationFinish( RemoteOperation operation, RemoteOperationResult result) {
+  public void onRemoteOperationFinish(RemoteOperation operation, RemoteOperationResult result) {
     if (operation instanceof RemoveRemoteShareOperation) {
       if (result.isSuccess()) {
-      // do your stuff here
+        // do your stuff here
       }
     }
   }

--- a/developer_manual/android_library/index.rst
+++ b/developer_manual/android_library/index.rst
@@ -18,7 +18,7 @@ the source code `in github <https://github.com/nextcloud/android/>`_. The
 setup and process of contribution is
 `documented here <https://github.com/nextcloud/android/blob/master/SETUP.md>`_.
 
-You might want to start with doing one or two `starter issue <https://github.com/nextcloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22starter+issue%22>`_
+You might want to start with doing one or two `starter issues <https://github.com/nextcloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22starter+issue%22>`_
 to get into the code and note our :doc:`../general/index`
 
 Nextcloud Android Library
@@ -27,12 +27,12 @@ Nextcloud Android Library
 This document will describe how to the use Nextcloud Android Library.  The
 Nextcloud Android Library allows a developer to communicate with any Nextcloud
 server; among the features included are file synchronization, upload and
-download of files, delete rename files and folders, etc.
+download of files, delete or rename files and folders, etc.
 
 This library may be added to a project and seamlessly integrates any
 application with Nextcloud.
 
-The tool needed is any IDE for Android preferred IDE at the moment is Android Studio.
+The tool needed is any IDE for Android; the preferred IDE at the moment is Android Studio.
 
 .. toctree::
    :maxdepth: 2

--- a/developer_manual/android_library/index.rst
+++ b/developer_manual/android_library/index.rst
@@ -13,8 +13,8 @@ library under the MIT license.
 Android Nextcloud Client development
 ------------------------------------
 
-If you are interested in working on the Nextcloud android client, you can find
-the source code `in github <https://github.com/nextcloud/android/>`_. The
+If you are interested in working on the Nextcloud Android client, you can find
+the source code `in GitHub <https://github.com/nextcloud/android/>`_. The
 setup and process of contribution is
 `documented here <https://github.com/nextcloud/android/blob/master/SETUP.md>`_.
 

--- a/developer_manual/android_library/index.rst
+++ b/developer_manual/android_library/index.rst
@@ -19,7 +19,7 @@ setup and process of contribution is
 `documented here <https://github.com/nextcloud/android/blob/master/SETUP.md>`_.
 
 You might want to start with doing one or two `starter issues <https://github.com/nextcloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22starter+issue%22>`_
-to get into the code and note our :doc:`../general/index`
+to get into the code and note our :doc:`../general/index`.
 
 Nextcloud Android Library
 -------------------------

--- a/developer_manual/android_library/library_installation.rst
+++ b/developer_manual/android_library/library_installation.rst
@@ -46,6 +46,7 @@ Add the library project to your project as a Git submodule
 Basically get the code and compile it having it integrated via a Git submodule.
 
 Go into your own apps directory on the command line and add the Nextcloud Android library as a submodule::
+
   git submodule add https://github.com/nextcloud/android-library nextcloud-android-library
 
 Import/Open your app in Android Studio and you are done. All the public classes and methods of the library will be available for your own app.

--- a/developer_manual/android_library/library_installation.rst
+++ b/developer_manual/android_library/library_installation.rst
@@ -5,11 +5,11 @@ Obtaining the library
 ---------------------
 
 
-The Nextcloud Android library may be obtained from the following Github repository:
+The Nextcloud Android library may be obtained from the following GitHub repository:
 
 `https://github.com/nextcloud/android-library <https://github.com/nextcloud/android-library>`_
 
-Once obtained, this code should be compiled. The Github repository not only contains the library, but also a sample project, sample_client
+Once obtained, this code should be compiled. The GitHub repository not only contains the library, but also a sample project, sample_client
 sample_client  properties/android/librerias
 , which will assist in learning how to use the library.
 
@@ -19,14 +19,14 @@ Add the library to a project
 
 There are different methods to add an external library to a project, we will describe two.
 
-#.  Add the library as a gradle dependency via jitpack
+#.  Add the library as a Gradle dependency via JitPack
 
 
 
-#.  Add the library repo to your Android project as a git submodule
+#.  Add the library repo to your Android project as a Git submodule
 
 
-Add the library as a gradle dependency
+Add the library as a Gradle dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Simply open your::
@@ -40,10 +40,10 @@ and add the dependency::
 <version> refers to the exact version you would like to include in your application. This could be -SNAPSHOT for always using the latest code revision of the master branch. Alternatively you can also specifiy a version number which refers to a fixed release, e.g. 1.0.0. (compile 'com.github.nextcloud:android-library:1.0.0')
 
 
-Add the library project to your project as a git submodule
+Add the library project to your project as a Git submodule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Basically get the code and compile it having it integrated via a git submodule
+Basically get the code and compile it having it integrated via a Git submodule
 
 Go into your own apps directory on the command line and add the Nextcloud Android library as a submodule::
   git submodule add https://github.com/nextcloud/android-library nextcloud-android-library

--- a/developer_manual/android_library/library_installation.rst
+++ b/developer_manual/android_library/library_installation.rst
@@ -37,13 +37,13 @@ and add the dependency::
 
   compile 'com.github.nextcloud:android-library:<version>'
 
-<version> refers to the exact version you would like to include in your application. This could be -SNAPSHOT for always using the latest code revision of the master branch. Alternatively you can also specifiy a version number which refers to a fixed release, e.g. 1.0.0. (compile 'com.github.nextcloud:android-library:1.0.0')
+<version> refers to the exact version you would like to include in your application. This could be -SNAPSHOT for always using the latest code revision of the master branch. Alternatively you can also specifiy a version number which refers to a fixed release, e.g. 1.0.0. (compile 'com.github.nextcloud:android-library:1.0.0').
 
 
 Add the library project to your project as a Git submodule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Basically get the code and compile it having it integrated via a Git submodule
+Basically get the code and compile it having it integrated via a Git submodule.
 
 Go into your own apps directory on the command line and add the Nextcloud Android library as a submodule::
   git submodule add https://github.com/nextcloud/android-library nextcloud-android-library

--- a/developer_manual/app/backgroundjobs.rst
+++ b/developer_manual/app/backgroundjobs.rst
@@ -11,7 +11,7 @@ Background/cron jobs are usually registered in the :file:`appinfo/app.php` by us
     <?php
     \OCP\Backgroundjob::addRegularTask('\OCA\MyApp\Cron\SomeTask', 'run');
 
-The class for the above example would live in :file:`cron/sometask.php`. Try to keep the method as small as possible because its hard to test static methods. Simply reuse the app container and execute a service that was registered in it.
+The class for the above example would live in :file:`cron/sometask.php`. Try to keep the method as small as possible because its hard to test static methods. Simply reuse the app container and execute a service that was registered in it:
 
 .. code-block:: php
 

--- a/developer_manual/app/code_signing.rst
+++ b/developer_manual/app/code_signing.rst
@@ -58,7 +58,7 @@ private key.
 
 This Root Authority is only used for signing certificate signing requests (CSRs)
 for additional certificates. Certificates issued by the Root Authority must
-always to be limited to a specific scope, usually the application identifier.
+always be limited to a specific scope, usually the application identifier.
 This enforcement is done using the ``CN`` attribute of the certificate.
 
 Code signing is then done by creating a  ``signature.json`` file with the
@@ -121,10 +121,10 @@ examples will assume that you are trying to sign an application named
    your GitHub account to show your mail address in your profile. Nextcloud
    might ask you for further information to verify that you're the legitimate
    owner of the application. Make sure to keep the private key file (``contacts.key``)
-   secret and not disclose it to any third-parties.
+   secret and not disclose it to any third parties.
 3. Nextcloud will provide you with the signed certificate.
 4. Run ``./occ integrity:sign-app`` to sign your application, and specify
-   your private and the public key as well as the path to the application.
+   your private and public keys as well as the path to the application.
    A valid example looks like: ``./occ integrity:sign-app --privateKey=/Users/lukasreschke/contacts.key
    --certificate=/Users/lukasreschke/CA/contacts.crt --path=/Users/lukasreschke/Programming/contacts``
 

--- a/developer_manual/app/code_signing.rst
+++ b/developer_manual/app/code_signing.rst
@@ -174,7 +174,7 @@ manual.
   - Another exception has prevented the code verification. There are currently
     these following exceptions:
 
-    - ``Signature data not found.```
+    - ``Signature data not found.``
 
       - The app has mandatory code signing enforced but no ``signature.json``
         file has been found in its ``appinfo`` folder.

--- a/developer_manual/app/container.rst
+++ b/developer_manual/app/container.rst
@@ -125,7 +125,7 @@ The container works in the following way:
       $c->query('AuthorService')
     );
 
-* The **AppName** is queried and returned from the baseclass
+* The **AppName** is queried and returned from the base class
 * The **Request** is queried and returned from the server container
 * **AuthorService** is queried::
 

--- a/developer_manual/app/controllers.rst
+++ b/developer_manual/app/controllers.rst
@@ -319,7 +319,7 @@ Cookies can be set or modified directly on the response class:
 
 Responses
 =========
-Similar to how every controller receives a request object, every controller method has to to return a Response. This can be in the form of a Response subclass or in the form of a value that can be handled by a registered responder.
+Similar to how every controller receives a request object, every controller method has to return a Response. This can be in the form of a Response subclass or in the form of a value that can be handled by a registered responder.
 
 JSON
 ----
@@ -342,7 +342,7 @@ Returning JSON is simple, just pass an array to a JSONResponse:
 
     }
 
-Because returning JSON is such an common task, there's even a shorter way to do this:
+Because returning JSON is such a common task, there's even a shorter way to do this:
 
 .. code-block:: php
 
@@ -525,7 +525,7 @@ A file download can be triggered by returning a DownloadResponse:
 
 Creating custom responses
 -------------------------
-If no premade Response fits the needed usecase, its possible to extend the Response baseclass and custom Response. The only thing that needs to be implemented is the **render** method which returns the result as string.
+If no premade Response fits the needed usecase, it is possible to extend the Response base class and custom Response. The only thing that needs to be implemented is the **render** method which returns the result as string.
 
 Creating a custom XMLResponse class could look like this:
 
@@ -600,7 +600,7 @@ If you want to use a custom, lazily rendered response simply implement the inter
 Modifying the Content Security Policy
 -------------------------------------
 
-By default Nextcloud disables all resources which are not served on the same domain, forbids cross domain requests and disables inline CSS and JavaScript by setting a `Content Security Policy <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy>`_. However if an app relies on thirdparty media or other features which are forbidden by the current policy the policy can be relaxed.
+By default Nextcloud disables all resources which are not served on the same domain, forbids cross domain requests and disables inline CSS and JavaScript by setting a `Content Security Policy <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy>`_. However if an app relies on third-party media or other features which are forbidden by the current policy the policy can be relaxed.
 
 .. note:: Double check your content and edge cases before you relax the policy! Also read the `documentation provided by MDN <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy>`_
 
@@ -653,7 +653,7 @@ OCS
 ---
 .. note:: This is purely for compatibility reasons. If you are planning to offer an external API, go for a :doc:`api` instead.
 
-In order to ease migration from OCS API routes to the App Framework, an additional controller and response have been added. To migrate your API you can use the **OCP\\AppFramework\\OCSController** baseclass and return your data in the form of a DataResponse in the following way:
+In order to ease migration from OCS API routes to the App Framework, an additional controller and response have been added. To migrate your API you can use the **OCP\\AppFramework\\OCSController** base class and return your data in the form of a DataResponse in the following way:
 
 
 .. code-block:: php
@@ -742,7 +742,7 @@ Most of the time though it makes sense to also allow normal users to access the 
 To turn off checks the following *Annotations* can be added before the controller:
 
 * **@NoAdminRequired**: Also users that are not admins can access the page
-* **@NoCSRFRequired**: Don't check the CSRF token (use this wisely since you might create a security hole, to understand what it does see :doc:`../general/security`)
+* **@NoCSRFRequired**: Don't check the CSRF token (use this wisely since you might create a security hole; to understand what it does see :doc:`../general/security`)
 * **@PublicPage**: Everyone can access the page without having to log in
 
 A controller method that turns off all checks would look like this:

--- a/developer_manual/app/css.rst
+++ b/developer_manual/app/css.rst
@@ -15,7 +15,7 @@ The CSS files reside in the **css/** folder and should be included in the templa
   // include multiple files for the same app
   style('myapp', array('style', 'navigation'));  // adds css/style.css, css/navigation.css
 
-  // include vendor file (also allows vendor syntax)
+  // include vendor file (also allows array syntax)
   vendor_style('myapp', 'style');  // adds vendor/style.css
 
 Web Components go into the **component/** folder and can be imported like this:
@@ -153,7 +153,7 @@ To add actions that affect the current list element you can add a menu for secon
         </ul>
     </div>
 
-The div with the class **app-navigation-entry-utils** contains only the button (class: **app-navigation-entry-utils-menu-button**) to display the menu but in many cases another entry is needed to display some sort of count (mails count, unread feed count, etc.). In that case add the **with-counter** class to the list entry to adjust the correct padding and text-oveflow of the entry's title.
+The div with the class **app-navigation-entry-utils** contains only the button (class: **app-navigation-entry-utils-menu-button**) to display the menu but in many cases another entry is needed to display some sort of count (mails count, unread feed count, etc.). In that case add the **with-counter** class to the list entry to adjust the correct padding and text-overflow of the entry's title.
 
 The count should be limitted to 999 and turn to 999+ if any higher number is given. If AngularJS is used the following filter can be used to get the correct behaviour:
 
@@ -274,7 +274,7 @@ If you want to undo a performed action on a navigation entry such as deletion, y
 
 Settings Area
 =============
-To create a settings area create a div with the id **app-settings** inside the **app-navgiation** div:
+To create a settings area create a div with the id **app-settings** inside the **app-navigation** div:
 
 .. code-block:: html
 

--- a/developer_manual/app/css.rst
+++ b/developer_manual/app/css.rst
@@ -30,7 +30,7 @@ Web Components go into the **component/** folder and can be imported like this:
   component('myapp', array('tabs', 'forms'));  // adds component/tabs.html, component/forms.html
   
   
-.. note:: Keep in mind that Web Components are still very new and you `might need to add polyfills using Polymer <http://www.polymer-project.org/resources/compatibility.html>`_
+.. note:: Keep in mind that Web Components are still very new and you `might need to add polyfills <https://www.webcomponents.org/polyfills/>`_
   
 Standard layout
 ===============

--- a/developer_manual/app/css.rst
+++ b/developer_manual/app/css.rst
@@ -71,7 +71,7 @@ Nextcloud provides a default CSS navigation layout. If list entries should have 
 Folders
 -------
 
-Folders are like normal entries and are only supported for the first level. In contrast to normal entries, the links which show the title of the folder need to have the **icon-folder** css class.
+Folders are like normal entries and are only supported for the first level. In contrast to normal entries, the links which show the title of the folder need to have the **icon-folder** CSS class.
 
 If the folder should be collapsible, the **collapsible** class and a button with the class **collapse** are needed. After adding the collapsible class the folder's child entries can be toggled by adding the **open** class to the list element:
 
@@ -116,7 +116,7 @@ Menus
 
 .. versionadded:: 8
 
-To add actions that affect the current list element you can add a menu for second and/or first level elements by adding the button and menu inside the corresponding **li** element and adding the **with-menu** css class:
+To add actions that affect the current list element you can add a menu for second and/or first level elements by adding the button and menu inside the corresponding **li** element and adding the **with-menu** CSS class:
 
 .. code-block:: html
 

--- a/developer_manual/app/database.rst
+++ b/developer_manual/app/database.rst
@@ -100,7 +100,7 @@ To create a mapper, inherit from the mapper base class and call the parent const
 
     }
 
-.. note:: The cursor is closed automatically for all **INSERT**, **DELETE**, **UPDATE** queries and when calling the methods **findOneQuery**, **findEntities**, **findEntity**, **delete**, **insert** and **update**. For custom calls using execute you should always close the cursor after you are done with the fetching to prevent database lock problems on SqLite
+.. note:: The cursor is closed automatically for all **INSERT**, **DELETE**, **UPDATE** queries and when calling the methods **findOneQuery**, **findEntities**, **findEntity**, **delete**, **insert** and **update**. For custom calls using execute you should always close the cursor after you are done with the fetching to prevent database lock problems on SQLite
 
 Every mapper also implements default methods for deleting and updating an entity based on its id::
 
@@ -141,7 +141,7 @@ Entities are data objects that carry all the table's information for one row. Ev
 
 Types
 -----
-The following properties should be annotated by types, to not only assure that the types are converted correctly for storing them in the database (e.g. PHP casts false to the empty string which fails on postgres) but also for casting them when they are retrieved from the database.
+The following properties should be annotated by types, to not only assure that the types are converted correctly for storing them in the database (e.g. PHP casts false to the empty string which fails on PostgreSQL) but also for casting them when they are retrieved from the database.
 
 The following types can be added for a field:
 

--- a/developer_manual/app/database.rst
+++ b/developer_manual/app/database.rst
@@ -48,7 +48,7 @@ The aforementioned example is the most basic way to write a simple database quer
 To generalize and simplify the problem, split code into resources and create an **Entity** and a **Mapper** class for it. The mapper class provides a way to run SQL queries and maps the result onto the related entities.
 
 
-To create a mapper, inherit from the mapper baseclass and call the parent constructor with the following parameters:
+To create a mapper, inherit from the mapper base class and call the parent constructor with the following parameters:
 
 * Database connection
 * Table name
@@ -204,7 +204,7 @@ mapping, simply override the **columnToProperty** and **propertyToColumn** metho
         }
 
         public function propertyToColumn($property) {
-            if ($column === 'phoneNumber') {
+            if ($property === 'phoneNumber') {
                 return 'phonenumber';
             } else {
                 return parent::propertyToColumn($property);
@@ -216,7 +216,7 @@ mapping, simply override the **columnToProperty** and **propertyToColumn** metho
 
 Slugs
 -----
-Slugs are used to identify resources in the URL by a string rather than integer id. Since the URL allows only certain values, the entity baseclass provides a slugify method for it:
+Slugs are used to identify resources in the URL by a string rather than integer id. Since the URL allows only certain values, the entity base class provides a slugify method for it:
 
 .. code-block:: php
 

--- a/developer_manual/app/database.rst
+++ b/developer_manual/app/database.rst
@@ -114,7 +114,7 @@ or::
 
 Entities
 ========
-Entities are data objects that carry all the table's information for one row. Every Entity has an **id** field by default that is set to the integer type. Table rows are mapped from lower case and underscore separated names to pascal case attributes:
+Entities are data objects that carry all the table's information for one row. Every Entity has an **id** field by default that is set to the integer type. Table rows are mapped from lower case and underscore separated names to *lowerCamelCase* attributes:
 
 * **Table column name**: phone_number
 * **Property name**: phoneNumber

--- a/developer_manual/app/hooks.rst
+++ b/developer_manual/app/hooks.rst
@@ -14,7 +14,7 @@ Hooks are used to execute code before or after an event has occurred. This is fo
     $app = new Application();
     $app->getContainer()->query('UserHooks')->register();
 
-The hook logic should be in a separate class that is being registered in the :doc:`container`
+The hook logic should be in a separate class that is being registered in the :doc:`container`:
 
 .. code-block:: php
 

--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -185,7 +185,7 @@ owncloud
 ========
 **Required**: Defines minimum and maximum versions of the Nextcloud core. In case undefined the values will be taken from the tag `requiremin`_.
 
-.. note:: Currently this tag is also used to check for the nextcloud version number.
+.. note:: Currently this tag is also used to check for the Nextcloud version number.
           Thereby the following "translation" is made:
 
           * ownCloud 9.0 matches Nextcloud 9

--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -175,7 +175,7 @@ specified. Valid values for the 'os' attribute are as returned by the PHP functi
 lib
 ===
 Defines a required PHP extension with required minimum and/or maximum version. The names for the libraries have to match the result as returned by the PHP function  `get_loaded_extensions <http://php.net/manual/en/function.get-loaded-extensions.php>`_.
-The explicit version of an extension is read from `phpversion <http://php.net/manual/de/function.phpversion.php>`_ - with some exception as to be read up in the `code base <https://github.com/nextcloud/server/blob/master/lib/private/App/PlatformRepository.php>`_
+The explicit version of an extension is read from `phpversion <http://php.net/manual/de/function.phpversion.php>`_ - with some exception as to be read up in the `code base <https://github.com/nextcloud/server/blob/master/lib/private/App/PlatformRepository.php>`_.
 
 os
 ==

--- a/developer_manual/app/init.rst
+++ b/developer_manual/app/init.rst
@@ -13,7 +13,7 @@ The :file:`appinfo/app.php` is the first file that is loaded and executed in Nex
     \OC::$server->getNavigationManager()->add(function () {
         $urlGenerator = \OC::$server->getURLGenerator();
         return [
-            // the string under which your app will be referenced in nextcloud
+            // the string under which your app will be referenced in Nextcloud
             'id' => 'myapp',
 
             // sorting weight for the navigation. The higher the number, the higher

--- a/developer_manual/app/l10n.rst
+++ b/developer_manual/app/l10n.rst
@@ -4,7 +4,7 @@ Translation
 
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
 
-Nextcloud's translation system is powered by `Transifex <https://www.transifex.com/nextcloud/>`_. To start translating sign up and enter a group. If your community app should be added to Transifex contact one of the translation team `in the forums <https://help.nextcloud.com/c/translations>`_ to set it up for you.
+Nextcloud's translation system is powered by `Transifex <https://www.transifex.com/nextcloud/>`_. To start translating sign up and enter a group. If your community app should be added to Transifex contact one of the translation teams `in the forums <https://help.nextcloud.com/c/translations>`_ to set it up for you.
 
 PHP
 ===
@@ -103,7 +103,7 @@ There is a global function **t()** available for translating strings. The first 
 
     t('myapp', 'Hello World!');
 
-For advanced usage, refer to the source code **core/js/l10n.js**, **t()** is bind to **OC.L10N.translate()**.
+For advanced usage, refer to the source code **core/js/l10n.js**; **t()** is bind to **OC.L10N.translate()**.
 
 Hints
 =====

--- a/developer_manual/app/l10n.rst
+++ b/developer_manual/app/l10n.rst
@@ -8,7 +8,7 @@ Nextcloud's translation system is powered by `Transifex <https://www.transifex.c
 
 PHP
 ===
-Should it ever be needed to use localized strings on the server-side, simply inject the L10N service from the ServerContainer into the needed constructor
+Should it ever be needed to use localized strings on the server-side, simply inject the L10N service from the ServerContainer into the needed constructor:
 
 
 .. code-block:: php

--- a/developer_manual/app/middleware.rst
+++ b/developer_manual/app/middleware.rst
@@ -8,7 +8,7 @@ Middleware is logic that is run before and after each request and is modelled af
 
 * **beforeController**: This is executed before a controller method is being executed. This allows you to plug additional checks or logic before that method, like for instance security checks
 * **afterException**: This is being run when either the beforeController method or the controller method itself is throwing an exception. The middleware is asked in reverse order to handle the exception and to return a response. If the middleware can't handle the exception, it throws the exception again
-* **afterController**: This is being run after a successful controllermethod call and allows the manipulation of a Response object. The middleware is run in reverse order
+* **afterController**: This is being run after a successful controller method call and allows the manipulation of a Response object. The middleware is run in reverse order
 * **beforeOutput**: This is being run after the response object has been rendered and allows the manipulation of the outputted text. The middleware is run in reverse order
 
 To generate your own middleware, simply inherit from the Middleware class and overwrite the methods that should be used.
@@ -77,7 +77,7 @@ The middleware can be registered in the :doc:`container` and added using the **r
 
 Parsing annotations 
 ===================
-Sometimes its useful to conditionally execute code before or after a controller method. This can be done by defining custom annotations. An example would be to add a custom authentication method or simply add an additional header to the response. To access the parsed annotations, inject the **ControllerMethodReflector** class:
+Sometimes it is useful to conditionally execute code before or after a controller method. This can be done by defining custom annotations. An example would be to add a custom authentication method or simply add an additional header to the response. To access the parsed annotations, inject the **ControllerMethodReflector** class:
 
 .. code-block:: php
 

--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -6,7 +6,7 @@ App store publishing
 
 The Nextcloud App Store
 -----------------------
-The Nextcloud app store is build into Nextcloud to allow you to get your apps to users as easily and safely as possible. The app store and the process of publishing apps aims to be:
+The Nextcloud app store is built into Nextcloud to allow you to get your apps to users as easily and safely as possible. The app store and the process of publishing apps aims to be:
 
 * secure
 * transparent
@@ -65,8 +65,8 @@ Requirements:
 
 .. * app is signed, at least domain verified
 
-.. note:: **Developer trust**: The developer(s) is/are known in community; he/she has/have been active for a while, have met others at events and/or worked with others in various areas.
-.. note:: **security audits**: in practice this means that at least some of the code of this developer has been audited; either through another app by the same developer or with an earlier version of the app. And that the attitude of the developer towards these audits has been positive.
+.. note:: **Developer trust**: the developer(s) is/are known in community; he/she has/have been active for a while, have met others at events and/or worked with others in various areas.
+.. note:: **Security audits**: in practice this means that at least some of the code of this developer has been audited; either through another app by the same developer or with an earlier version of the app. And that the attitude of the developer towards these audits has been positive.
 
 App store:
 
@@ -131,7 +131,7 @@ Legal and security
 * Apps do not violate any laws; it has to comply with copyright- and trademark law.
 * App authors have to respond timely to security concerns and not make Nextcloud more vulnerable to attack.
 
-.. note:: distributing malicious or illegal applications can have legal consequences including, but not limited to Nextcloud or affected users taking legal action.
+.. note:: Distributing malicious or illegal applications can have legal consequences including, but not limited to Nextcloud or affected users taking legal action.
 
 Be technically sound
 ^^^^^^^^^^^^^^^^^^^^

--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -54,7 +54,7 @@ Approved apps are developed by trusted developers and have passed a cursory secu
 
 Requirements:
 
-* code is developed in an open and version-managed code repository, ideally GitHub with Git but other SCM/hosting is OK.
+* code is developed in an open and version-managed code repository, ideally GitHub with Git but other SCM/hosting is OK
 * minimum of one active developer/maintainer
 * minimum 5 ratings, average score 60/100 or better
 * app is at least 3 months old
@@ -91,9 +91,9 @@ Requirements:
 
 App store:
 
-* show up in Apps page provided user has enabled "allow installation of experimental apps" in the settings.
-* Warning about security and stability risks is shown for app
-* sorted below all others.
+* show up in Apps page provided user has enabled "allow installation of experimental apps" in the settings
+* warning about security and stability risks is shown for app
+* sorted below all others
 
 Getting an app approved
 -----------------------
@@ -124,7 +124,7 @@ These are the app guidelines an app has to comply with to have a chance to be ap
 Legal and security
 ^^^^^^^^^^^^^^^^^^
 
-* Apps can not use 'Nextcloud' in their name
+* Apps can not use 'Nextcloud' in their name.
 * Irregular and unannounced security audits of all apps can and will take place.
 * If any indication of malicious intent or bad faith is found the developer(s) in question can count on a minimum 2 year ban from any Nextcloud infrastructure.
    * Malicious intent includes deliberate spying on users by leaking user data to a third party system or adding a back door (like a hard-coded user account) to Nextcloud. An unintentional security bug that gets fixed in time won't be considered bad faith.
@@ -136,16 +136,16 @@ Legal and security
 Be technically sound
 ^^^^^^^^^^^^^^^^^^^^
 
-* Apps can only use the public Nextcloud API
-* At time of the release of an app it can only be configured to be compatible with the latest Nextcloud release +1
-* Apps should not cause Nextcloud to break, consume excessive memory or slow Nextcloud down
-* Apps should not hamper functionality of Nextcloud unless that is explicitly the goal of the app
+* Apps can only use the public Nextcloud API.
+* At time of the release of an app it can only be configured to be compatible with the latest Nextcloud release +1.
+* Apps should not cause Nextcloud to break, consume excessive memory or slow Nextcloud down.
+* Apps should not hamper functionality of Nextcloud unless that is explicitly the goal of the app.
 
 Respect the users
 ^^^^^^^^^^^^^^^^^
 
-* Apps have to follow design and `HTML/CSS layout guidelines <../app/css.html>`_
-* Apps correctly clean up after themselves on uninstall and correctly handle up- and downgrades
+* Apps have to follow design and `HTML/CSS layout guidelines <../app/css.html>`_.
+* Apps correctly clean up after themselves on uninstall and correctly handle up- and downgrades.
 * Apps clearly communicate their intended purpose and active features, including features introduced through updates.
 * Apps respect the users' choices and do not make unexpected changes, or limit users' ability to revert them. For example, they do not remove other apps or disable settings.
 * Apps must respect user privacy. IF user data is sent anywhere, this must be clearly explained and be kept to a minimum for the functioning of an app. Use proper security measures when needed.

--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -24,11 +24,11 @@ With each level come requirements and a position in the store.
 
 Official
 ^^^^^^^^
-Official apps are developed by and within the Nextcloud community and its `Github <https://github.com/nextcloud>`_ repository and offer functionality central to Nextcloud. They are ready for serious use and can be considered a part of Nextcloud.
+Official apps are developed by and within the Nextcloud community and its `GitHub <https://github.com/nextcloud>`_ repository and offer functionality central to Nextcloud. They are ready for serious use and can be considered a part of Nextcloud.
 
 Requirements:
 
-* developed in Nextcloud github repo
+* developed in Nextcloud GitHub repo
 * minimum of 2 active maintainers and contributions from others
 * security audited and design reviewed
 * app is at least 6 months old and has seen regular releases
@@ -54,7 +54,7 @@ Approved apps are developed by trusted developers and have passed a cursory secu
 
 Requirements:
 
-* code is developed in an open and version-managed code repository, ideally github with git but other scm/hosting is OK.
+* code is developed in an open and version-managed code repository, ideally GitHub with Git but other SCM/hosting is OK.
 * minimum of one active developer/maintainer
 * minimum 5 ratings, average score 60/100 or better
 * app is at least 3 months old
@@ -97,7 +97,7 @@ App store:
 
 Getting an app approved
 -----------------------
-If you want your app to be approved, make sure you fulfill all the requirements and then create an issue in the `app approval github repository <https://github.com/owncloud/app-approval>`_ using `this template <https://github.com/owncloud/app-approval/blob/master/README.md>`_. A team of Nextcloud contributors will review your application. Updates to an app require re-review but, of course, an initial review takes more effort and time than the checking of an update.
+If you want your app to be approved, make sure you fulfill all the requirements and then create an issue in the `app approval GitHub repository <https://github.com/owncloud/app-approval>`_ using `this template <https://github.com/owncloud/app-approval/blob/master/README.md>`_. A team of Nextcloud contributors will review your application. Updates to an app require re-review but, of course, an initial review takes more effort and time than the checking of an update.
 
 You are encouraged to help review other contributors' apps as well! Every app requires at least two independent reviews so your review of at least 2 (more is better!) other apps will ensure the process continues smoothly. Thank you for participating in this process and being a great Nextcloud Community member!
 

--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -45,8 +45,7 @@ App store:
 * major releases optionally featured on nextcloud.com
 * new versions/updates approved by at least one other person
 
-note:
-Official apps include those that are part of the release tarball. We'd like to keep the tarball minimal so most official apps are not part of the standard installation.
+.. note:: Official apps include those that are part of the release tarball. We'd like to keep the tarball minimal so most official apps are not part of the standard installation.
 
 Approved
 ^^^^^^^^

--- a/developer_manual/app/request.rst
+++ b/developer_manual/app/request.rst
@@ -6,7 +6,7 @@ Request lifecycle
 
 A typical HTTP request consists of the following:
 
-* **An URL**: e.g. /index.php/apps/myapp/something
+* **A URL**: e.g. /index.php/apps/myapp/something
 * **Request Parameters**: e.g. ?something=true&name=tom
 * **A Method**: e.g. GET
 * **Request headers**: e.g. Accept: application/json
@@ -15,7 +15,7 @@ The following sections will present an overview over how that request is being p
 
 Front controller
 ================
-In the beginning, all requests are sent to Nextcloud's :file:`index.php` which in turn executes :file:`lib/base.php`. This file inspects the HTTP headers and abstracts away differences between different Web servers and initializes the basic classes. Afterwards the basic apps are being loaded in the following order:
+In the beginning, all requests are sent to Nextcloud's :file:`index.php` which in turn executes :file:`lib/base.php`. This file inspects the HTTP headers, abstracts away differences between different Web servers and initializes the basic classes. Afterwards the basic apps are being loaded in the following order:
 
 * Authentication backends
 * Filesystem

--- a/developer_manual/app/routes.rst
+++ b/developer_manual/app/routes.rst
@@ -21,7 +21,7 @@ Routes map a URL and a method to a controller method. Routes are defined inside 
 
 The route array contains the following parts:
 
-* **url**: The url that is matched after */index.php/apps/myapp*
+* **url**: The URL that is matched after */index.php/apps/myapp*
 * **name**: The controller and the method to call; *page#index* is being mapped to *PageController->index()*, *articles_api#drop_latest* would be mapped to *ArticlesApiController->dropLatest()*. The controller that matches the page#index name would have to be registered in the following way inside :file:`appinfo/application.php`:
 
   .. code-block:: php
@@ -54,9 +54,9 @@ The route array contains the following parts:
 
         }
 * **method** (Optional, defaults to GET): The HTTP method that should be matched, (e.g. GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH)
-* **requirements** (Optional): lets you match and extract URLs that have slashes in them (see **Matching suburls**)
-* **postfix** (Optional): lets you define a route id postfix. Since each route name will be transformed to a route id (**page#method** -> **myapp.page.method**) and the route id can only exist once you can use the postfix option to alter the route id creation by adding a string to the route id, e.g., **'name' => 'page#method', 'postfix' => 'test'** will yield the route id **myapp.page.methodtest**. This makes it possible to add more than one route/url for a controller method
-* **defaults** (Optional): If this setting is given, a default value will be assumed for each url parameter which is not present. The default values are passed in as a key => value par array
+* **requirements** (Optional): lets you match and extract URLs that have slashes in them (see **Matching subURLs**)
+* **postfix** (Optional): lets you define a route id postfix. Since each route name will be transformed to a route id (**page#method** -> **myapp.page.method**) and the route id can only exist once you can use the postfix option to alter the route id creation by adding a string to the route id, e.g., **'name' => 'page#method', 'postfix' => 'test'** will yield the route id **myapp.page.methodtest**. This makes it possible to add more than one route/URL for a controller method
+* **defaults** (Optional): If this setting is given, a default value will be assumed for each URL parameter which is not present. The default values are passed in as a key => value par array
 
 Extracting values from the URL
 ==============================
@@ -83,7 +83,7 @@ It is possible to extract values from the URL to allow RESTful URL design. To ex
 
 The identifier used inside the route is being passed into controller method by reflecting the method parameters. So basically if you want to get the value **{id}** in your method, you need to add **$id** to your method parameters.
 
-Matching suburls
+Matching subURLs
 ================
 Sometimes it is needed to match more than one URL fragment. An example would be to match a request for all URLs that start with **OPTIONS /index.php/apps/myapp/api**. To do this, use the **requirements** parameter in your route which is an array containing pairs of **'key' => 'regex'**:
 
@@ -106,9 +106,9 @@ Sometimes it is needed to match more than one URL fragment. An example would be 
 
     }
 
-Default values for suburl
+Default values for subURL
 ==========================
-Apart from matching requirements, a suburl may also have a default value. Say you want to support pagination (a 'page' parameter) for your **/posts** suburl that displays posts entries list. You may set a default value for the 'page' parameter, that will be used if not already set in the url. Use the **defaults** parameter in your route which is an array containing pairs of **'urlparameter' => 'defaultvalue'**:
+Apart from matching requirements, a subURL may also have a default value. Say you want to support pagination (a 'page' parameter) for your **/posts** subURL that displays posts entries list. You may set a default value for the 'page' parameter, that will be used if not already set in the URL. Use the **defaults** parameter in your route which is an array containing pairs of **'urlparameter' => 'defaultvalue'**:
 
 .. code-block:: php
 
@@ -121,7 +121,7 @@ Apart from matching requirements, a suburl may also have a default value. Say yo
         'name'     => 'post#index',
         'url'      => '/post/{page}',
         'verb'     => 'GET',
-        'defaults' => array('page' => 1) // this allows same url as /index.php/myapp/post/1
+        'defaults' => array('page' => 1) // this allows same URL as /index.php/myapp/post/1
     ),
 
     // controller/postcontroller.php

--- a/developer_manual/app/routes.rst
+++ b/developer_manual/app/routes.rst
@@ -4,7 +4,7 @@ Routing
 
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
 
-Routes map an URL and a method to a controller method. Routes are defined inside :file:`appinfo/routes.php` by passing a configuration array to the registerRoutes method. An example route would look like this:
+Routes map a URL and a method to a controller method. Routes are defined inside :file:`appinfo/routes.php` by passing a configuration array to the registerRoutes method. An example route would look like this:
 
 .. code-block:: php
 
@@ -55,7 +55,7 @@ The route array contains the following parts:
         }
 * **method** (Optional, defaults to GET): The HTTP method that should be matched, (e.g. GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH)
 * **requirements** (Optional): lets you match and extract URLs that have slashes in them (see **Matching suburls**)
-* **postfix** (Optional): lets you define a route id postfix. Since each route name will be transformed to a route id (**page#method** -> **myapp.page.method**) and the route id can only exist once you can use the postfix option to alter the route id creation by adding a string to the route id e.g.: **'name' => 'page#method', 'postfix' => 'test'** will yield the route id **myapp.page.methodtest**. This makes it possible to add more than one route/url for a controller method
+* **postfix** (Optional): lets you define a route id postfix. Since each route name will be transformed to a route id (**page#method** -> **myapp.page.method**) and the route id can only exist once you can use the postfix option to alter the route id creation by adding a string to the route id, e.g., **'name' => 'page#method', 'postfix' => 'test'** will yield the route id **myapp.page.methodtest**. This makes it possible to add more than one route/url for a controller method
 * **defaults** (Optional): If this setting is given, a default value will be assumed for each url parameter which is not present. The default values are passed in as a key => value par array
 
 Extracting values from the URL
@@ -85,7 +85,7 @@ The identifier used inside the route is being passed into controller method by r
 
 Matching suburls
 ================
-Sometimes its needed to match more than one URL fragment. An example would be to match a request for all URLs that start with **OPTIONS /index.php/apps/myapp/api**. To do this, use the **requirements** parameter in your route which is an array containing pairs of **'key' => 'regex'**:
+Sometimes it is needed to match more than one URL fragment. An example would be to match a request for all URLs that start with **OPTIONS /index.php/apps/myapp/api**. To do this, use the **requirements** parameter in your route which is an array containing pairs of **'key' => 'regex'**:
 
 .. code-block:: php
 
@@ -181,7 +181,7 @@ can be abbreviated by using the **resources** key:
 
 Using the URLGenerator
 ========================
-Sometimes its useful to turn a route into a URL to make the code independent from the URL design or to generate an URL for an image in **img/**. For that specific use case, the ServerContainer provides a service that can be used in your container:
+Sometimes it is useful to turn a route into a URL to make the code independent from the URL design or to generate a URL for an image in **img/**. For that specific use case, the ServerContainer provides a service that can be used in your container:
 
 .. code-block:: php
 
@@ -216,7 +216,7 @@ Sometimes its useful to turn a route into a URL to make the code independent fro
 
     }
 
-Inside the PageController the URL generator can now be used to generate an URL for a redirect:
+Inside the PageController the URL generator can now be used to generate a URL for a redirect:
 
 .. code-block:: php
 

--- a/developer_manual/app/settings.rst
+++ b/developer_manual/app/settings.rst
@@ -12,7 +12,7 @@ Admin
 For Nextcloud 10 the admin settings page got reworked. It is not a long list
 anymore, but divided into sections, where related settings forms are grouped.
 For example, in the **Sharing** section are only settings (built-in and of apps)
-relate to sharing.
+related to sharing.
 
 Settings Form
 =============
@@ -21,7 +21,7 @@ For the settings form, three things are necessary
 
 1. A class implementing ``\OCP\Settings\ISettings``
 2. A template
-3. The implementing class specified in the apps`s info.xml
+3. The implementing class specified in the app's info.xml
 
 Below is an example for an implementor of the ISettings interface. It is based
 on the survey_client solution.
@@ -202,8 +202,8 @@ implementation of the **user_ldap** app.
 Section
 =======
 
-It is also possible, that an app registers its own section. This should be done
-only, if there is not fitting corresponding section and the apps settings form
+It is also possible that an app registers its own section. This should be done
+only if there is not fitting corresponding section and the apps settings form
 takes a lot of screen estate. Otherwise, register to "additional".
 
 Basically, it works the same way as with the settings form. There are only two
@@ -260,7 +260,7 @@ An example implementation of the ISection interface:
 
     }
 
-Also the section must be registered in the apps`s info.xml.
+Also the section must be registered in the app's info.xml.
 
 Personal
 --------

--- a/developer_manual/app/settings.rst
+++ b/developer_manual/app/settings.rst
@@ -17,7 +17,7 @@ related to sharing.
 Settings Form
 =============
 
-For the settings form, three things are necessary
+For the settings form, three things are necessary:
 
 1. A class implementing ``\OCP\Settings\ISettings``
 2. A template

--- a/developer_manual/app/startapp.rst
+++ b/developer_manual/app/startapp.rst
@@ -21,6 +21,6 @@ The following directories have now been created:
 * **appinfo/**: Contains app metadata and configuration
 * **css/**: Contains the CSS
 * **js/**: Contains the JavaScript files
-* **lib/**: Contains the php class files of your app
+* **lib/**: Contains the PHP class files of your app
 * **templates/**: Contains the templates
 * **tests/**: Contains the tests

--- a/developer_manual/app/startapp.rst
+++ b/developer_manual/app/startapp.rst
@@ -12,7 +12,7 @@ Then create a skeleton app in the `app store <https://apps.nextcloud.com/develop
 
 Enable the app
 --------------
-The app can now be enabled on the Nextcloud apps page
+The app can now be enabled on the Nextcloud apps page.
 
 App architecture
 ----------------

--- a/developer_manual/app/tutorial.rst
+++ b/developer_manual/app/tutorial.rst
@@ -1045,7 +1045,7 @@ The template file **ownnotes/templates/part.navigation.php** contains the naviga
     <script id="navigation-tpl" type="text/x-handlebars-template">
         <li id="new-note"><a href="#"><?php p($l->t('Add note')); ?></a></li>
         {{#each notes}}
-            <li class="note with-menu {{#if active}}active{{/if}}"  data-id="{{ id }}">
+            <li class="note with-menu {{#if active}}active{{/if}}" data-id="{{ id }}">
                 <a href="#">{{ title }}</a>
                 <div class="app-navigation-entry-utils">
                     <ul>

--- a/developer_manual/app/tutorial.rst
+++ b/developer_manual/app/tutorial.rst
@@ -172,7 +172,7 @@ Since the route which returns the initial HTML has been taken care of, the contr
 
     }
 
-.. note:: The parameters are extracted from the request body and the url using the controller method's variable names. Since PHP does not support type hints for primitive types such as ints and booleans, we need to add them as annotations in the comments. In order to type cast a parameter to an int, add **@param int $parameterName**
+.. note:: The parameters are extracted from the request body and the URL using the controller method's variable names. Since PHP does not support type hints for primitive types such as ints and booleans, we need to add them as annotations in the comments. In order to type cast a parameter to an int, add **@param int $parameterName**
 
 Now the controller methods need to be connected to the corresponding URLs in the **ownnotes/appinfo/routes.php** file:
 

--- a/developer_manual/app/tutorial.rst
+++ b/developer_manual/app/tutorial.rst
@@ -33,7 +33,7 @@ Now open another terminal window and start the development server::
 
 Afterwards a skeleton app can be created in the `app store <https://apps.nextcloud.com/developer/apps/generate>`_.
 
-Download the extracted the downloaded file and move it into your ``apps/`` directory. Afterwards the application can be enabled on the `apps page <http://localhost:8080/index.php/settings/apps>`_.
+Download the compressed file that contains the generated app and extract it into your ``apps/`` directory. Afterwards the application can be enabled on the `apps page <http://localhost:8080/index.php/settings/apps>`_.
 
 The first basic app is now available at ``http://localhost:8080/index.php/apps/yourappid/``
 

--- a/developer_manual/app/users.rst
+++ b/developer_manual/app/users.rst
@@ -1,5 +1,5 @@
 ==============
-Usermanagement
+User Management
 ==============
 
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>

--- a/developer_manual/bugtracker/codereviews.rst
+++ b/developer_manual/bugtracker/codereviews.rst
@@ -10,7 +10,7 @@ Introduction
 
 In order to increase the code quality within Nextcloud, developers are requested
 to perform code reviews.  As we are now heavily using the GitHub platform these
-code review shall take place on GitHub as well.
+code reviews shall take place on GitHub as well.
 
 Precondition
 ------------
@@ -32,7 +32,7 @@ How will it work?
 #. Other developers (either named or at free will) have a look at the changes
    and are welcome to write comments within the comment field.
 #. In case the reviewer is okay with the changes and thinks all his comments and
-   suggestions have been take into account a :+1 on the comment will signal a positive
+   suggestions have been taken into account a :+1 on the comment will signal a positive
    review.
 #. Before a pull request will be merged into master or the corresponding
    branch at least 2 reviewers need to give :+1 score.

--- a/developer_manual/bugtracker/index.rst
+++ b/developer_manual/bugtracker/index.rst
@@ -15,7 +15,7 @@ Thank you for helping Nextcloud by reporting bugs. Before submitting an issue, p
 
 * If the issue is with the Nextcloud server, report it to the `Server repository`_
 * If the issue is with the Nextcloud client, report it to the `Client repository`_
-* If the issue with with an Nextcloud app, report it to where that app is developed
+* If the issue with with a Nextcloud app, report it to where that app is developed
 * If the app is listed in our `main GitHub organization`_ report it to the correct sub
   repository
 

--- a/developer_manual/bugtracker/kanban.rst
+++ b/developer_manual/bugtracker/kanban.rst
@@ -154,7 +154,7 @@ What does a developer think?
   manually.*
 
 When can I pull?
-  As long as you are reviewing the issue the you should leave the "6 –
+  As long as you are reviewing the issue you should leave the "6 –
   Reviewing" label assigned. Before moving the issue to the "To review" step the
   issue should have been resolved, meaning that not only the issue has been
   implemented but also no other functionality has been broken.
@@ -182,7 +182,7 @@ Who is Assigned?
   No one.
 
 
-While we stated before that said that we push issues to the next column, we can
+While we stated before that we push issues to the next column, we can
 of course move the item back and forth arbitrarily. Basically you can drag the
 issue around in the huboard or just change the label when viewing the issue in
 the GitHub.
@@ -241,7 +241,7 @@ Misc Labels
 
 * Needs info – Either from a developer or the bug reporter. This is nearly as
   severe as Panic, because no further action can be taken
-* L18n – A translation issue go see our `transifex`_
+* L18n – A translation issue; go see our `transifex`_
 * Junior Job – The issue is considered a good starting point to get involved in Nextcloud development
 
 Milestones equal Releases

--- a/developer_manual/bugtracker/kanban.rst
+++ b/developer_manual/bugtracker/kanban.rst
@@ -18,7 +18,7 @@ Backlog
 
 Why do we have it?
   To keep us focused on finishing issues that we started, new issues will be
-  hidden in this column. In huboard you can see the list of things that we could
+  hidden in this column. In HuBoard you can see the list of things that we could
   think about by clicking the small arrow in the top left corner of the concept
   column header.
 
@@ -61,7 +61,7 @@ When can I pull?
       when the issue is ready to be released.
 
     * A concept describing the planned implementation. This can be as simple as
-      a “this just needs changes to the login screen css” or so complex that you
+      a “this just needs changes to the login screen CSS” or so complex that you
       link to a blog entry somewhere else.
 
 Who is Assigned?
@@ -82,7 +82,7 @@ What does a developer think?
 
 When can I pull?
   If you feel like diving into the code and getting your hands dirty you should
-  look for issues with this label. In the comments, there should be a gherkin
+  look for issues with this label. In the comments, there should be a Gherkin
   scenario to tell you when you are done and a concept describing how to
   implement it. Before you start move the issue to the “Developing” step by
   assigning the "4 – Developing" label.
@@ -127,11 +127,11 @@ What does a developer think?
   "I’ll check the Scenario described earlier works as expected. If necessary
   I’ll update the related Gherkin Scenarios. `Drone`_ will test the scenario
   on all kinds of platforms, Web server and database combinations with
-  `cucumber`_."
+  `Cucumber`_."
 
 When can I pull?
   If you feel like making sure an issue works as expected you should look for
-  issues with this label. In the comments you should find a gherkin scenario that
+  issues with this label. In the comments you should find a Gherkin scenario that
   can be used as a checklist for what to try. Before you start move the issue to
   the “Reviewing” step by assigning the “6 – Reviewing” label.
 
@@ -184,7 +184,7 @@ Who is Assigned?
 
 While we stated before that we push issues to the next column, we can
 of course move the item back and forth arbitrarily. Basically you can drag the
-issue around in the huboard or just change the label when viewing the issue in
+issue around in the HuBoard or just change the label when viewing the issue in
 the GitHub.
 
 Reviewing considered impossible?
@@ -192,11 +192,11 @@ Reviewing considered impossible?
 
 How can you possibly review an issue when it requires you to test various
 combinations of browsers, platforms, databases and maybe even app combinations?
-Well, you can’t. But you can write a gherkin scenario that can be used to write
+Well, you can’t. But you can write a Gherkin scenario that can be used to write
 an automated test that is executed by Drone on every commit to the main
 repositories. If for some reason Drone cannot be used for the review you will
 find yourself in the very uncomfortable situation where you release half tested
-code that will hopefully not eat user data. Seriously! Write gherkin scenarios!
+code that will hopefully not eat user data. Seriously! Write Gherkin scenarios!
 
 Other Labels
 ------------
@@ -241,7 +241,7 @@ Misc Labels
 
 * Needs info – Either from a developer or the bug reporter. This is nearly as
   severe as Panic, because no further action can be taken
-* L18n – A translation issue; go see our `transifex`_
+* L18n – A translation issue; go see our `Transifex`_
 * Junior Job – The issue is considered a good starting point to get involved in Nextcloud development
 
 Milestones equal Releases
@@ -251,7 +251,7 @@ Releases are planned via milestones which contain all the Enhancements and Bugs
 that we plan to release when the Deadline is met. When the Deadline approaches
 we will push new Enhancement request and less important bugs to the next
 milestone. This way a milestone will upon release contain all the issues that
-make up the changelog for the release. Furthermore, huboard allows us to filter
+make up the changelog for the release. Furthermore, HuBoard allows us to filter
 the Kanban board by Milestone, making it especially easy to focus on the current
 Release.
 
@@ -263,5 +263,5 @@ Release.
 .. _unit tests: https://github.com/nextcloud/server/tree/master/tests
 .. _Code Review Documentation: codereviews
 .. _Drone: https://drone.weasel.rocks
-.. _cucumber: http://cukes.info/
-.. _transifex: https://www.transifex.com/nextcloud/
+.. _Cucumber: http://cukes.info/
+.. _Transifex: https://www.transifex.com/nextcloud/

--- a/developer_manual/bugtracker/triaging.rst
+++ b/developer_manual/bugtracker/triaging.rst
@@ -34,11 +34,11 @@ Triaging follows these steps:
 General considerations
 ======================
 
-* You need a `github account <https://github.com>`_ to contribute to bug triaging.
-* If you are not familiar with the github issue tracker interface (which is used by Nextcloud to handle bug reports), you `may find this guide useful <https://guides.github.com/features/issues/>`_.
+* You need a `GitHub account <https://github.com>`_ to contribute to bug triaging.
+* If you are not familiar with the GitHub issue tracker interface (which is used by Nextcloud to handle bug reports), you `may find this guide useful <https://guides.github.com/features/issues/>`_.
 * You will initially only be able to comment on issues. The ability to close issues or assign labels will be given liberally to those who have shown to be willing and able to contribute. Just ask on IRC!
 * Read `our bug reporting guidelines <https://github.com/nextcloud/server/blob/master/CONTRIBUTING.md#submitting-issues>`_ so you know what a good report should look like and where things belong. The `issue template <https://raw.github.com/nextcloud/server/master/issue_template.md>`_ asks specifically for some information developers need to solve issues.
-* It might even be fixed, sometimes! It can also be fruitful to contact the `developers on irc <irc://freenode/#nextcloud-dev>`_. Tell them you're triaging bugs and share what problem you bumped into. Or just ask on the test-pilots mailing list.
+* It might even be fixed, sometimes! It can also be fruitful to contact the `developers on IRC <irc://freenode/#nextcloud-dev>`_. Tell them you're triaging bugs and share what problem you bumped into. Or just ask on the test-pilots mailing list.
 * To ensure no two people are working on the same issue, we ask you to simply add a comment like "I am triaging this" in the issue you want to work on, and when done, before or after executing the triaging actions, note similarly that you're done.
 
     To be able to tag and close issues, you need to have access to the repository. For the core and sync app repositories this also means having signed the contributor agreement. However, this isn't really needed for triaging as you can comment after you're done triaging and somebody else can execute those actions.
@@ -46,13 +46,13 @@ General considerations
 Finding bugs to triage
 ======================
 
-Github offers several search queries which can be useful to find a list of bugs which deserve a closer look:
+GitHub offers several search queries which can be useful to find a list of bugs which deserve a closer look:
 
 * `The bugs least recently commented on <https://github.com/issues?q=is%3Aissue+user%3Anextcloud+is%3Aopen+sort%3Aupdated-asc++is%3Apublic+>`_
 * `Least commented issues <https://github.com/issues?q=is%3Aissue+user%3Anextcloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+>`_
 * `Bugs which need info <https://github.com/issues?q=is%3Aissue+user%3Anextcloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+>`_
 
-But there are more methods. For example, if you are a user of Nextcloud with a specific setup like using nginx as Web server or dropbox as storage, or using the encryption app, you could look for bugs with these keywords. You can then use your knowledge of your installation and your installation itself to see if bugs are (still) valid or reproduce them.
+But there are more methods. For example, if you are a user of Nextcloud with a specific setup like using nginx as Web server or Dropbox as storage, or using the encryption app, you could look for bugs with these keywords. You can then use your knowledge of your installation and your installation itself to see if bugs are (still) valid or reproduce them.
 
 Once you have picked an issue, add a comment that you've started triaging:
 
@@ -72,7 +72,7 @@ Let's go over each step.
 
 Finding duplicates
 ------------------
-To find duplicates, the search tool in github is your first stop. In `this screen <https://github.com/nextcloud/server/issues>`_ you can easily search for a few keywords from the bug report. If you find other bugs with the same content, decide what the best bug report is (often the oldest or the one where one or more developers have already started to engage and discuss the problem). That is the 'master' bug report, you can now close the other one (or comment that it can be closed as duplicate).
+To find duplicates, the search tool in GitHub is your first stop. In `this screen <https://github.com/nextcloud/server/issues>`_ you can easily search for a few keywords from the bug report. If you find other bugs with the same content, decide what the best bug report is (often the oldest or the one where one or more developers have already started to engage and discuss the problem). That is the 'master' bug report, you can now close the other one (or comment that it can be closed as duplicate).
 
 If the bug report you were reviewing contains additional information, you can add that information to the 'master' bug report in a comment. Mention this bug report (using #<bug report number>) so a developer can look up the original, closed, report and perhaps ask the initial reporter there for additional information.
 
@@ -82,7 +82,7 @@ When the issue is a feature request, you can be helpful in the same way: merge r
 
 .. note:: Be polite: when you need to request information or feedback be clear and polite, and you will get more information in less time. Think about how you'd like to be treated, were you to report a bug!
 .. note:: You can answer more quickly and friendly using one of `these templates <https://gist.github.com/jancborchardt/6155185#clean-up-inactive-issues>`_. 
-.. note:: Often our github issue tracker is a place for discussions about solutions. Be friendly, inclusive and respect other people's position.
+.. note:: Often our GitHub issue tracker is a place for discussions about solutions. Be friendly, inclusive and respect other people's position.
 
 Determining relevance of issue
 ------------------------------

--- a/developer_manual/bugtracker/triaging.rst
+++ b/developer_manual/bugtracker/triaging.rst
@@ -6,7 +6,7 @@ Nextcloud Bug Triaging
    :maxdepth: 2
    :hidden:
 
-Bug Triaging is the process of checking bug reports to see if they are still valid (the problem might be solved since the bug was reported), reproducing them when possible (to make sure it really is an Nextcloud issue and not a configuration problem) and in general making sure the bug is useful for a developer who wants to fix it. If the bug is not useful and can't be augmented by the original reporter or the triaging contributor, it has to be closed.
+Bug Triaging is the process of checking bug reports to see if they are still valid (the problem might be solved since the bug was reported), reproducing them when possible (to make sure it really is a Nextcloud issue and not a configuration problem) and in general making sure the bug is useful for a developer who wants to fix it. If the bug is not useful and can't be augmented by the original reporter or the triaging contributor, it has to be closed.
 
 Why do you want to join
 =======================

--- a/developer_manual/bugtracker/triaging.rst
+++ b/developer_manual/bugtracker/triaging.rst
@@ -28,7 +28,7 @@ Triaging follows these steps:
 
 * Find an issue somebody should look at
 * Be that somebody and see if the issue content is useful for a developer
-* Reply and close, ask a question, add information or a label.
+* Reply and close, ask a question, add information or a label
 * Find the next bug-to-be-dealt-with and repeat!
 
 General considerations

--- a/developer_manual/bugtracker/triaging.rst
+++ b/developer_manual/bugtracker/triaging.rst
@@ -48,9 +48,9 @@ Finding bugs to triage
 
 GitHub offers several search queries which can be useful to find a list of bugs which deserve a closer look:
 
-* `The bugs least recently commented on <https://github.com/issues?q=is%3Aissue+user%3Anextcloud+is%3Aopen+sort%3Aupdated-asc++is%3Apublic+>`_
-* `Least commented issues <https://github.com/issues?q=is%3Aissue+user%3Anextcloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+>`_
-* `Bugs which need info <https://github.com/issues?q=is%3Aissue+user%3Anextcloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+>`_
+* `The bugs least recently commented on <https://github.com/search?q=is%3Aissue+user%3Anextcloud+is%3Aopen+sort%3Aupdated-asc+is%3Apublic+>`_
+* `Least commented issues <https://github.com/search?q=is%3Aissue+user%3Anextcloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+>`_
+* `Bugs which need info <https://github.com/search?q=is%3Aissue+user%3Anextcloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+>`_
 
 But there are more methods. For example, if you are a user of Nextcloud with a specific setup like using nginx as Web server or Dropbox as storage, or using the encryption app, you could look for bugs with these keywords. You can then use your knowledge of your installation and your installation itself to see if bugs are (still) valid or reproduce them.
 
@@ -61,7 +61,7 @@ Once you have picked an issue, add a comment that you've started triaging:
 Checking if the issue is useful
 ===============================
 
-Much content from https://techbase.kde.org/Contribute/Bugsquad/Guide_To_BugTriaging
+Much content from https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging
 
 The goal of triaging is to have only useful bug reports for the developers. And you don't have to know much to be able to judge at least some bug reports to be less than useful. There are duplications, incomplete reports and so on. Here is the work flow for each bug:
 
@@ -121,6 +121,6 @@ Once you are done reproducing an issue, it is time to finish up and make clear t
 Now, the developers can pick the issue up. Note that while we wish we would always pick up and solve problems promptly, not all areas of Nextcloud get the same amount of attention and contribution, so this can occasionally take a long time.
 
 
-**Credit:** this document is in debt to the extensive `KDE guide to bug triaging <https://techbase.kde.org/Contribute/Bugsquad/Guide_To_BugTriaging>`_.
+**Credit:** this document is in debt to the extensive `KDE guide to bug triaging <https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging>`_.
 
 

--- a/developer_manual/commun/index.rst
+++ b/developer_manual/commun/index.rst
@@ -11,7 +11,7 @@ Communicate via our `forums <https://help.nextcloud.com>`_.
 
 IRC channels
 ------------
-Chat with us on `IRC <http://www.irchelp.org/>`_. All channels are on **irc.freenode.net**
+Chat with us on `IRC <http://www.irchelp.org/>`_. All channels are on **irc.freenode.net**:
 
 * Setup: **#nextcloud**
 * Development: **#nextcloud-dev**

--- a/developer_manual/core/externalapi.rst
+++ b/developer_manual/core/externalapi.rst
@@ -31,13 +31,13 @@ Returning Data
 Once the API backend has matched your URL, your callable function as defined in
 **BarController::getFoo** will be executed. The AppFramework will make sure that
 send parameters are provided to the method based on its declaration. To return
-data back the the client, you should return an instance of (a subclass of)
+data back to the client, you should return an instance of (a subclass of)
 :php:class:`OCP\AppFramework\Http\Response`, typically :php:class:`OCSResponse`.
 The API backend will then use this to construct the XML or JSON response.
 
 Authentication & Basics
 ~~~~~~~~~~~~~~~~~~~~~~~
-Because REST is stateless you have to send user and password each time you access the API. Therefore running Nextcloud **with SSL is highly recommended** otherwise **everyone in your network can log your credentials**::
+Because REST is stateless you have to send user and password each time you access the API. Therefore running Nextcloud **with SSL is highly recommended**; otherwise **everyone in your network can log your credentials**::
 
     https://user:password@example.com/ocs/v1.php/apps/yourapp
 

--- a/developer_manual/core/ocs-share-api.rst
+++ b/developer_manual/core/ocs-share-api.rst
@@ -43,7 +43,7 @@ Get all shares from a given file/folder.
 
 * Result: XML with the shares
 
-Statuscodes
+Statuscodes:
 
 * 100 - successful
 * 400 - not a directory (if the 'subfile' argument was used)

--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -51,7 +51,7 @@ for example in /nextcloud/core/ and /nextcloud/settings/ in these sub folders:
 * js = JavaScripts
 * img = images
 * l10n = translation files
-* templates = php and html template files
+* templates = PHP and HTML template files
 
 .. _notes-for-updates:
 
@@ -99,7 +99,7 @@ The (main) pictures that can be found inside Nextcloud standard theming are the 
 Inserting your new logo
 -----------------------
 Inserting a new logo into an existing theme is as simple as replacing the old logo with the new (generated) one.
-You can use: scalable vector graphics (.svg) or common graphics formats for the internet such as portable network graphics (.png) or .jpeg
+You can use: scalable vector graphics (.svg) or common graphics formats for the Internet such as portable network graphics (.png) or .jpeg
 Just insert the new created picture by using the unchanged name of the old picture.
 
 The app icons can also be overwritten in a theme. To change for example the app icon of the activity app you need to overwrite it by saving the new image to …/nextcloud/themes/default/apps/activity/img/activity.svg

--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -29,10 +29,10 @@ Creating and activating a new theme
 ===================================
 There are two basic ways of creating new themings:
 
-* Doing all new from scratch
-* Starting from an existing theme or the example theme and doing everything step by step and more experimentally
+* doing all new from scratch
+* starting from an existing theme or the example theme and doing everything step by step and more experimentally
 
-Depending on how you created your new theme it will be necessary to
+Depending on how you created your new theme it will be necessary to:
 
 * put a new theme into the /themes folder. The theme can be activated by putting ``'theme' => 'MyTheme'`` into the ``/config/config.php`` file.
 * make your changes in the ``/themes/MyTheme`` folder
@@ -99,10 +99,10 @@ The (main) pictures that can be found inside Nextcloud standard theming are the 
 Inserting your new logo
 -----------------------
 Inserting a new logo into an existing theme is as simple as replacing the old logo with the new (generated) one.
-You can use: scalable vector graphics (.svg) or common graphics formats for the Internet such as portable network graphics (.png) or .jpeg
+You can use: scalable vector graphics (.svg) or common graphics formats for the Internet such as portable network graphics (.png) or .jpeg.
 Just insert the new created picture by using the unchanged name of the old picture.
 
-The app icons can also be overwritten in a theme. To change for example the app icon of the activity app you need to overwrite it by saving the new image to …/nextcloud/themes/default/apps/activity/img/activity.svg
+The app icons can also be overwritten in a theme. To change for example the app icon of the activity app you need to overwrite it by saving the new image to …/nextcloud/themes/default/apps/activity/img/activity.svg.
 
 Changing favicon
 ----------------

--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -11,16 +11,15 @@ This documentation contains only the Web-frontend adaptations so far.
 
 Getting started
 ===============
-A good idea getting starting with a dynamically created website is to inspect it with **web developer tools**, that are found in almost any browser. They show the generated HTML and the CSS Code, that the client/browser is receiving:
-With this facts you can easily determine, where the following object-related attributes for the phenomenons are settled:
+A good idea to get started with a dynamically created website is to inspect it with **web developer tools**, that are found in almost any browser. They show the generated HTML and the CSS Code that the client/browser is receiving:
+With this facts you can easily determine where the following object-related attributes for the phenomenons are settled:
 
 * place
 * colour
 * links
 * graphics
 
-The next thing you should do, before starting any changes is:
-Make a backup of your current theme(s) e.g.:
+The next thing you should do, before starting any changes, is to make a backup of your current theme(s), e.g.:
 
 * cd …/nextcloud/themes
 * cp -r example mytheme
@@ -35,8 +34,8 @@ There are two basic ways of creating new themings:
 
 Depending on how you created your new theme it will be necessary to
 
-* put a new theme into the /themes -folder. The theme can be activated by putting ``'theme' => 'MyTheme'``, into the ``/config/config.php`` file.
-* make your changes in the ``/themes/MyTheme`` -folder
+* put a new theme into the /themes folder. The theme can be activated by putting ``'theme' => 'MyTheme'`` into the ``/config/config.php`` file.
+* make your changes in the ``/themes/MyTheme`` folder
 * make sure that the theming app is disabled
 
 
@@ -92,15 +91,15 @@ If you want to do a quick exchange like (1) it's important to know the size of t
 * You can look up sizing in most cases via the file properties inside your file-manager
 * Create an own picture/logo with the same size then
 
-The (main) pictures, that can be found inside Nextcloud standard theming are the following:
+The (main) pictures that can be found inside Nextcloud standard theming are the following:
 
 * The logo at the login-page above the credentials-box: 	        …/nextcloud/themes/default/core/img/logo.svg
-* The logo, that's always in the left upper corner after login:   …/nextcloud/themes/default/core/img/logo-wide.svg
+* The logo that's always in the left upper corner after login:   …/nextcloud/themes/default/core/img/logo-wide.svg
 
 Inserting your new logo
 -----------------------
 Inserting a new logo into an existing theme is as simple as replacing the old logo with the new (generated) one.
-You can use: scalable vector graphics (.svg) or common graphics formats for the internet such as portable network graphics (.png) or .jepg
+You can use: scalable vector graphics (.svg) or common graphics formats for the internet such as portable network graphics (.png) or .jpeg
 Just insert the new created picture by using the unchanged name of the old picture.
 
 The app icons can also be overwritten in a theme. To change for example the app icon of the activity app you need to overwrite it by saving the new image to …/nextcloud/themes/default/apps/activity/img/activity.svg
@@ -134,10 +133,10 @@ On the top of the login page you can see a case- distinguished setting for diffe
     background: linear-gradient(top, #33537a 0%,#1d2d42 100%); /* W3C */
   }
 
-The different background-assignments indicate the headers for a lot of different browser types. What you most likely want to do is change the #35537a (lighter blue) and #ld2d42 (dark blue) color to the colours of our choice. In some older and other browsers, there is just one color, but in the rest showing gradients is possible.
-The login page background is a horizontal gradient. The first hex number, #35537a, is the top color of the gradient at the login screen. The second hex number, #ld2d42 is the bottom color of the gradient at the login screen.
+The different background-assignments indicate the headers for a lot of different browser types. What you most likely want to do is change the #35537a (lighter blue) and #ld2d42 (dark blue) color to the colours of our choice. In some older and other browsers there is just one color, but in the rest showing gradients is possible.
+The login page background is a horizontal gradient. The first hex number, #35537a, is the top color of the gradient at the login screen. The second hex number, #ld2d42, is the bottom color of the gradient at the login screen.
 The gradient in top of the normal view after login is also defined by these CSS-settings, so that they take effect in logged in situation as well.
-Change these colors to the hex color of your choice:
+Change these colors to the hex color of your choice.
 As usual:
 
 * the first two figures give the intensity of the red channel,
@@ -156,7 +155,7 @@ How to change translations
 
 You can override the translation of single strings within your theme. Simply
 create the same folder structure within your theme folder for the language file
-you want to override. Only the changed strings need to be added to that file for
+you want to override. Only the changed strings need to be added to that file; for
 all other terms the shipped translation will be used.
 
 If you want to override the translation of the term "Download" within the

--- a/developer_manual/core/translation.rst
+++ b/developer_manual/core/translation.rst
@@ -6,7 +6,7 @@ Make text translatable
 
 In HTML or PHP wrap it like this ``<?php p($l->t('This is some text'));?>`` or this ``<?php print_unescaped($l->t('This is some text'));?>``.
 For the right date format use ``<?php p($l->l('date', time()));?>``. Change the way dates are shown by editing /core/l10n/l10n-[lang].php.
-To translate text in javascript use: ``t('appname','text to translate');``
+To translate text in JavaScript use: ``t('appname','text to translate');``
 
 
 .. note:: ``print_unescaped()`` should be preferred only if you would like to display HTML code. Otherwise, using ``p()`` is strongly preferred to escape HTML characters against XSS attacks.
@@ -36,10 +36,10 @@ Translators will translate:
 
 Translating these individual strings results in  ``local filesystem`` and ``cloud`` losing case. The two white spaces surrounding ``or`` will get lost while translating as well. For languages that have a different grammatical order it prevents the translators from reordering the sentence components.
 
-Html on translation string:
+HTML on translation string:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Html tags in translation strings is ugly but usually translators can handle this.
+HTML tags in translation strings is ugly but usually translators can handle this.
 
 What about variable in the strings?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -54,11 +54,11 @@ Automated synchronization of translations
 -----------------------------------------
 
 Multiple nightly jobs have been setup in order to synchronize translations - it's a multi-step process:
-``perl l10n.pl read`` will rescan all php and javascript files and generate the templates.
+``perl l10n.pl read`` will rescan all PHP and JavaScript files and generate the templates.
 The templates are pushed to `Transifex`_ (tx push -s).
 All translations are pulled from `Transifex`_ (tx pull -a).
-``perl l10n.pl write`` will write the php files containing the translations.
-Finally the changes are pushed to git.
+``perl l10n.pl write`` will write the PHP files containing the translations.
+Finally the changes are pushed to Git.
 
 Please follow the steps below to add translation support to your app:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -67,7 +67,7 @@ Create a folder ``l10n``.
 Create the file ``ignorelist`` which can contain files which shall not be scanned during step 4.
 Edit ``l10n/.tx/config`` and copy/paste a config section and adapt it by changing the app/folder name.
 Run ``perl l10n.pl read`` with l10n.
-Add the newly created translation template (l10n/Templates/<appname>.pot) to git and commit the changes above.
+Add the newly created translation template (l10n/Templates/<appname>.pot) to Git and commit the changes above.
 After the next nightly sync job a new resource will appear on Transifex and from now on every night the latest translations will arrive.
 
 Translation sync jobs:
@@ -86,7 +86,7 @@ Manual quick translation update:
 
 The translation script requires Locale::PO, installable via ``apt-get install liblocale-po-perl``
 
-Configure transifex
+Configure Transifex
 -------------------
 
 .. code-block:: bash

--- a/developer_manual/core/translation.rst
+++ b/developer_manual/core/translation.rst
@@ -84,7 +84,7 @@ Manual quick translation update:
 
   cd l10n/ && perl l10n.pl read && tx push -s && tx pull -a && perl l10n.pl write && cd ..
 
-The translation script requires Locale::PO, installable via ``apt-get install liblocale-po-perl``
+The translation script requires Locale::PO, installable via ``apt-get install liblocale-po-perl``.
 
 Configure Transifex
 -------------------

--- a/developer_manual/core/translation.rst
+++ b/developer_manual/core/translation.rst
@@ -4,8 +4,8 @@ Translation
 Make text translatable
 ----------------------
 
-In HTML or PHP wrap it like this ``<?php p($l->t('This is some text'));?>`` or this ``<?php print_unescaped($l->t('This is some text'));?>``
-For the right date format use ``<?php p($l->l('date', time()));?>``. Change the way dates are shown by editing /core/l10n/l10n-[lang].php
+In HTML or PHP wrap it like this ``<?php p($l->t('This is some text'));?>`` or this ``<?php print_unescaped($l->t('This is some text'));?>``.
+For the right date format use ``<?php p($l->l('date', time()));?>``. Change the way dates are shown by editing /core/l10n/l10n-[lang].php.
 To translate text in javascript use: ``t('appname','text to translate');``
 
 
@@ -65,8 +65,8 @@ Please follow the steps below to add translation support to your app:
 
 Create a folder ``l10n``.
 Create the file ``ignorelist`` which can contain files which shall not be scanned during step 4.
-Edit ``l10n/.tx/config`` and copy/past a config section and adopt it by changing the app/folder name.
-Run ``perl l10n.pl read`` with l10n
+Edit ``l10n/.tx/config`` and copy/paste a config section and adapt it by changing the app/folder name.
+Run ``perl l10n.pl read`` with l10n.
 Add the newly created translation template (l10n/Templates/<appname>.pot) to git and commit the changes above.
 After the next nightly sync job a new resource will appear on Transifex and from now on every night the latest translations will arrive.
 

--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -19,7 +19,7 @@ or install it manually::
   chmod +x phpunit.phar
   sudo mv phpunit.phar /usr/local/bin/phpunit
 
-After the installation the ''phpunit'' command is available::
+After the installation the **phpunit** command is available::
 
   phpunit --version
 
@@ -36,7 +36,7 @@ To get started, do the following:
  - Create a directory called ``tests`` in the top level of your application
  - Create a PHP file in the directory and ``require_once`` your class which you want to test
 
-Then you can simply run the created test with phpunit.
+Then you can simply run the created test with **phpunit**.
 
 .. note:: If you use Nextcloud functions in your class under test (i.e., OC::getUser()) you'll need to bootstrap Nextcloud or use dependency injection.
 

--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -34,7 +34,7 @@ Writing PHP unit tests
 
 To get started, do the following:
  - Create a directory called ``tests`` in the top level of your application
- - Create a PHP file in the directory and ``require_once`` your class which you want to test.
+ - Create a PHP file in the directory and ``require_once`` your class which you want to test
 
 Then you can simply run the created test with phpunit.
 
@@ -95,7 +95,7 @@ Bootstrapping Nextcloud
 ~~~~~~~~~~~~~~~~~~~~~~~
 If you use Nextcloud functions or classes in your code, you'll need to make them available to your test by bootstrapping Nextcloud.
 
-To do this, you'll need to provide the ``--bootstrap`` argument when running PHPUnit
+To do this, you'll need to provide the ``--bootstrap`` argument when running PHPUnit:
 
 :file:`/srv/http/nextcloud`::
 
@@ -177,9 +177,9 @@ Every time you reload the page, the unit tests will be relaunched and will outpu
 Unit test paths
 ~~~~~~~~~~~~~~~
 
-JavaScript unit test examples can be found in :file:`apps/files/tests/js/`
+JavaScript unit test examples can be found in :file:`apps/files/tests/js/`.
 
-Unit tests for the core app JavaScript code can be found in :file:`core/js/tests/specs`
+Unit tests for the core app JavaScript code can be found in :file:`core/js/tests/specs`.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -138,7 +138,7 @@ Further Reading
 JavaScript unit testing for core
 --------------------------------
 
-JavaScript Unit testing for **core** and **core apps** is done using the `Karma <http://karma-runner.github.io>`_ test runner with `Jasmine <http://pivotal.github.io/jasmine/>`_.
+JavaScript Unit testing for **core** and **core apps** is done using the `Karma <http://karma-runner.github.io>`_ test runner with `Jasmine <https://jasmine.github.io/>`_.
 
 Installing Node JS
 ~~~~~~~~~~~~~~~~~~

--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -9,7 +9,7 @@ Getting PHPUnit
 
 Nextcloud uses PHPUnit >= 4.8 for unit testing.
 
-To install it, either get it via your packagemanager::
+To install it, either get it via your package manager::
 
   sudo apt-get install phpunit
 
@@ -38,9 +38,9 @@ To get started, do the following:
 
 Then you can simply run the created test with phpunit.
 
-.. note:: If you use Nextcloud functions in your class under test (i.e: OC::getUser()) you'll need to bootstrap Nextcloud or use dependency injection.
+.. note:: If you use Nextcloud functions in your class under test (i.e., OC::getUser()) you'll need to bootstrap Nextcloud or use dependency injection.
 
-.. note:: You'll most likely run your tests under a different user than the Web server. This might cause problems with your PHP settings (i.e: open_basedir) and requires you to adjust your configuration.
+.. note:: You'll most likely run your tests under a different user than the Web server. This might cause problems with your PHP settings (i.e., open_basedir) and requires you to adjust your configuration.
 
 An example for a simple test would be:
 
@@ -84,7 +84,7 @@ In :file:`/srv/http/nextcloud/apps/myapp/` you run the test with::
   phpunit tests/testaddtwo.php
 
 
-Make sure to extend the ``\Test\TestCase`` class with your test and always call the parent methods,
+Make sure to extend the ``\Test\TestCase`` class with your test and always call the parent methods
 when overwriting ``setUp()``, ``setUpBeforeClass()``, ``tearDown()`` or ``tearDownAfterClass()`` method
 from the TestCase. These methods set up important stuff and clean up the system after the test,
 so the next test can run without side effects, like remaining files and entries in the file cache, etc.

--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -34,7 +34,7 @@ Writing PHP unit tests
 
 To get started, do the following:
  - Create a directory called ``tests`` in the top level of your application
- - Create a php file in the directory and ``require_once`` your class which you want to test.
+ - Create a PHP file in the directory and ``require_once`` your class which you want to test.
 
 Then you can simply run the created test with phpunit.
 

--- a/developer_manual/general/codingguidelines.rst
+++ b/developer_manual/general/codingguidelines.rst
@@ -7,12 +7,12 @@ General
 -------
 
 * Ideally, discuss your plans on the `forums <https://help.nextcloud.com>`_ to see if others want to work with you on it
-* We use `Github <https://github.com/nextcloud>`_, please get an account there and clone the repositories you want to work on
+* We use `GitHub <https://github.com/nextcloud>`_, please get an account there and clone the repositories you want to work on
 * Fixes go directly to master, nevertheless they need to be tested thoroughly.
 * New features are always developed in a branch and only merged to master once they are fully done.
 * Software should work. We only put features into master when they are complete. It's better to not have a feature instead of having one that works poorly.
 * It is best to start working based on an issue - create one if there is none. You describe what you want to do, ask feedback on the direction you take it and take it from there.
-* When you are finished, use the merge request function on Github to create a pull request. The other developers will look at it and give you feedback. You can signify that your PR is ready for review by adding the label "5 - ready for review" to it. You can also post your merge request to the mailing list to let people know. See `the code review page for more information <../bugtracker/codereviews.html>`_
+* When you are finished, use the merge request function on GitHub to create a pull request. The other developers will look at it and give you feedback. You can signify that your PR is ready for review by adding the label "5 - ready for review" to it. You can also post your merge request to the mailing list to let people know. See `the code review page for more information <../bugtracker/codereviews.html>`_
 * It is key to keep changes separate and small. The bigger and more hairy a PR grows, the harder it is to get it in. So split things up where you can in smaller changes - if you need a small improvement like a API addition for a big feature addition, get it in first rather than adding it to the big piece of work!
 * Decisions are made by consensus. We strive for making the best technical decisions and as nobody can know everything, we collaborate. That means a first negative comment might not be the final word, neither is positive feedback an immediate GO. Nextcloud is built out of modular pieces (apps) and maintainers have a strong influence. In case of disagreement we consult other seasoned contributors.
 

--- a/developer_manual/general/codingguidelines.rst
+++ b/developer_manual/general/codingguidelines.rst
@@ -131,7 +131,7 @@ All API methods need to be marked with `PHPDoc <http://en.wikipedia.org/wiki/PHP
 
 Objects, Functions, Arrays & Variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Use Pascal case for Objects, Camel case for functions and variables. If you set
+Use *UpperCamelCase* for Objects, *lowerCamelCase* for functions and variables. If you set
 a default function/method parameter, do not use spaces. Do not prepend private
 class members with underscores.
 
@@ -332,7 +332,7 @@ This is how you'd do inheritance in JavaScript:
 
 Objects, Functions & Variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Use Pascal case for Objects, Camel case for functions and variables.
+Use *UpperCamelCase* for Objects, *lowerCamelCase* for functions and variables.
 
 .. code-block:: javascript
 

--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -24,12 +24,12 @@ There are two ways to obtain Nextcloud sources:
 .. TODO ON RELEASE: Update version number above on release
 * Using the development version from `GitHub`_ which will be explained below.
 
-To check out the source from `GitHub`_ you will need to install git (see `Setting up git <https://help.github.com/articles/set-up-git>`_ from the GitHub help)
+To check out the source from `GitHub`_ you will need to install Git (see `Setting up Git <https://help.github.com/articles/set-up-git>`_ from the GitHub help)
 
 Gather information about server setup
 -------------------------------------
 
-To get started the basic git repositories need to cloned into the Web server's directory. Depending on the distribution this will either be
+To get started the basic Git repositories need to cloned into the Web server's directory. Depending on the distribution this will either be
 
 * **/var/www**
 * **/var/www/html**
@@ -52,7 +52,7 @@ After the development tool installation make the directory writable::
 
   sudo chmod o+rw /var/www
 
-Then install Nextcloud from git::
+Then install Nextcloud from Git::
 
   git clone git@github.com:nextcloud/server.git /var/www/<folder>
   cd /var/www/<folder> 

--- a/developer_manual/general/security.rst
+++ b/developer_manual/general/security.rst
@@ -58,7 +58,7 @@ An attacker might now easily send the user a link to::
 
 to overtake the user account. The same problem occurs when outputting content from the database or any other location that is writable by users.
 
-Another attack vector that is often overlooked is XSS in **href** attributes. HTML allows to execute javascript in href attributes like this::
+Another attack vector that is often overlooked is XSS in **href** attributes. HTML allows to execute JavaScript in href attributes like this::
 
     <a href="javascript:alert('xss')">
 


### PR DESCRIPTION
I have fixed several typos I found in the developer manual. However, there are still other typos that I did **NOT** know how to fix:

- [not be used because](https://github.com/nextcloud/documentation/blame/66aa779a86be909361f418906b038a69dcba1096/developer_manual/app/info.rst#L214); missing explanation
- [Create an own picture/logo with the same size then](https://github.com/nextcloud/documentation/blame/1460ce458c40e2f590ab310acd2f75b1a1a1dae8/developer_manual/core/theming.rst#L93); missing following step
- [but also a sample project, sample_client sample_client  properties/android/librerias, which will assist in learning how to use the library](https://github.com/nextcloud/documentation/blame/6ccd2c5678b85d35a8673d784bef5c6c89e7ecb9/developer_manual/android_library/library_installation.rst#L12-L14); I am not sure what it should say there
- [Run `perl l10n.pl read` with l10n](https://github.com/nextcloud/documentation/blame/2647609319e63f79327b7d0119dd68250c9cf771/developer_manual/core/translation.rst#L69); _in_ instead of _with_?
- [TODO ON RELEASE: Update version number above on release](https://github.com/nextcloud/documentation/blame/9ef437c382e549f6088f8d4b128a9c3731499c6e/developer_manual/core/ocs-share-api.rst#L142) is [shown in the final version](https://docs.nextcloud.com/server/12/developer_manual/core/ocs-share-api.html)
- broken external link to _https://ci.owncloud.org/view/translation-sync/_ in [core/translation.rst](https://github.com/nextcloud/documentation/blame/2647609319e63f79327b7d0119dd68250c9cf771/developer_manual/core/translation.rst#L76)
- broken external link to _https://drone.weasel.rocks/_ in [bugtracker/kanban.rst](https://github.com/nextcloud/documentation/blame/2647609319e63f79327b7d0119dd68250c9cf771/developer_manual/bugtracker/kanban.rst#L265) and [bugtracker/codereviews.rst](https://github.com/nextcloud/documentation/blame/2647609319e63f79327b7d0119dd68250c9cf771/developer_manual/bugtracker/codereviews.rst#L58); I do not know how to replace it, as _https://drone.nextcloud.com/_ does not offer any value to a regular user (it is just a login screen), and _https://drone.nextcloud.com/nextcloud/server/_ applies only to the server, but not to the other projects.
- broken internal links in [bugtracker/codereviews.rst](https://github.com/nextcloud/documentation/blame/2647609319e63f79327b7d0119dd68250c9cf771/developer_manual/bugtracker/codereviews.rst#L61) and [bugtracker/kanban.rst](https://github.com/nextcloud/documentation/blame/2647609319e63f79327b7d0119dd68250c9cf771/developer_manual/bugtracker/kanban.rst#L264)
- missing internal links in _core/theming.rst_: [as described under 1.3. by adding](https://github.com/nextcloud/documentation/blame/1460ce458c40e2f590ab310acd2f75b1a1a1dae8/developer_manual/core/theming.rst#L85), [to do a quick exchange like (1) it's important](https://github.com/nextcloud/documentation/blame/1460ce458c40e2f590ab310acd2f75b1a1a1dae8/developer_manual/core/theming.rst#L89) and [as described in 1. you can](https://github.com/nextcloud/documentation/blame/1460ce458c40e2f590ab310acd2f75b1a1a1dae8/developer_manual/core/theming.rst#L247)
- missing internal link in _app/routes.rst_: [see Matching suburls](https://github.com/nextcloud/documentation/blame/d88db49bd4961f1651b65806d833196fcf3ba5ad/developer_manual/app/routes.rst#L57)
- in [app/tutorial.rst](https://github.com/nextcloud/documentation/blame/d0437c17688646dc5cd8dfde8d8cdad0f1223718/developer_manual/app/tutorial.rst#L362), is there any reason to use `$AppName` and `$UserId` in _UpperCamelCase_ instead of _lowerCamelCase_?

Finally, should the manual use UK or US spelling (e.g., _colour_ or _color_)? And, are contractions fine or should they be expanded (e.g., "you're" or "you are")?
