### PR TITLE
Typo fixed

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -304,7 +304,7 @@ the command from, use::
 
   psql -Uusername -dnextcloud
 
-To access a MySQL installation on a different machine, add the -h option with
+To access a PostgreSQL installation on a different machine, add the -h option with
 the respective host name::
 
   psql -Uusername -dnextcloud -h HOSTNAME


### PR DESCRIPTION
Mysql swapped out for postgresql in the line above a postgresql remote connection command.