### PR TITLE
fix regular expressions in nginx config

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -124,15 +124,15 @@ webroot of your nginx installation. In this example it is
           rewrite ^ /index.php$request_uri;
       }
 
-      location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)/ {
+      location ~ ^\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
           deny all;
       }
-      location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console) {
+      location ~ ^\/(?:\.|autotest|occ|issue|indie|db_|console) {
           deny all;
       }
 
-      location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+)\.php(?:$|/) {
-          fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+      location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+)\.php(?:$|\/) {
+          fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
           include fastcgi_params;
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_param PATH_INFO $fastcgi_path_info;
@@ -145,7 +145,7 @@ webroot of your nginx installation. In this example it is
           fastcgi_request_buffering off;
       }
 
-      location ~ ^/(?:updater|ocs-provider)(?:$|/) {
+      location ~ ^\/(?:updater|ocs-provider)(?:$|\/) {
           try_files $uri/ =404;
           index index.php;
       }
@@ -281,15 +281,15 @@ your nginx installation.
               rewrite ^ /nextcloud/index.php$request_uri;
           }
 
-          location ~ ^/nextcloud/(?:build|tests|config|lib|3rdparty|templates|data)/ {
+          location ~ ^\/nextcloud\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
               deny all;
           }
-          location ~ ^/nextcloud/(?:\.|autotest|occ|issue|indie|db_|console) {
+          location ~ ^\/nextcloud\/(?:\.|autotest|occ|issue|indie|db_|console) {
               deny all;
           }
 
-          location ~ ^/nextcloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+)\.php(?:$|/) {
-              fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+          location ~ ^\/nextcloud\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+)\.php(?:$|\/) {
+              fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
               include fastcgi_params;
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               fastcgi_param PATH_INFO $fastcgi_path_info;
@@ -302,14 +302,14 @@ your nginx installation.
               fastcgi_request_buffering off;
           }
 
-          location ~ ^/nextcloud/(?:updater|ocs-provider)(?:$|/) {
+          location ~ ^\/nextcloud\/(?:updater|ocs-provider)(?:$|\/) {
               try_files $uri/ =404;
               index index.php;
           }
 
           # Adding the cache control header for js and css files
           # Make sure it is BELOW the PHP block
-          location ~ \.(?:css|js|woff2?|svg|gif)$ {
+          location ~ ^\/nextcloud\/.+[^\/]\.(?:css|js|woff2?|svg|gif)$ {
               try_files $uri /nextcloud/index.php$request_uri;
               add_header Cache-Control "public, max-age=15778463";
               # Add headers to serve security related headers  (It is intended
@@ -329,7 +329,7 @@ your nginx installation.
               access_log off;
           }
 
-          location ~ \.(?:png|html|ttf|ico|jpg|jpeg)$ {
+          location ~ ^\/nextcloud\/.+[^\/]\.(?:png|html|ttf|ico|jpg|jpeg)$ {
               try_files $uri /nextcloud/index.php$request_uri;
               # Optional: Don't log access to other assets
               access_log off;
@@ -372,7 +372,7 @@ block shown above not located **below** the:
 
 .. code-block:: nginx
 
-        location ~ \.php(?:$|/) {
+        location ~ \.php(?:$|\/) {
 
 block. Other custom configurations like caching JavaScript (.js)
 or CSS (.css) files via gzip could also cause such issues.


### PR DESCRIPTION
A number of fixes to regular expressions in the nginx config example:
* escaping forward slash by prefixing a backslash (not essential, but seems good practise anyway)
* fix the second expression in fastcgi_split_path_info to allow for uris ending in .php (which do satisfy the location definition but would result in a 404 with the current specification of fastcgi_split_path_info
* adding /nextcloud to all regex location definitions in the subdirectory example