### PR TITLE
update sub-section 'systemd' of 'background jobs'

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -119,11 +119,12 @@ Replace the user ``www-data`` with the user of your http server and ``/var/www/n
   [Install]
   WantedBy=timers.target
 
-The important parts in the timer-unit are ``OnBootSec`` and ``OnUnitActiveSec``.``OnBootSec`` will start the timer 5 minutes after boot, otherwise you would have to start it manually after every boot. ``OnUnitActiveSec`` will set a 15 minute timer after the service-unit was last activated.
+The important parts in the timer-unit are ``OnBootSec`` and ``OnUnitActiveSec``. ``OnBootSec`` will start the timer 5 minutes after boot, otherwise you would have to start it manually after every boot. ``OnUnitActiveSec`` will set a 15 minute timer after the service-unit was last activated.
 
-Now all that is left is to start and enable the timer by running these commands::
+Now all that is left is to start and enable the timer by running this command::
 
-  systemctl start nextcloudcron.timer
-  systemctl enable nextcloudcron.timer
+  systemctl enable --now nextcloudcron.timer
+
+When the option ``--now`` is used with ``enable``, the resp. unit will also be started.
 
 .. note:: Select the option ``Cron`` in the admin menu for background jobs. if left on ``AJAX`` it would execute the AJAX job on every page load.


### PR DESCRIPTION
Proposed changes comprise:
- remove typo to get the expected layout for  ``OnBootSec`` in line 122
- improve the effort "to start and enable the timer" by establishing _one_ command line and reducing redundancy in lines 124 to 128