### PR TITLE
Fix latexpdf generation for developer_manual (also fixes automatic builds)

### DIFF
--- a/developer_manual/conf.py
+++ b/developer_manual/conf.py
@@ -183,7 +183,7 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-'preamble': '\extrafloats{100}\maxdeadcycles=500',
+'preamble': '\extrafloats{100}\maxdeadcycles=500\DeclareUnicodeCharacter{274C}{\sffamily X}',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
PDF creation of developer_manual via 'latexpdf' target fails because 
'client_apis/WebDAV/search.rst' uses a unicode character 
(U+274C CROSS MARK) which pdflatex does not recognize. 

Added character definition to preamble in conf.py makes pdflatex replace
it with a plain "X" which is a good enough replacement.