### PR TITLE
Fix issue with PHP 7.1 dependency in dev manual

### DIFF
--- a/build/composer.json
+++ b/build/composer.json
@@ -1,6 +1,13 @@
 {
     "minimum-stability": "dev",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/juliushaertl/reflection.git"
+        }
+    ],
     "require": {
-        "juliushaertl/phpdoc-to-rst": "dev-php7.0"
+        "juliushaertl/phpdoc-to-rst": "dev-php7.0",
+        "phpdocumentor/reflection": "dev-php7.0"
     }
 }

--- a/build/composer.json
+++ b/build/composer.json
@@ -1,6 +1,6 @@
 {
     "minimum-stability": "dev",
     "require": {
-        "juliushaertl/phpdoc-to-rst": "dev-master"
+        "juliushaertl/phpdoc-to-rst": "dev-php7.0"
     }
 }


### PR DESCRIPTION
Currently our doc host and the drone server run PHP 7.0. I would also like to keep it like that for now. The only way I found is to actively patch the dependency to not say, that it need PHP 7.1 because it is a dependency to a git branch and not properly versioned. Also pinning a sha sum didn't worked out.

@juliushaertl Any other ideas how to fix this? With this branch it properly builds on our server: https://docs.nextcloud.com/server/13/developer_manual/ 