### PR TITLE
Update Webcron url path

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -55,7 +55,7 @@ service (for example, easyCron_), you ensure that background jobs are executed
 regularly. To use this type of service with your server, you must be able to
 access your server using the Internet. For example::
 
-  URL to call: http[s]://<domain-of-your-server>/nextcloud/cron.php
+  URL to call: http[s]://<domain-of-your-server>/cron.php
 
 Cron
 ^^^^


### PR DESCRIPTION
It looks like the Webcron url path in Nextcloud 14 is at **/cron.php** rather than at **/nextcloud/cron.php**. I discovered this after spending a while trying to figure out why EasyCron wasn't invoking cron.php correctly. It turned out that it just needed to hit /cron.php instead.