### PR TITLE
[stable12] Provide a link to stable version of documentation

### DIFF
--- a/_shared_assets/themes/nextcloud_com/layout.html
+++ b/_shared_assets/themes/nextcloud_com/layout.html
@@ -79,6 +79,22 @@
     </nav>
   </div>
 </header>
+
+{% if project == "Nextcloud 9 Server Administration Manual" %}
+<div class="container" style="background-color: #E6C4C2;color: #b10000;border: #b10000 2px solid;border-right: none;border-left: none;padding: 15px 10px;">You are reading an outdated version of this documentation. Please check out the <a href="https://docs.nextcloud.com/server/stable/admin_manual/" style="
+color: rgb(177,0,0);text-decoration: underline;">latest version</a> of the server administration manual.</div>
+{% else %}
+{% if project == "Nextcloud 9 User Manual" %}
+<div class="container" style="background-color: #E6C4C2;color: #b10000;border: #b10000 2px solid;border-right: none;border-left: none;padding: 15px 10px;">You are reading an outdated version of this documentation. Please check out the <a href="https://docs.nextcloud.com/server/stable/user_manual/" style="
+color: rgb(177,0,0);text-decoration: underline;">latest version</a> of the user manual.</div>
+{% else %}
+{% if project == "Nextcloud Developer Manual" %}
+<div class="container" style="background-color: #E6C4C2;color: #b10000;border: #b10000 2px solid;border-right: none;border-left: none;padding: 15px 10px;">You are reading an outdated version of this documentation. Please check out the <a href="https://docs.nextcloud.com/server/stable/developer_manual/" style="
+color: rgb(177,0,0);text-decoration: underline;">latest version</a> of the developer manual.</div>
+{% endif %}
+{% endif %}
+{% endif %}
+
 {% endmacro %}
 
 {% if theme_bootstrap_version == "3" %}


### PR DESCRIPTION
Same as #990 for stable12 and also includes a version for the German translation.

Fixes #958

![bildschirmfoto 2018-12-03 um 14 31 57](https://user-images.githubusercontent.com/245432/49376703-6fa9d400-f708-11e8-8a6e-76d4ce126975.png)
![bildschirmfoto 2018-12-03 um 14 32 07](https://user-images.githubusercontent.com/245432/49376704-70426a80-f708-11e8-9391-96e4a9411b84.png)
![bildschirmfoto 2018-12-03 um 14 32 30](https://user-images.githubusercontent.com/245432/49376705-70426a80-f708-11e8-8bac-8e8b4747f77f.png)
![bildschirmfoto 2018-12-03 um 14 32 38](https://user-images.githubusercontent.com/245432/49376706-70426a80-f708-11e8-90fc-b87b700d52d9.png)

