### PR TITLE
Update install instructions for PHP7 on Ubuntu.

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -423,14 +423,15 @@ variables in the appropropriate ``php-fpm`` ini/config file.
 
 Here are some example root paths for these ini/config files:
 
-+--------------------+-----------------------+
-| Ubuntu/Mint        | CentOS/Red Hat/Fedora |
-+--------------------+-----------------------+
-| ``/etc/php5/fpm/`` | ``/etc/php-fpm.d/``   |
-+--------------------+-----------------------+
++-----------------------+-----------------------+
+| Ubuntu/Mint           | CentOS/Red Hat/Fedora |
++-----------------------+-----------------------+
+| ``/etc/php5/fpm/`` or | ``/etc/php-fpm.d/``   |
+| ``/etc/php/7.0/fpm/`` |                       |
++-----------------------+-----------------------+
 
 In both examples, the ini/config file is called ``www.conf``, and depending on
-the distro version or customizations you have made, it may be in a subdirectory.
+the distro version or customizations you have made, it may be in a subdirectory such as ``pool.d``.
 
 Usually, you will find some or all of the environment variables
 already in the file, but commented out like this::


### PR DESCRIPTION
Some instructions are PHP5 specific, while someone doing a new install is probably using PHP7. I updated some sections to reflect PHP7.