### PR TITLE
fix bash chown problem

### DIFF
--- a/admin_manual/configuration_files/external_storage/local.rst
+++ b/admin_manual/configuration_files/external_storage/local.rst
@@ -12,9 +12,15 @@ of your Nextcloud ``data/`` directory. This directory must be readable and
 writable by your HTTP server user. These ownership and permission examples 
 are on Ubuntu Linux::
 
- sudo -u www-data chown -R www-data:www-data /localdir
- sudo -u www-data chmod -R 0750 /localdir
- 
+ sudo chown -R www-data:www-data /path/to/localdir
+ sudo chmod -R 0750 /path/to/localdir
+
+Important: If you use consecutive commands, make sure, you are user ``www-data``::
+
+ sudo -u www-data bash
+ cd /path/to/localdir
+ mkdir data
+
 In the **Folder name** field enter the folder name that you want to appear on 
 your Nextcloud Files page.
 


### PR DESCRIPTION
PR as suggested by @MorrisJobke [see the commit](https://github.com/nextcloud/documentation/commit/18e351083d89b50b2e140e2aadba7803e7790d20#commitcomment-24078010)

How I found the problem: 

 - I did want to connect a local drive to a raspberry pi [using this distribution](https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/): 

I did use the commands as described here: 

 - [docs for version 9](https://docs.nextcloud.com/server/9/admin_manual/configuration_files
/external_storage/local.html)
 - It didn't work!

I did search the community and found:

 - [You don’t have permission to upload or create files here](https://help.nextcloud.com/t/you-don-t-have-permission-to-upload-or-create-files-here/3303) ... Which proposes to use ``777` on the mounted directories :/
 - which imo is a problem 


