### PR TITLE
XCache is not supported on 14

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -1192,7 +1192,6 @@ Available cache backends:
 * ``\OC\Memcache\ArrayCache`` In-memory array-based backend (not recommended)
 * ``\OC\Memcache\Memcached``  Memcached backend
 * ``\OC\Memcache\Redis``      Redis backend
-* ``\OC\Memcache\XCache``     XCache backend
 
 Advice on choosing between the various backends:
 


### PR DESCRIPTION
Since XCache is not compatible with php7 it is removed here as well.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>