### PR TITLE
Fix nginx pattern which split path to script

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -122,7 +122,7 @@ webroot of your nginx installation. In this example it is
       }
 
       location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+)\.php(?:$|/) {
-          fastcgi_split_path_info ^(.+\.php)(/.*)$;
+          fastcgi_split_path_info ^(.+?\.php)(/.*)$;
           include fastcgi_params;
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_param PATH_INFO $fastcgi_path_info;
@@ -266,7 +266,7 @@ your nginx installation.
           }
 
           location ~ ^/nextcloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+)\.php(?:$|/) {
-              fastcgi_split_path_info ^(.+\.php)(/.*)$;
+              fastcgi_split_path_info ^(.+?\.php)(/.*)$;
               include fastcgi_params;
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               fastcgi_param PATH_INFO $fastcgi_path_info;


### PR DESCRIPTION
Fixes error of parsing path of script, if user uses folders with php script-like names.

```
[error] *****#*****: *<pid> upstream sent invalid status "0" while reading response header from upstream, client: IP, server: cloud.example.com, request: "PUT /remote.php/webdav/vendor/test.php/tst.txt HTTP/2.0", upstream: "fastcgi://...", host: "cloud.example.com"
```

How reproduce error:
1. Auth on your nextcloud instance.
2. Create folder with `.php` at end of name.
3. Try to create file inside that folder.

