### PR TITLE
fix: change 'sqlite' to 'sqlite3'

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -92,17 +92,17 @@ during installation and update, so you shouldn't need to change it.
 
 ::
 
-	'dbtype' => 'sqlite',
+	'dbtype' => 'sqlite3',
 
 Identifies the database used with this installation. See also config option
 ``supportedDatabases``
 
 Available:
-	- sqlite (SQLite3)
+	- sqlite3 (SQLite3)
 	- mysql (MySQL/MariaDB)
 	- pgsql (PostgreSQL)
 
-Defaults to ``sqlite``
+Defaults to ``sqlite3``
 
 ::
 


### PR DESCRIPTION
On a fresh Nextcloud 13 Installation the default value for dbtype in config.php is 'sqlite3' (and not 'sqlite'). I also noticed that on previous versions.
Despite the fact that Nextcloud 13 also works though, if that value is manually changed to 'sqlite', I would suggest to change that in the documentation to the actually used value created when installing Nextcloud - and that is 'sqlite3'.