### PR TITLE
external SMB storage: fix and emphasize ``domain\username``

### DIFF
--- a/admin_manual/configuration_files/external_storage/smb.rst
+++ b/admin_manual/configuration_files/external_storage/smb.rst
@@ -16,7 +16,7 @@ You need the following information:
 
 *    Folder name for your local mountpoint.
 *    Host: The URL of the Samba server.
-*    Username: The username or domain/username used to login to the Samba 
+*    Username: The username or ``domain\username`` (see below) used to login to the Samba 
      server.
 *    Password: the password to login to the Samba server.
 *    Share: The share on the Samba server to mount.


### PR DESCRIPTION
**What did I change**
This PR is fairly small. On the _external SMB storage_ page I think "domain/username" should actually be written with a backslash, and with monospace font. I also added a reference (”see below“).

**Why I made this change**
After I've been adding the SMB storage (as the admin), I had to enter username and password (as a user). Using my bare SMB username (e.g. `my_smb_username`) simply failed. I've been debugging the SMB connection on the CLI until I carefully read the docs page—and finally using `WORKGROUP\my_smb_username` worked.

BTW thank you a lot for this great piece of software + documentation! :+1: 