### PR TITLE
Update landing page: move 12 docs, remove "production" statement on all docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,19 +226,19 @@
 							</div>
 							<div class="section" id="nextcloud-15">
 								<h2>Nextcloud 15<a class="headerlink" href="#nextcloud-15" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>latest production</em> version of Nextcloud.</p>
+								<p>This documents the <em>latest</em> version of Nextcloud.</p>
 								<ul class="simple">
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/15/user_manual/">User Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/15/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/15/admin_manual/">Administration Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/15/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/15/developer_manual/">Developer Manual</a>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/stable/user_manual/">User Manual</a>
+										(<a class="reference external" href="https://docs.nextcloud.com/server/stable/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/stable/admin_manual/">Administration Manual</a>
+										(<a class="reference external" href="https://docs.nextcloud.com/server/stable/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/stable/developer_manual/">Developer Manual</a>
 								</ul>
 							</div>
 
 							<div class="section" id="nextcloud-14">
 								<h2>Nextcloud 14<a class="headerlink" href="#nextcloud-14" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>previous production</em> version of Nextcloud.</p>
+								<p>This documents the <em>previous</em> version of Nextcloud.</p>
 								<ul class="simple">
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/14/user_manual/">User Manual</a>
 										(<a class="reference external" href="https://docs.nextcloud.com/server/14/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
@@ -250,7 +250,7 @@
 
 							<div class="section" id="nextcloud-13">
 								<h2>Nextcloud 13<a class="headerlink" href="#nextcloud-13" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>previous production</em> version of Nextcloud.</p>
+								<p>This documents a <em>previous</em> version of Nextcloud.</p>
 								<ul class="simple">
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/13/user_manual/">User Manual</a>
 										(<a class="reference external" href="https://docs.nextcloud.com/server/13/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
@@ -261,26 +261,13 @@
 								</ul>
 							</div>
 
-							<div class="section" id="nextcloud-12">
-								<h2>Nextcloud 12<a class="headerlink" href="#nextcloud-12" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>previous production</em> version of Nextcloud.</p>
-								<ul class="simple">
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/12/user_manual/">User Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/12/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/12/admin_manual/">Administration Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/12/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/12/developer_manual/">Developer Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/12/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
-								</ul>
-							</div>
-
 							<div class="section" id="desktop">
 								<h1>Nextcloud Desktop Client<a class="headerlink" href="#desktop" title="Permalink to this headline">¶</a></h1>
 								<p>Once you have a Nextcloud Server running, you can connect to it with various <a class="reference external" href="https://nextcloud.com/install/#install-clients">clients like our mobile and desktop client.</a>
 								Find documentation for the desktop client below.</p>
 								<div class="section" id="desktop-23">
 									<h2>Desktop 2.3<a class="headerlink" href="#desktop-23" title="Permalink to this headline">¶</a></h2>
-									<p>This documents the <em>latest production</em> version of the Nextcloud desktop client.</p>
+									<p>This documents the <em>latest</em> version of the Nextcloud desktop client.</p>
 									<ul class="simple">
 										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/2.3">Manual</a>
 									</ul>
@@ -302,6 +289,19 @@
 								publicly maintained and users are strongly encouraged to upgrade to a maintained
 								release or get access to long term security and stability updates through a 
 								<a href="https://nextcloud.com/enterprise">Nextcloud Subscription.</a></p>
+
+
+								<div class="section" id="nextcloud-12">
+									<h2>Nextcloud 12<a class="headerlink" href="#nextcloud-12" title="Permalink to this headline">¶</a></h2>
+									<ul class="simple">
+										<li><a class="reference external" href="https://docs.nextcloud.com/server/12/user_manual/">User Manual</a>
+											(<a class="reference external" href="https://docs.nextcloud.com/server/12/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
+										<li><a class="reference external" href="https://docs.nextcloud.com/server/12/admin_manual/">Administration Manual</a>
+											(<a class="reference external" href="https://docs.nextcloud.com/server/12/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
+										<li><a class="reference external" href="https://docs.nextcloud.com/server/12/developer_manual/">Developer Manual</a>
+											(<a class="reference external" href="https://docs.nextcloud.com/server/12/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
+									</ul>
+								</div>
 
 								<div class="section" id="nextcloud-11">
 									<h2>Nextcloud 11<a class="headerlink" href="#nextcloud-11" title="Permalink to this headline">¶</a></h2>


### PR DESCRIPTION
* moves 12 docs to the "old docs" section
* removes the "latest production version" and "previous production version" statements to "latest version"
* updates the links of the top most section to point to "stable"