### PR TITLE
Header link tweak

### DIFF
--- a/_shared_assets/themes/nextcloud_com/static/styles.css
+++ b/_shared_assets/themes/nextcloud_com/static/styles.css
@@ -1080,6 +1080,8 @@ h4:hover a.headerlink {
 }
 a.headerlink {
     display: none;
+    padding-left: 5px;
+    text-decoration: none;
 }
 
 #menu-support {


### PR DESCRIPTION
I feel like the header link is too close to the heading which doesn't look particularly pleasing on the eye. So this is a very small tweak to add a bit of space and remove the underline (again because it doesn't look pretty).