### PR TITLE
fix typo in markup to repair code block

### DIFF
--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -114,13 +114,13 @@ Changing the default colours
 
 You can inject custom variables into the SCSS generator to apply colors to the default css code by adding the following method to defaults.php:
 
-.. code-clock:: php
+.. code-block:: php
 
-   	public function getScssVariables() {
-		return [
-			'color-primary' => '#745bca'
-		];
-	}
+    public function getScssVariables() {
+        return [
+            'color-primary' => '#745bca'
+        ];
+    }
 
 
 The following variables can be overwritten:


### PR DESCRIPTION
The code block was invisible through a typo (code-clock) on the official website:
https://docs.nextcloud.com/server/12/developer_manual/core/theming.html#changing-the-default-colours

I also changed the indentation to 4 spaces.