### PR TITLE
Add example for inserting csrf-token inside a form

### DIFF
--- a/developer_manual/general/security.rst
+++ b/developer_manual/general/security.rst
@@ -229,6 +229,15 @@ To prevent CSRF in an app, be sure to call the following method at the top of al
 
 If you are using the App Framework, every controller method is automatically checked for CSRF unless you explicitly exclude it by setting the @NoCSRFRequired annotation before the controller method, see :doc:`../app/controllers`
 
+When using forms in your app or theme, you need to supply a csrf-token to be checked when submitting the form. Insert a token like this:
+
+.. code-block:: php
+  
+  <form action="/index.php/apps/myapp" method="post">
+    <input type="hidden" name="requesttoken" value="<?php echo $_['requesttoken']; ?>" />
+  </form>
+  
+
 Unvalidated redirects
 ---------------------
 

--- a/developer_manual/general/security.rst
+++ b/developer_manual/general/security.rst
@@ -233,8 +233,13 @@ When using forms in your app or theme, you need to supply a csrf-token to be che
 
 .. code-block:: php
   
-  <form action="/index.php/apps/myapp" method="post">
-    <input type="hidden" name="requesttoken" value="<?php echo $_['requesttoken']; ?>" />
+  <?php $urlGenerator = \OC::$server->getURLGenerator(); ?>
+  <form action="<?php echo $urlGenerator->linkToRoute('appname.page.pagename'); ?>" method="post">
+    <label>Item name<br />
+      <input type="text" name="name" placeholder="My item" />
+    </label>
+    <input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']); ?>" />
+    <button type="submit" class="btn primary">Add</button>
   </form>
   
 

--- a/developer_manual/general/security.rst
+++ b/developer_manual/general/security.rst
@@ -233,6 +233,18 @@ When using forms in your app or theme, you need to supply a csrf-token to be che
 
 .. code-block:: php
   
+  // in itemController.php
+  ...
+  function renderItemTemplate() {
+    ...
+    return new TemplateResponse('appname', 'itemTemplate', array(
+      'items' => ...,
+      'requesttoken' => (\OC::$server->getSession()) ? \OCP\Util::callRegister() : ''
+    ));
+  }
+  ...
+
+  // in itemTemplate.php
   <?php $urlGenerator = \OC::$server->getURLGenerator(); ?>
   <form action="<?php p($urlGenerator->linkToRoute('appname.page.pagename')); ?>" method="post">
     <label>Item name<br />
@@ -241,7 +253,9 @@ When using forms in your app or theme, you need to supply a csrf-token to be che
     <input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']); ?>" />
     <button type="submit" class="btn primary">Add</button>
   </form>
-  
+
+
+Note that the template variable *requesttoken* is prefilled for every template, though this is nothing you can rely on to exist in the future. Also note that a request token will expire after a while. If you want users to be able to submit an already loaded form after a very long time, consider fetching a new requesttoken via AJAX every once in a while.
 
 Unvalidated redirects
 ---------------------

--- a/developer_manual/general/security.rst
+++ b/developer_manual/general/security.rst
@@ -234,7 +234,7 @@ When using forms in your app or theme, you need to supply a csrf-token to be che
 .. code-block:: php
   
   <?php $urlGenerator = \OC::$server->getURLGenerator(); ?>
-  <form action="<?php echo $urlGenerator->linkToRoute('appname.page.pagename'); ?>" method="post">
+  <form action="<?php p($urlGenerator->linkToRoute('appname.page.pagename')); ?>" method="post">
     <label>Item name<br />
       <input type="text" name="name" placeholder="My item" />
     </label>

--- a/developer_manual/general/security.rst
+++ b/developer_manual/general/security.rst
@@ -233,24 +233,12 @@ When using forms in your app or theme, you need to supply a csrf-token to be che
 
 .. code-block:: php
   
-  // in itemController.php
-  ...
-  function renderItemTemplate() {
-    ...
-    return new TemplateResponse('appname', 'itemTemplate', array(
-      'items' => ...,
-      'requesttoken' => (\OC::$server->getSession()) ? \OCP\Util::callRegister() : ''
-    ));
-  }
-  ...
-
   // in itemTemplate.php
   <?php $urlGenerator = \OC::$server->getURLGenerator(); ?>
+  <?php $CSRFToken = \OCP\Util::callRegister(); ?>
   <form action="<?php p($urlGenerator->linkToRoute('appname.page.pagename')); ?>" method="post">
-    <label>Item name<br />
-      <input type="text" name="name" placeholder="My item" />
-    </label>
-    <input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']); ?>" />
+    ...
+    <input type="hidden" name="requesttoken" value="<?php p($CSRFToken); ?>" />
     <button type="submit" class="btn primary">Add</button>
   </form>
 


### PR DESCRIPTION
While reading up on CSRF and implementing it into my nextcloud app, I couldn't find how to add a CSRF-token to a form. So, I added this example. Not sure, if this is the best place, but I would look for it there.