### PR TITLE
 Fixing several typos in German version_control.rst 

### DIFF
--- a/user_manual_de/files/version_control.rst
+++ b/user_manual_de/files/version_control.rst
@@ -2,21 +2,21 @@
 Versionsverwaltung
 ==================
 
-Nextcloud hat ein einfaches Versionsverwaltung-System für Dateien. Versionierung
-erstellt Backups, welche unter dem "Versions"-Reiter in der Detail-Sidebar zu
+In Nextcloud ist eine einfache Versionsverwaltung für Dateien integriert. Die Versionsverwaltung
+erstellt Backups, welche unter dem "Versionen"-Reiter in der Seitenleiste "Details" einer Datei zu
 finden sind. Dieser Reiter enhält eine komplette Historie aller Änderungen an der
-entsprechenden Datei und erlaubt es, jegliche alte Version wiederherzustellen.
-Änderungen werden alle zwei Minuten unter data/[user]/versions abgelegt.
+entsprechenden Datei und erlaubt es, beliebige alte Version wiederherzustellen.
+Die geänderten Dateien werden alle zwei Minuten unter data/[user]/versions abgelegt.
 
 .. figure:: ../images/files_versioning.png
 
-Um eine bestimmte Version einer Datei wiederherzustellen, klicken Sie den
-Kreispfeil auf der linken Seite. Mit einem Klick auf den Zeitstempel kann die Datei
+Um eine bestimmte Version einer Datei wiederherzustellen, klicken Sie auf den
+Kreispfeil an der linken Seite. Mit einem Klick auf den Zeitstempel kann die Datei
 heruntergeladen werden.
 
 Um Speicherplatz zu sparen, löscht die "Versionen"-App automatisch ältere Versionen nach diesen Regeln:
 
-- In der ersten Sekunde wird einer Version erstellt
+- In der ersten Sekunde wird eine Version erstellt
 - Die ersten 10 Sekunden wird alle 2 Sekunden eine Version erstellt
 - Die erste Minute wird alle 10 Sekunden eine Version erstellt
 - Die erste Stunde wird jede Minute eine Version erstellt
@@ -29,4 +29,4 @@ diesem Schema an.
 
 Die "Versionen"-App benutzt nie mehr als 50% des für den Nutzer verfügbaren
 Speicherplatzes. Wenn dieses Limit überschritten wird, werden die ältesten
-Versionen gelöscht, sobald wieder mindestens 50% Speicher frei sind.
+Versionen gelöscht, bis wieder mindestens 50% Speicher frei sind.


### PR DESCRIPTION
Hi,
some typos I found in the German version control documentation are fixed in this pr.

Regards
jk