### PR TITLE
Indicate required mod_rewrite

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -259,8 +259,9 @@ and if running in a subfolder like ``nextcloud``:
 ``https://example.com/nextcloud/remote.php/dav``
 
 For the first case the :file:`.htaccess` file shipped with Nextcloud should do
-this work for your when running Apache. You only need to make sure that your
-Web server is using this file. When running Nginx please refer to
+this work for your when running Apache. You need to make sure that your
+Web server is using this file. Additionally, you need the mod_rewrite Apache
+module installed to process these redirects. When running Nginx please refer to
 :doc:`../installation/nginx`.
 
 


### PR DESCRIPTION
Added a note indicating that mod_rewrite is required for .well-known redirects in the .htaccess file. I stumbled across this missing requirement when upgrading to NC 13.0.