### PR TITLE
Use a2ensite instead of ln -s to enable site

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -256,9 +256,9 @@ it, replacing the **Directory** and other filepaths with your own filepaths::
 
   </Directory>
  
-Then create a symlink to :file:`/etc/apache2/sites-enabled`::
+Then enable the newly created site::
 
-  ln -s /etc/apache2/sites-available/nextcloud.conf /etc/apache2/sites-enabled/nextcloud.conf
+  a2ensite nextcloud.conf
  
 Additional Apache configurations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Replace instruction using `ln -s` to enable Apache site to use `a2ensite` instead in Debian and derivatives. Closes [#884](https://github.com/nextcloud/documentation/issues/884).