### PR TITLE
Fix typos in developer manual

### DIFF
--- a/developer_manual/android_library/library_installation.rst
+++ b/developer_manual/android_library/library_installation.rst
@@ -9,9 +9,7 @@ The Nextcloud Android library may be obtained from the following GitHub reposito
 
 `https://github.com/nextcloud/android-library <https://github.com/nextcloud/android-library>`_
 
-Once obtained, this code should be compiled. The GitHub repository not only contains the library, but also a sample project, sample_client
-sample_client  properties/android/librerias
-, which will assist in learning how to use the library.
+Once obtained, this code should be compiled. The GitHub repository not only contains the library, but also a sample project, *sample_client*, which will assist in learning how to use the library.
 
 
 Add the library to a project

--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -211,7 +211,7 @@ In case the app has its own admin related settings, it needs to implement the \O
 Deprecated
 ----------
 
-The following sections are just listed for reference and should not be used because
+The following sections are just listed for reference and should not be used; they are deprecated and often not evaluated anymore (i.e., they are ignored).
 
 requiremin
 ==========

--- a/developer_manual/app/routes.rst
+++ b/developer_manual/app/routes.rst
@@ -54,7 +54,7 @@ The route array contains the following parts:
 
         }
 * **method** (Optional, defaults to GET): The HTTP method that should be matched, (e.g. GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH)
-* **requirements** (Optional): lets you match and extract URLs that have slashes in them (see **Matching subURLs**)
+* **requirements** (Optional): lets you match and extract URLs that have slashes in them (see :ref:`matching-suburls`)
 * **postfix** (Optional): lets you define a route id postfix. Since each route name will be transformed to a route id (**page#method** -> **myapp.page.method**) and the route id can only exist once you can use the postfix option to alter the route id creation by adding a string to the route id, e.g., **'name' => 'page#method', 'postfix' => 'test'** will yield the route id **myapp.page.methodtest**. This makes it possible to add more than one route/URL for a controller method
 * **defaults** (Optional): If this setting is given, a default value will be assumed for each URL parameter which is not present. The default values are passed in as a key => value par array
 
@@ -82,6 +82,8 @@ It is possible to extract values from the URL to allow RESTful URL design. To ex
     }
 
 The identifier used inside the route is being passed into controller method by reflecting the method parameters. So basically if you want to get the value **{id}** in your method, you need to add **$id** to your method parameters.
+
+.. _matching-suburls:
 
 Matching subURLs
 ================

--- a/developer_manual/app/users.rst
+++ b/developer_manual/app/users.rst
@@ -1,6 +1,6 @@
-==============
+===============
 User Management
-==============
+===============
 
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
 

--- a/developer_manual/bugtracker/codereviews.rst
+++ b/developer_manual/bugtracker/codereviews.rst
@@ -42,8 +42,8 @@ How will it work?
 
 Examples
 --------
-Read our `coding guidelines`_ for information on what a good pull request and
-good Nextcloud code looks like.
+Read our documentation about :doc:`../general/codingguidelines` for information
+on what a good pull request and good Nextcloud code looks like.
 
 These are two examples that are considered to be good examples of how pull
 requests should be handled
@@ -58,4 +58,3 @@ Feel free to drop a line on the `forums`_ or join us on `IRC`_.
 
 .. _forums: https://help.nextcloud.com/
 .. _IRC: http://webchat.freenode.net/?channels=nextcloud-dev
-.. _coding guidelines: ../general/codingguidelines

--- a/developer_manual/bugtracker/codereviews.rst
+++ b/developer_manual/bugtracker/codereviews.rst
@@ -36,8 +36,9 @@ How will it work?
    review.
 #. Before a pull request will be merged into master or the corresponding
    branch at least 2 reviewers need to give :+1 score.
-#. Our `continuous integration server`_ will give an additional indicator for
-   the quality of the pull request.
+#. Our continuous integration server will give an additional indicator for
+   the quality of the pull request (the results can be accessed from the GitHub
+   interface for that pull request).
 
 Examples
 --------
@@ -55,7 +56,6 @@ Questions?
 
 Feel free to drop a line on the `forums`_ or join us on `IRC`_.
 
-.. _continuous integration server: https://drone.weasel.rocks/
 .. _forums: https://help.nextcloud.com/
 .. _IRC: http://webchat.freenode.net/?channels=nextcloud-dev
 .. _coding guidelines: ../general/codingguidelines

--- a/developer_manual/bugtracker/kanban.rst
+++ b/developer_manual/bugtracker/kanban.rst
@@ -57,12 +57,11 @@ When can I pull?
   documented in a comment to the issue before moving it to the "To develop"
   step:
 
-    * At least one Scenario – written in Gherkin – that tells you and the tester
-      when the issue is ready to be released.
-
-    * A concept describing the planned implementation. This can be as simple as
-      a “this just needs changes to the login screen CSS” or so complex that you
-      link to a blog entry somewhere else.
+  * At least one Scenario – written in Gherkin – that tells you and the tester
+    when the issue is ready to be released.
+  * A concept describing the planned implementation. This can be as simple as
+    a “this just needs changes to the login screen CSS” or so complex that you
+    link to a blog entry somewhere else.
 
 Who is Assigned?
   The maintainer that feels responsible for the issue.
@@ -135,7 +134,8 @@ When can I pull?
   can be used as a checklist for what to try. Before you start move the issue to
   the “Reviewing” step by assigning the “6 – Reviewing” label.
 
-**Who is Assigned?** No one. Especially not if you are working on something else!
+Who is Assigned?
+  No one. Especially not if you are working on something else!
 
 Reviewing
 ~~~~~~~~~

--- a/developer_manual/bugtracker/kanban.rst
+++ b/developer_manual/bugtracker/kanban.rst
@@ -120,7 +120,7 @@ To Review
 Why do we have it?
   Instead of directly committing to master we agree that **a second set of eyes
   will spot bugs** and increase our code quality and give us an opportunity to
-  learn from each other. See also our `Code Review Documentation`_
+  learn from each other. See also our documentation about :doc:`codereviews`
 
 What does a developer think?
   "I’ll check the Scenario described earlier works as expected. If necessary

--- a/developer_manual/bugtracker/kanban.rst
+++ b/developer_manual/bugtracker/kanban.rst
@@ -262,6 +262,6 @@ Release.
 .. _“Given … when … then …“: https://github.com/cucumber/cucumber/wiki/Given-When-Then
 .. _unit tests: https://github.com/nextcloud/server/tree/master/tests
 .. _Code Review Documentation: codereviews
-.. _Drone: https://drone.weasel.rocks
+.. _Drone: https://github.com/drone/drone
 .. _Cucumber: http://cukes.info/
 .. _Transifex: https://www.transifex.com/nextcloud/

--- a/developer_manual/client_apis/index.rst
+++ b/developer_manual/client_apis/index.rst
@@ -6,9 +6,9 @@ Client API's
 Nextcloud provides an number of api's for client applications to talk to.
 
 
-----
+------
 WebDAV
-----
+------
 WebDAV is the main api for file related operations, it supports listing directories, downloading an uploading files, manipulating tags and favorites and more.
 
 An overview of how to use the various WebDAV api's can be found at :doc:`WebDAV/index`
@@ -30,6 +30,6 @@ Other OCS API documentations:
     :maxdepth: 2
     :hidden:
 
-    webdav/index
-    ocs/index
+    WebDAV/index
+    OCS/index
 

--- a/developer_manual/core/ocs-share-api.rst
+++ b/developer_manual/core/ocs-share-api.rst
@@ -139,6 +139,7 @@ Federated Cloud Shares
 
 Both the sending and the receiving instance need to have federated cloud sharing
 enabled and configured. See `Configuring Federated Cloud Sharing <https://docs.nextcloud.org/server/12/admin_manual/configuration_files/federated_cloud_sharing_configuration.html>`_.
+
 .. TODO ON RELEASE: Update version number above on release
 
 Create a new Federated Cloud Share

--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -8,6 +8,7 @@ Themes can relate to the following topics of Nextcloud:
 
 This documentation contains only the Web-frontend adaptations so far.
 
+.. note:: This is an advanced way of theming Nextcloud; the Nextcloud team recommends instead the use of the **Theming** app which, when enabled, can be accessed from the Admin settings.
 
 Getting started
 ===============
@@ -89,7 +90,7 @@ If you want to do a quick exchange like (1) it's important to know the size of t
 
 * Go to the place in the filesystem, that has been shown by the web developer tool/s
 * You can look up sizing in most cases via the file properties inside your file-manager
-* Create an own picture/logo with the same size then
+* Create an own picture/logo with the same size as the original photo
 
 The (main) pictures that can be found inside Nextcloud standard theming are the following:
 

--- a/developer_manual/core/translation.rst
+++ b/developer_manual/core/translation.rst
@@ -5,7 +5,8 @@ Make text translatable
 ----------------------
 
 In HTML or PHP wrap it like this ``<?php p($l->t('This is some text'));?>`` or this ``<?php print_unescaped($l->t('This is some text'));?>``.
-For the right date format use ``<?php p($l->l('date', time()));?>``. Change the way dates are shown by editing /core/l10n/l10n-[lang].php.
+For the right date format use ``<?php p($l->l('date', time()));?>``. Change the way dates are shown by editing :file:`/core/l10n/l10n-{lang}.php`.
+
 To translate text in JavaScript use: ``t('appname','text to translate');``
 
 
@@ -54,21 +55,22 @@ Automated synchronization of translations
 -----------------------------------------
 
 Multiple nightly jobs have been setup in order to synchronize translations - it's a multi-step process:
-``perl l10n.pl read`` will rescan all PHP and JavaScript files and generate the templates.
-The templates are pushed to `Transifex`_ (tx push -s).
-All translations are pulled from `Transifex`_ (tx pull -a).
-``perl l10n.pl write`` will write the PHP files containing the translations.
-Finally the changes are pushed to Git.
+
+#. ``perl l10n.pl read`` will rescan all PHP and JavaScript files and generate the templates.
+#. The templates are pushed to `Transifex`_ (tx push -s).
+#. All translations are pulled from `Transifex`_ (tx pull -a).
+#. ``perl l10n.pl write`` will write the PHP files containing the translations.
+#. Finally the changes are pushed to Git.
 
 Please follow the steps below to add translation support to your app:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a folder ``l10n``.
-Create the file ``ignorelist`` which can contain files which shall not be scanned during step 4.
-Edit ``l10n/.tx/config`` and copy/paste a config section and adapt it by changing the app/folder name.
-Run ``perl l10n.pl read`` within the folder :file:`l10n`.
-Add the newly created translation template (l10n/Templates/<appname>.pot) to Git and commit the changes above.
-After the next nightly sync job a new resource will appear on Transifex and from now on every night the latest translations will arrive.
+#. Create a folder ``l10n``.
+#. Create the file ``ignorelist`` which can contain files which shall not be scanned during step 4.
+#. Edit ``l10n/.tx/config`` and copy/paste a config section and adapt it by changing the app/folder name.
+#. Run ``perl l10n.pl read`` within the folder :file:`l10n`.
+#. Add the newly created translation template (*l10n/Templates/<appname>.pot*) to Git and commit the changes above.
+#. After the next nightly sync job a new resource will appear on Transifex and from now on every night the latest translations will arrive.
 
 Translation sync jobs:
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/developer_manual/core/translation.rst
+++ b/developer_manual/core/translation.rst
@@ -72,11 +72,6 @@ Please follow the steps below to add translation support to your app:
 #. Add the newly created translation template (*l10n/Templates/<appname>.pot*) to Git and commit the changes above.
 #. After the next nightly sync job a new resource will appear on Transifex and from now on every night the latest translations will arrive.
 
-Translation sync jobs:
-~~~~~~~~~~~~~~~~~~~~~~
-
-https://ci.owncloud.org/view/translation-sync/
-
 **Caution: information below is in general not needed!**
 
 Manual quick translation update:

--- a/developer_manual/core/translation.rst
+++ b/developer_manual/core/translation.rst
@@ -66,7 +66,7 @@ Please follow the steps below to add translation support to your app:
 Create a folder ``l10n``.
 Create the file ``ignorelist`` which can contain files which shall not be scanned during step 4.
 Edit ``l10n/.tx/config`` and copy/paste a config section and adapt it by changing the app/folder name.
-Run ``perl l10n.pl read`` with l10n.
+Run ``perl l10n.pl read`` within the folder :file:`l10n`.
 Add the newly created translation template (l10n/Templates/<appname>.pot) to Git and commit the changes above.
 After the next nightly sync job a new resource will appear on Transifex and from now on every night the latest translations will arrive.
 

--- a/developer_manual/general/codingguidelines.rst
+++ b/developer_manual/general/codingguidelines.rst
@@ -28,7 +28,7 @@ The most important labels and their meaning:
 * #design - this needs help from the design team or is a design-related issue/pull request
 * #technical debt - this issue or PR is about `technical debt <http://en.wikipedia.org/wiki/Technical_debt>`_
 * #starter issue - these are issues which are relatively easy to solve and ideal for people who want to learn how to code in Nextcloud
-* #needs info - this issue needs further information from the reporter, see `triaging <../bugtracker/triaging.html>`_
+* #needs info - this issue needs further information from the reporter, see :doc:`../bugtracker/triaging`
 * #high #medium #low signify how important the bug is.
 * Tags showing the state of the issue or PR, numbered 0-4:
  * #0 - Needs triage - ready to start development on this


### PR DESCRIPTION
Follow up for #447

@MorrisJobke
>  >  Run perl l10n.pl read with l10n; in instead of with?
>  
>  within or just write there "ping @MorrisJobke to get the automatic sync to transifex setup" ... Yes I know documentation is better ... maybe create a ticket in here so I can fix this.

Ok, I will open an issue named "_Review documentation about adding translation support for an app_" and assign it to you.

>  >  broken external link to https://ci.owncloud.org/view/translation-sync/ in core/translation.rst
>  
>  We only have an employee only version as of now, because it allows to trigger new syncs: http://transifex-sync.weasel.rocks (same here - ping @MorrisJobke to the sync up and running)

As the server to view the status of Transifex syncs is not publicly available and the section simply provided the link to view the status of Transifex updates I opted for removing it altogether.

>  >  broken external link to https://drone.weasel.rocks/ in bugtracker/kanban.rst and bugtracker/codereviews.rst; I do not know how to replace it, as https://drone.nextcloud.com/ does not offer any value to a regular user (it is just a login screen), and https://drone.nextcloud.com/nextcloud/server/ applies only to the server, but not to the other projects.
>  
>  Yes ... maybe add the server link for now. Usually this all doesn't add value except you are looking at the PR and there you get the link to the drone job.

Instead of linking the login page of the Drone server in one case I replaced the link with a link to the GitHub repository of the Drone project, and in the other I replaced it with an explanation about checking the results in the GitHub interface for the pull request.

>  >  broken internal links in bugtracker/codereviews.rst and bugtracker/kanban.rst
>  
>  o.O They should be somewhere ... maybe they have been moved.

Sorry, I did not express myself clearly. I meant that the links were broken because they were links to other documents in the developer manual, but they were using the markup of external links. I replaced it with document reference markup.

>  >  missing internal links in core/theming.rst: as described under 1.3. by adding, to do a quick exchange like (1) it's important and as described in 1. you can
>  
>  I would say we should move the whole theming to the admin manual and describe the theming app. Maybe there is already a page available. This old theming is so error prone.

I left it as is.

>  >  in app/tutorial.rst, is there any reason to use $AppName and $UserId in UpperCamelCase instead of lowerCamelCase?
>  
>  I think to use the proper dependency injection object, but I'm not 100% sure. needs to be tested. But both should work: https://github.com/nextcloud/server/blob/8149945a916447b4e7dae8182dbf0c354e7d19e8/lib/private/AppFramework/DependencyInjection/DIContainer.php#L92-L94

I left it as is.

>  >  Finally, should the manual use UK or US spelling (e.g., colour or color)? And, are contractions fine or should they be expanded (e.g., "you're" or "you are")?
>  
>  Ummm ... @jospoortvliet ?

I left it as is.
