### PR TITLE
Hardcode https redirects

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -98,10 +98,10 @@ webroot of your nginx installation. In this example it is
       # rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
 
       location = /.well-known/carddav {
-        return 301 $scheme://$host/remote.php/dav;
+        return 301 https://$host/remote.php/dav;
       }
       location = /.well-known/caldav {
-        return 301 $scheme://$host/remote.php/dav;
+        return 301 https://$host/remote.php/dav;
       }
 
       # set max upload size
@@ -251,10 +251,10 @@ your nginx installation.
       # rewrite ^/.well-known/webfinger /nextcloud/public.php?service=webfinger last;
 
       location = /.well-known/carddav {
-        return 301 $scheme://$host/nextcloud/remote.php/dav;
+        return 301 https://$host/nextcloud/remote.php/dav;
       }
       location = /.well-known/caldav {
-        return 301 $scheme://$host/nextcloud/remote.php/dav;
+        return 301 https://$host/nextcloud/remote.php/dav;
       }
 
       location /.well-known/acme-challenge { }


### PR DESCRIPTION
Other https settings are already selected (redirecting 80 to 443) so why not hardcode the redirects too?

The existing $scheme breaks "System Overview" checks if nextcloud is placed behind an ssl terminating proxy, as it'll return http links which see a further redirect.

Who doesn't enable https?