### PR TITLE
Remove TODO from two_factor-auth.rst

### DIFF
--- a/admin_manual/configuration_user/two_factor-auth.rst
+++ b/admin_manual/configuration_user/two_factor-auth.rst
@@ -8,6 +8,7 @@ Several 2FA apps are already available including
 `TOTP <https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm>`_, 
 SMS 2-factor and `U2F <https://en.wikipedia.org/wiki/Universal_2nd_Factor>`_. 
 Developers can `built new two-factor provider apps <https://docs.nextcloud.com/server/12/developer_manual/app/two-factor-provider.html>`_.
+
 .. TODO ON RELEASE: Update version number above on release
 
 Enabling two factor authentication
@@ -21,4 +22,5 @@ you want, 2FA will be installed and enabled on your Nextcloud server.
 .. figure:: ../images/2fa-app-install.png
 
 Once 2FA has been enabled, users have to `activate it in their personal settings. <https://docs.nextcloud.com/server/12/user_manual/user_2fa.html>`_
+
 .. TODO ON RELEASE: Update version number above on release


### PR DESCRIPTION
It doesn't look like that TODO was intended to go live

I found it here:
https://docs.nextcloud.com/server/11/admin_manual/configuration_user/two_factor-auth.html