### PR TITLE
Switch to OCSv2

### DIFF
--- a/developer_manual/core/ocs-share-api.rst
+++ b/developer_manual/core/ocs-share-api.rst
@@ -5,7 +5,7 @@ OCS Share API
 The OCS Share API allows you to access the sharing API from outside over
 pre-defined OCS calls.
 
-The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v1.php/apps/files_sharing/api/v1*
+The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v2.php/apps/files_sharing/api/v1*
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 


### PR DESCRIPTION
All Nextcloud versions support OCSv2 so our documentation should recommend to use this API which result in a more restful behaviour.

cc @rullzer