### PR TITLE
Remove option -A from rsync

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -33,7 +33,7 @@ Backup folders
 Simply copy your config, data and theme folders (or even your whole Nextcloud install and data folder) to a place outside of
 your Nextcloud environment. You could use this command::
 
-    rsync -Aax nextcloud/ nextcloud-dirbkp_`date +"%Y%m%d"`/
+    rsync -avx nextcloud/ nextcloud-dirbkp_`date +"%Y%m%d"`/
 
 Backup database
 ---------------


### PR DESCRIPTION
Fixes https://github.com/nextcloud/documentation/issues/606

On top of the suggestions from @dartmann, I added the verbose option `-v` because I think it is useful to know if there are problems and that it does not fail silently.