### PR TITLE
CalDAV sync with macOS

### DIFF
--- a/user_manual/pim/sync_osx.rst
+++ b/user_manual/pim/sync_osx.rst
@@ -1,51 +1,17 @@
-=======================
-Synchronizing with OS X
-=======================
+========================
+Synchronizing with macOS
+========================
 
-To use Nextcloud with iCal you will need to use the following URL::
+With Nextcloud 13 and its CalDAV-backend, syncing your Calendars with your macOS-device is easy.
 
-    https://example.com/remote.php/dav/principals/users/USERNAME/
+To use Nextcloud with macOS Calendar you will need to use the following steps:
 
-The setup is basically the same as with iOS using the path ``https://example.com/remote.php/dav/principals/users/USERNAME/``
-to sync with Nextcloud. For OS X 10.7 Lion and 10.8 Mountain Lion everything works
-fine, but OS X 10.6 (Snow Leopard) and older needs some fiddling to work. A user
-contributed the following:
+1. Open the Calendar-app in your Nextcloud (https://cloud.example.com/apps/calendar)
+2. Navigate into the app-settings (lower left corner) and copy the iOS/macOS CalDAV adress provided there
+3. Open the system prefrenences of your macOS-device
+4. Navigate to "Online-Accounts"
+5. Click on "Add another account..." and click on "CalDAV-Account"
+6. Select "Manually" as Account-Type and type in your username or email-adress of your Nextcloud-instance as username, and your app-passoword/token or password as password.
+7. Paste the previous copied (step 2) iOS/macOS CalDAV adress into the server adress field and click on "Login".
 
-#. Make sure, "Addressbook" is not running. If it is, select the windows and press
-Command + Q to terminate it.
-#. Navigate to **/Users/YOUR\_USERNAME/Library/Application Support/AddressBook/Sources**.
-If you already have some kind of addressbook set up, it is likely you will see
-some folders named like this **BEA92826-FBF3-4E53-B5C6-ED7C2B454430**.
-Note down what folders there are now and leave the window open.
-#. Open "Addressbook" and try to add a new CardDav addressbook. At this point, it
-does not matter what information you enter. It will come up with the same error
-message you mentioned before when you click "Create". Ignore it and click "Create"
-again. A non-functional addressbook will be added.
-#. Close "Addressbook" again using Command + Q
-#. Go back to the folder window from step 2. You will now see a newly created folder
-with another long string as its name.
-#. Navigate to the newly created folder and edit the **Configuration.plist** with
-your favorite text editor.
-#. Search for a section looking like this::
-
-    <key>servername</key> <string>https://:0(null)</string> <key>username</key> <string>Whatever_you_entered_before</string>
-
-8. Make it look like this. Please note that the :443 after **example.com** is important::
-
-    <key>servername</key <string>https://example.com:443/nextcloud/remote.php/dav/principals/users/USERNAME</string> <key>username</key <string>username</string>
-
-9. Save the file and open addressbook again. It will not work yet.
-
-10. Open the preferences for your Nextcloud CardDAV-Account and enter your password.
-
-11. You may have to restart addressbook once more. After this, it should work.
-
-If it's still not working, have a look at the :doc:`troubleshooting` and
-`Troubleshooting Contacts & Calendar`_ guides.
-
-There is also an easy `HOWTO`_ in the forum.
-
-
-.. _HOWTO: https://forum.owncloud.org/viewtopic.php?f=3&t=132
-.. _Troubleshooting Contacts & Calendar: https://docs.nextcloud.org/server/12/admin_manual/issues/index.html#troubleshooting-contacts-calendar
-.. TODO ON RELEASE: Update version number above on release
+You can now select, with which applications you want to use this CalDAV resource. In the most cases, this will be "Calendar", sometimes you may also want to use it for your Tasks and reminders.


### PR DESCRIPTION
The old docs were not longer working at all and this. The workaround for Snow Leopard and older was removed because it is probably not longer working at all and Snow Leopard and older are not longer supported ... This should work for the most cases :)

@MorrisJobke @georgehrke @raghunayyar 