### PR TITLE
Config file is located in `config/config.php`, not `core/config/config.php`

### DIFF
--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -83,7 +83,7 @@ Enabling debug mode
 
 .. note:: Do not enable this for production! This can create security problems and is only meant for debugging and development!
 
-To disable JavaScript and CSS caching debugging has to be enabled by setting ``debug`` to ``true`` in :file:`core/config/config.php`::
+To disable JavaScript and CSS caching debugging has to be enabled by setting ``debug`` to ``true`` in :file:`config/config.php`::
 
   <?php
   $CONFIG = array (


### PR DESCRIPTION
Hello,

I was following the guide and noticed that config file is located in `config/config.php` not `core/config/config.php`.

Isaac


