### PR TITLE
add occ commands to upgrade documentation

### DIFF
--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -91,3 +91,22 @@ Change ``"maintenance" => false`` to ``"maintenance" => true``:
     "maintenance" => true,
 
 Then change it back to ``false`` when you are finished.
+
+Manual steps during upgrade
+---------------------------
+
+Some opertation can be quite time consuming. Therefore we decided not to add them
+the the normal upgrade process. We recommend to run them manually after the upgrade
+was completed. Below you find a list of this commands.
+
+Upgrading to Nextcloud 13
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With Nextcloud 13 we added a new index to the share table which should result in
+significant performance improvements:
+
+ $ sudo -u www-data php occ db:add-missing-indice
+
+With Nextcloud 13 we switched to bigint for the file ID's in the file cache table
+
+ $ sudo -u www-data php occ db:convert-filecache-bigint 

--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -39,7 +39,7 @@ Update notifications
 --------------------
 
 Nextcloud has an update notification app, that informs the administrator about
-the availablilty of an update. Then you decide which update method to use.
+the availability of an update. Then you decide which update method to use.
 
 .. figure:: images/2-updates.png
    :alt: Both update notifications displayed on Admin page.
@@ -95,7 +95,7 @@ Then change it back to ``false`` when you are finished.
 Manual steps during upgrade
 ---------------------------
 
-Some opertation can be quite time consuming. Therefore we decided not to add them
+Some operation can be quite time consuming. Therefore we decided not to add them
 the the normal upgrade process. We recommend to run them manually after the upgrade
 was completed. Below you find a list of this commands.
 


### PR DESCRIPTION
We should document somehow that people should maually update the fileache table and the share index after upgrading to Nextcloud 13. Therefore I added this section to the upgrade documentation.

@MorrisJobke @rullzer @jospoortvliet please review