### PR TITLE
Fix certificate key length in dev manual

### DIFF
--- a/developer_manual/app/code_signing.rst
+++ b/developer_manual/app/code_signing.rst
@@ -116,7 +116,7 @@ Ensure that you keep all generated files to sign your application. The following
 examples will assume that you are trying to sign an application named
 "contacts".
 
-1. Generate a private key and CSR: ``openssl req -nodes -newkey rsa:2048 -keyout contacts.key -out contacts.csr -subj "/CN=contacts"``. Replace "contacts" with your application identifier.
+1. Generate a private key and CSR: ``openssl req -nodes -newkey rsa:4096 -keyout contacts.key -out contacts.csr -subj "/CN=contacts"``. Replace "contacts" with your application identifier.
 2. Post the CSR at https://github.com/nextcloud/app-certificate-requests, and configure
    your GitHub account to show your mail address in your profile. Nextcloud
    might ask you for further information to verify that you're the legitimate


### PR DESCRIPTION
Ref https://github.com/nextcloud/app-certificate-requests/pull/170.
Ref https://nextcloudappstore.readthedocs.io/en/latest/developer.html#obtaining-a-certificate.

cc @BernhardPosselt 