### PR TITLE
[stable10] Provide a link to stable version of documentation

### DIFF
--- a/_shared_assets/themes/nextcloud_com/layout.html
+++ b/_shared_assets/themes/nextcloud_com/layout.html
@@ -79,6 +79,22 @@
     </nav>
   </div>
 </header>
+
+{% if project == "Nextcloud 10 Server Administration Manual" %}
+<div class="container" style="background-color: #E6C4C2;color: #b10000;border: #b10000 2px solid;border-right: none;border-left: none;padding: 15px 10px;">You are reading an outdated version of this documentation. Please check out the <a href="https://docs.nextcloud.com/server/stable/admin_manual/" style="
+color: rgb(177,0,0);text-decoration: underline;">latest version</a> of the server administration manual.</div>
+{% else %}
+{% if project == "Nextcloud 10 User Manual" %}
+<div class="container" style="background-color: #E6C4C2;color: #b10000;border: #b10000 2px solid;border-right: none;border-left: none;padding: 15px 10px;">You are reading an outdated version of this documentation. Please check out the <a href="https://docs.nextcloud.com/server/stable/user_manual/" style="
+color: rgb(177,0,0);text-decoration: underline;">latest version</a> of the user manual.</div>
+{% else %}
+{% if project == "Nextcloud Developer Manual" %}
+<div class="container" style="background-color: #E6C4C2;color: #b10000;border: #b10000 2px solid;border-right: none;border-left: none;padding: 15px 10px;">You are reading an outdated version of this documentation. Please check out the <a href="https://docs.nextcloud.com/server/stable/developer_manual/" style="
+color: rgb(177,0,0);text-decoration: underline;">latest version</a> of the developer manual.</div>
+{% endif %}
+{% endif %}
+{% endif %}
+
 {% endmacro %}
 
 {% if theme_bootstrap_version == "3" %}


### PR DESCRIPTION
Same as #990 for stable10

Fixes #958 

![bildschirmfoto 2018-12-03 um 14 14 34](https://user-images.githubusercontent.com/245432/49376215-d75f1f80-f706-11e8-9c26-7993bb0cc875.png)
![bildschirmfoto 2018-12-03 um 14 19 29](https://user-images.githubusercontent.com/245432/49376216-d75f1f80-f706-11e8-9ace-08406f4c46a3.png)
![bildschirmfoto 2018-12-03 um 14 19 51](https://user-images.githubusercontent.com/245432/49376217-d75f1f80-f706-11e8-916d-ead5c4c0594c.png)
