### PR TITLE
change value of innodb_large_prefix to 1

### DIFF
--- a/admin_manual/configuration_database/mysql_4byte_support.rst
+++ b/admin_manual/configuration_database/mysql_4byte_support.rst
@@ -9,7 +9,7 @@ installation needs to be tweaked a bit.
 2. Make sure the following InnoDB settings are set on your MySQL server::
 
     [mysqld]
-    innodb_large_prefix=on
+    innodb_large_prefix=1
     innodb_file_format=barracuda
     innodb_file_per_table=1
 


### PR DESCRIPTION
Older versions of mysql may not accept `on` as a value and configuration may fail. `1` is sure to work as boolean value. 
See issue [#4846](https://github.com/nextcloud/server/issues/4846) of nextcloud server.