### PR TITLE
Fix dead link in bugtracker

### DIFF
--- a/developer_manual/bugtracker/index.rst
+++ b/developer_manual/bugtracker/index.rst
@@ -21,6 +21,6 @@ Thank you for helping Nextcloud by reporting bugs. Before submitting an issue, p
 
 
 .. _Issue submission guidelines: https://github.com/nextcloud/server/blob/master/CONTRIBUTING.md#submitting-issues
-.. _Server repository:  https://github.com/nextcloud/server/issues
-.. _Client repository: https://github.com/nextcloud/client/issues
+.. _Server repository: https://github.com/nextcloud/server/issues
+.. _Client repository: https://github.com/nextcloud/client_theming/issues
 .. _main GitHub organization: https://github.com/nextcloud


### PR DESCRIPTION
Fixes: #532 

Fix dead link to client repo in developer_manual/bugtracker/index.rst 