### PR TITLE
Add notice about HSTS preload option

### DIFF
--- a/admin_manual/configuration_server/harden_server.rst
+++ b/admin_manual/configuration_server/harden_server.rst
@@ -119,11 +119,22 @@ VirtualHost file::
  <VirtualHost *:443>
    ServerName cloud.nextcloud.com
      <IfModule mod_headers.c>
-       Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains; preload"
+       Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"
      </IfModule>
   </VirtualHost>
-  
-This example configuration will make all subdomains only accessible via HTTPS. If you have subdomains not accessible via HTTPS, remove ``includeSubdomains;``. 
+
+.. warning::
+   We recommend the additional setting ``; preload`` to be added to that header.
+   Then the domain will be added to an hardcoded list that is shipped with all
+   major browsers and enforce HTTPS upon those domains. See the `HSTS preload
+   website for more information <https://hstspreload.org/>`_. Due to the policy
+   of this list you need to add it to the above example for yourself once you
+   are sure that this is what you want. `Removing the domain from this list
+   <https://hstspreload.org/#removal>`_ could take some months until it reaches
+   all installed browsers.
+
+This example configuration will make all subdomains only accessible via HTTPS.
+If you have subdomains not accessible via HTTPS, remove ``includeSubdomains;``.
 
 This requires the ``mod_headers`` extension in Apache.
 

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -58,6 +58,12 @@ webroot of your nginx installation. In this example it is
       # topic first.
       # add_header Strict-Transport-Security "max-age=15768000; 
       # includeSubDomains; preload;";
+      #
+      # WARNING: Only add the preload option once you read about
+      # the consequences in https://hstspreload.org/. This option
+      # will add the domain to a hardcoded list that is shipped
+      # in all major browsers and getting removed from this list
+      # could take several months.
       add_header X-Content-Type-Options nosniff;
       add_header X-XSS-Protection "1; mode=block";
       add_header X-Robots-Tag none;
@@ -143,6 +149,12 @@ webroot of your nginx installation. In this example it is
           # this topic first.
           # add_header Strict-Transport-Security "max-age=15768000; 
           #  includeSubDomains; preload;";
+          #
+          # WARNING: Only add the preload option once you read about
+          # the consequences in https://hstspreload.org/. This option
+          # will add the domain to a hardcoded list that is shipped
+          # in all major browsers and getting removed from this list
+          # could take several months.
           add_header X-Content-Type-Options nosniff;
           add_header X-XSS-Protection "1; mode=block";
           add_header X-Robots-Tag none;


### PR DESCRIPTION
* fixes https://github.com/nextcloud/server/issues/4779

cc @jospoortvliet for the wording

@lgarron Is the content okay for you? I will backport this to all older manuals once this is approved and reviewed. I also added a similar warning to the Nginx config.

It then looks like this in the manual:

<img width="868" alt="bildschirmfoto 2017-05-14 um 23 06 04" src="https://cloud.githubusercontent.com/assets/245432/26042329/07b8deae-38fa-11e7-89a5-110e68fef24f.png">
