### PR TITLE
Add Apache modules to OAuth 2 docs

### DIFF
--- a/admin_manual/configuration_server/oauth2.rst
+++ b/admin_manual/configuration_server/oauth2.rst
@@ -33,4 +33,4 @@ Nextcloud server you will have to send the proper authorization header.
 
 Authorization: Bearer <TOKEN>
 
-Note that apache by default strips this. Make sure you have ``mod_rewrite`` and ``mod_env`` enabled.
+Note that apache by default strips this. Make sure you have ``mod_headers``, ``mod_rewrite`` and ``mod_env`` enabled.


### PR DESCRIPTION
IIRC, `mod_headers` should be the most important one... not sure if the others are required but they don't hurt either