### PR TITLE
Set Referrer-Policy header for nginx installation docs

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -74,6 +74,7 @@ webroot of your nginx installation. In this example it is
       add_header X-Robots-Tag none;
       add_header X-Download-Options noopen;
       add_header X-Permitted-Cross-Domain-Policies none;
+      add_header Referrer-Policy no-referrer;
 
       # Remove X-Powered-By, which is an information leak
       fastcgi_hide_header X-Powered-By;
@@ -219,6 +220,7 @@ your nginx installation.
       add_header X-Robots-Tag none;
       add_header X-Download-Options noopen;
       add_header X-Permitted-Cross-Domain-Policies none;
+      add_header Referrer-Policy no-referrer;
 
       # Remove X-Powered-By, which is an information leak
       fastcgi_hide_header X-Powered-By;


### PR DESCRIPTION
This PR adds a `Referrer-Policy` header to the example nginx configuration. Because a warning has been added since Nextcloud 14, I think this header should be included in the example config using the most strict value by default. In special use cases the user can adjust this value and use a less strict value if needed.

See nextcloud/docker#451 and nextcloud/server#9122.

PS do I have to create another PR to target the `stable14` branch?