### PR TITLE
Add basic redis configuration example

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -155,6 +155,17 @@ recommended if Redis is running on the same system as Nextcloud) use this exampl
 
 Only "host" and "port" variables are required, the other ones are optional.
 
+For the Redis side, you may need to add your web server user to the redis group::
+
+  usermod -a -G redis www-data
+
+If you were to use the Unix socket example right above, you'd edit and set the following lines in ``/etc/redis/redis.conf``::
+
+  port 0
+  unixsocket /var/run/redis/redis.sock
+  unixsocketperm 770
+  requirepass secret
+
 Redis is very configurable; consult `the Redis documentation 
 <http://redis.io/documentation>`_ to learn more.
 


### PR DESCRIPTION
This is enough to get Redis up and running.

Currently there is no information about actually setting up redis in a way that works on my setup, this fixes it.

Tested on Ubuntu 16.04 LTS with ondrej/php and chris-lea/redis-server PPAs.