### PR TITLE
Suppress confirmation

### DIFF
--- a/admin_manual/configuration_database/bigint_identifiers.rst
+++ b/admin_manual/configuration_database/bigint_identifiers.rst
@@ -20,5 +20,11 @@ or otherwise ask for confirmation, before performing the heavy actions::
     This can take up to hours, depending on the number of files in your instance!
     Continue with the conversion (y/n)? [n]
 
+in a shared hosting environment you can add
+
+    --no-interaction
+
+as an argument to suppress the confirmation.
+
 .. note:: Similar to a normal update, you should shutdown your apache or nginx server or enable maintenance
           mode before running the command to avoid issues with your sync clients.

--- a/admin_manual/configuration_database/bigint_identifiers.rst
+++ b/admin_manual/configuration_database/bigint_identifiers.rst
@@ -20,11 +20,10 @@ or otherwise ask for confirmation, before performing the heavy actions::
     This can take up to hours, depending on the number of files in your instance!
     Continue with the conversion (y/n)? [n]
 
-in a shared hosting environment you can add
+to suppress the confirmation message append `--no-interaction` to the argument list:
 
-    --no-interaction
+    sudo -u www-data php occ db:convert-filecache-bigint --no-interaction
 
-as an argument to suppress the confirmation.
 
 .. note:: Similar to a normal update, you should shutdown your apache or nginx server or enable maintenance
           mode before running the command to avoid issues with your sync clients.


### PR DESCRIPTION
Shared hostings without shell access make the confirmation step impossible. Therefore you can add named argument and suppress the confirmation message. Then the conversion works even from one time cronjobs.
See: https://github.com/nextcloud/server/issues/12976