### PR TITLE
Enabling Caching

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -235,3 +235,12 @@ On CentOS and Fedora, the ``yum`` command shows available and installed version
 information::
 
  yum search php-pecl-redis
+
+Enable Caching
+^^^^^^^^^^^^^^
+
+Depending on your configuration and PHP version, you should add 
+`apc.enable_cli=1
+in your `/etc/php/7.2/cli/php.ini` or in your `/etc/php/7.2/mods-available/apcu.ini`
+
+In addition, OPcache should be configured in `/etc/php/7.2/fpm/php.ini` or in `/etc/php/7.2/apache2/php.ini` according to your setup and the `Nexcloud instructions <https://docs.nextcloud.com/server/13/admin_manual/configuration_server/server_tuning.html?highlight=opcache#enable-php-opcache>`_.


### PR DESCRIPTION
@nickvergessen As I'm just copy-pasting that from other blogs/websites, and I don't understand all what I'm doing. I need your support for this documentation change.

Where should we put `apc.enable_cli=1` ?
- `/etc/php/7.2/cli/php.ini` as I see in @riegercloud (https://www.c-rieger.de/nextcloud-installation-guide-debian-stretch/) ?
- `/etc/php/7.2/mods-available/apcu.ini` ?
- Or in both?

In addition, I understand opcache should be configured correctly (https://docs.nextcloud.com/server/13/admin_manual/configuration_server/server_tuning.html?highlight=opcache#enable-php-opcache), where should it be configured?
- `/etc/php/7.2/fpm/php.ini` ?
- `/etc/php/7.2/apache2/php.ini` ?
- Or should it be in both?

Last question: I see in https://www.c-rieger.de/nextcloud-installation-guide-debian-stretch/#c03 that a lot more parameters are added about `apc`: are they optional, or should I include them in the documentation?

Thanks @nickvergessen 

Reference: started in https://github.com/nextcloud/docker/issues/336#event-1777314908