### PR TITLE
Update index.html - add links to current pdf manuals.

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,6 @@
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/13/admin_manual/">Administration Manual</a>
 									(<a class="reference external" href="https://docs.nextcloud.com/server/13/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/13/developer_manual/">Developer Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/13/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
 								</ul>
 							</div>
 
@@ -246,7 +245,6 @@
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/12/admin_manual/">Administration Manual</a>
 									(<a class="reference external" href="https://docs.nextcloud.com/server/12/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/12/developer_manual/">Developer Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/12/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
 								</ul>
 							</div>
 


### PR DESCRIPTION
I couldn't find these links anywhere on the site, but the files are generated and available (I deduced the links from the patterns in the historical manual links).