### PR TITLE
Remove explanation about "sizelimit exceeded"

### DIFF
--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -682,6 +682,11 @@ This error message means one of the following:
 #. No pagination is used and this indicates that there are more results on the
    LDAP server than what is returned. You should then enabled pagination on
    your LDAP server to import all available users.
+#. A request to LDAP was sent, which limited the amount of results. This happens
+   anywhere where pagination is used, but also in the LDAP wizard. Since PHP's
+   LDAP module sends this messages as errors, we could only decide to silence
+   all error output, or none. Therefore it is inevitable that the message appears
+   in the log from time to time. Please ignore it.
 
 Nextcloud LDAP internals
 ------------------------

--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -667,27 +667,6 @@ In case you have a working configuration and want to create a similar one or
 
 Now you can modify and enable the configuration.
 
-"Sizelimit exceeded" message in logs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  ldap_search(): Partial search results returned: Sizelimit exceeded at
-  apps/user_ldap/lib/LDAP.php#256
-
-This error message means one of the following:
-
-#. Pagination of the results is used for communicating with the LDAP server
-   (pagination is by default enabled in OpenLDAP and AD), but there are more
-   results to return than what the pagination limit is set to. If there are no
-   users missing in you setup then you can ignore this error message for now.
-#. No pagination is used and this indicates that there are more results on the
-   LDAP server than what is returned. You should then enabled pagination on
-   your LDAP server to import all available users.
-#. A request to LDAP was sent, which limited the amount of results. This happens
-   anywhere where pagination is used, but also in the LDAP wizard. Since PHP's
-   LDAP module sends this messages as errors, we could only decide to silence
-   all error output, or none. Therefore it is inevitable that the message appears
-   in the log from time to time. Please ignore it.
-
 Nextcloud LDAP internals
 ------------------------
 


### PR DESCRIPTION
even stated in the php docs: http://php.net/manual/en/function.ldap-search.php

> Some directory server hosts will be configured to return no more than a preset number of entries. If this occurs, the server will indicate that it has only returned a partial results set. This also occurs if you use this parameter to limit the count of fetched entries. 