### PR TITLE
Removed Upgrade Option

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -1313,10 +1313,9 @@ List all options, like this example on CentOS Linux::
 
  sudo -u apache php occ upgrade -h
  Usage:
- upgrade [--no-app-disable]
+ upgrade [--quiet]
 
  Options:
- --no-app-disable       skips the disable of third party apps
  --help (-h)            Display this help message.
  --quiet (-q)           Do not output any message.
  --verbose (-v|vv|vvv)  Increase the verbosity of messages: 1 for normal output, 


### PR DESCRIPTION
Removed “--no-app-disable” Option from the occ upgrade command since this option does not exist in Nextcloud 14 anymore.