### PR TITLE
Add another table not converted from sqlite to mysql

### DIFF
--- a/admin_manual/configuration_database/db_conversion.rst
+++ b/admin_manual/configuration_database/db_conversion.rst
@@ -69,5 +69,6 @@ Here is a list of known old tables:
 * oc_media_songs
 * oc_media_users
 * oc_permissions
+* oc_privatedata
 * oc_queuedtasks
 * oc_sharing

--- a/admin_manual/configuration_database/db_conversion.rst
+++ b/admin_manual/configuration_database/db_conversion.rst
@@ -69,6 +69,6 @@ Here is a list of known old tables:
 * oc_media_songs
 * oc_media_users
 * oc_permissions
-* oc_privatedata
+* oc_privatedata - this table was later added again by the app `privatedata` (https://apps.nextcloud.com/apps/privatedata) and is safe to be removed if that app is not enabled
 * oc_queuedtasks
 * oc_sharing


### PR DESCRIPTION
Hi,

I just converted an SQLite database to MySQL, and the tool reported that `oc_privatedata` table would not be converted: I suggest to add it to the documentation.

Regards,
Yvan