### PR TITLE
Add ownCloud migration paths to the docs

### DIFF
--- a/admin_manual/maintenance/index.rst
+++ b/admin_manual/maintenance/index.rst
@@ -12,3 +12,4 @@ Maintenance
    manual_upgrade
    package_upgrade
    migrating
+   migrating_owncloud

--- a/admin_manual/maintenance/migrating_owncloud.rst
+++ b/admin_manual/maintenance/migrating_owncloud.rst
@@ -1,0 +1,33 @@
+=======================
+Migrating from ownCloud
+=======================
+
+
+.. note:: Especially when migrating from ownCloud to Nextcloud you should
+          create a backup of the config, database and the data directory,
+          in case something goes wrong.
+
+Currently migrating from ownCloud is like performing a manual update.
+So it is quite easy, to migrate from one ownCloud version to at least one Nextcloud version.
+However this does only work with versions that are close enough database and code-wise.
+See the table below for a version map, where migrating is easily possible:
+
++-----------------+-----------------+
+| ownCloud        | Nextcloud       |
++=================+=================+
+| 10.0.1 or later | 12.0.1 or later |
++-----------------+-----------------+
+| 10.0.0          | 12.0.0          |
++-----------------+-----------------+
+| 9.1.x           | 10.0.x          |
++-----------------+-----------------+
+| 9.0.x           | 10.0.x          |
++-----------------+-----------------+
+| 9.0.x           | 9.0.x           |
++-----------------+-----------------+
+
+After downloading the correct version of Nextcloud from our
+`older releases page <https://nextcloud.com/changelog/>`_,
+proceed like described in the :doc:`manual_upgrade` manual.
+
+Afterwards you can use the Nextcloud updater to update your instance to the newest version.


### PR DESCRIPTION
Since the question arises quite often, lets add it to the docs.

@MorrisJobke @jospoortvliet 

> ![migrating_from_owncloud_ _nextcloud_12_server_administration_manual_12_documentation_-_2017-06-18_16 25 28](https://user-images.githubusercontent.com/213943/27261432-1e5a7208-5443-11e7-848f-f71fe1050ec5.png)
