### PR TITLE
Updated caching_configuration.rst

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -46,7 +46,7 @@ PHP 5.5 and up include the Zend OPcache in core, and on most Linux
 distributions it is enabled by default. However, it does 
 not bundle a data cache. APCu is a data cache, and it is available in most 
 Linux distributions. On Red Hat/CentOS/Fedora systems install
-``php-pecl-apcu``. On Debian/Ubuntu/Mint systems install ``php5-apcu`` or ``php7.0-apcu``.
+``php-pecl-apcu``. On Debian/Ubuntu/Mint systems install ``php-apcu``.
 On Ubuntu 14.04 LTS, the APCu version (4.0.2) is too old to use with Nextcloud (requires 4.0.6+).
 You may install 4.0.7 from Ubuntu backports with this command::
 


### PR DESCRIPTION
Signed-off-by: NickTh <nick-athens30@ubuntu.com>

Same as previous #541. The package name has changed, in Ubuntu 16.04 (Xenial), to `php-apcu`.
https://packages.ubuntu.com/xenial/php/php-apcu
It is a dual build package for both PHP 5.6 and 7.0.