### PR TITLE
noted required setting for accessing public shares over WebDAV

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -344,6 +344,10 @@ To access the public share, open::
 in a WebDAV client, use the share token as username and the (optional) share password
 as password.
 
+.. note:: ``Settings → Administration → Sharing → Allow users on this
+   server to send shares to other servers`` needs to be enabled in order
+   to make this feature work.
+
 Known problems
 --------------
 


### PR DESCRIPTION
Recently, we found that the setting "Allow users on this server to send shares to other servers" is required in order to access public shares over WebDAV.
If this setting is not enabled, "HTTP Access Denied" is returned (which is correct, but) what makes it difficult to find out how to enable this feature.
Hence, we should note this in the docs.