### PR TITLE
Add redirect for admin-bigint-conversion

### DIFF
--- a/go.php
+++ b/go.php
@@ -7,6 +7,7 @@ $mapping = array(
     'admin-antivirus-configuration'     => '/admin_manual/configuration_server/antivirus_configuration.html',
     'admin-background-jobs'   => '/admin_manual/configuration_server/background_jobs_configuration.html',
     'admin-backup'            => '/admin_manual/maintenance/backup.html',
+    'admin-bigint-conversion' => '/admin_manual/configuration_database/bigint_identifiers.html',
     'admin-code-integrity'    => '/admin_manual/issues/code_signing.html',
     'admin-config'            => '/admin_manual/configuration_server/config_sample_php_parameters.html',
     'admin-db-conversion'     => '/admin_manual/configuration_database/db_conversion.html',


### PR DESCRIPTION
Used here https://github.com/nextcloud/server/blob/17b2827bbf20691dc59721a9c61a225c5fb4e0de/core/js/setupchecks.js#L350 but redirect is missing.