### PR TITLE
added IPv6 example in trusted_domains

### DIFF
--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -100,6 +100,7 @@ and domain names. A typical configuration looks like this::
     0 => 'localhost', 
     1 => 'server1.example.com', 
     2 => '192.168.1.50',
+    3 => '[fe80::1:50]',
  ),
 
 The loopback address, ``127.0.0.1``, is automatically whitelisted, so as long 


### PR DESCRIPTION
Since IPv6 have to be inside brackets to work here, an example should be added.