### PR TITLE
Removed '=' from php_value statements

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -37,8 +37,8 @@ Set the following two parameters inside the corresponding php.ini file (see the
 **Loaded Configuration File** section of :ref:`label-phpinfo` to find your 
 relevant php.ini files) ::
 
- php_value upload_max_filesize = 16G
- php_value post_max_size = 16G
+ php_value upload_max_filesize 16G
+ php_value post_max_size 16G
 
 Adjust these values for your needs. If you see PHP timeouts in your logfiles, 
 increase the timeout values, which are in seconds::


### PR DESCRIPTION
There were equal signs in the php_value statement in this section of the big_file_upload_configuration page.
According to the php.net manual, php_value statements must be without equal signs. Simply copying the statements provided in the documentation to a .htaccess or to an Apache config file will lead to a server error.
