### PR TITLE
NC 14.0.1 requires the terminal / on overwrite.cli.url

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -318,7 +318,7 @@ must be writable by the HTTP user. Then you can set in the :file:`config.php` tw
 
 if your setup is available on ``https://example.org/nextcloud`` or::
 
- 'overwrite.cli.url' => 'https://example.org',
+ 'overwrite.cli.url' => 'https://example.org/',
  'htaccess.RewriteBase' => '/',
 
 if it isn't installed in a subfolder. Finally run this occ-command to update


### PR DESCRIPTION
for `overwrite.cli.url` when going to the root. Maybe required as well for other paths?

BTW: Could the following error message be made more specific?

```
# sudo -u www-data  php occ maintenance:update:htaccess
Error updating .htaccess file, not enough permissions or "overwrite.cli.url" set to an invalid URL?
```