### PR TITLE
Nginx config: Remove line-breaks from STS header

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -61,8 +61,7 @@ webroot of your nginx installation. In this example it is
       # Add headers to serve security related headers
       # Before enabling Strict-Transport-Security headers please read into this
       # topic first.
-      # add_header Strict-Transport-Security "max-age=15768000;
-      # includeSubDomains; preload;";
+      # add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
       #
       # WARNING: Only add the preload option once you read about
       # the consequences in https://hstspreload.org/. This option
@@ -316,8 +315,7 @@ your nginx installation.
               # to have those duplicated to the ones above)
               # Before enabling Strict-Transport-Security headers please read
               # into this topic first.
-              # add_header Strict-Transport-Security "max-age=15768000;
-              # includeSubDomains; preload;";
+              # add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
               add_header X-Content-Type-Options nosniff;
               add_header X-XSS-Protection "1; mode=block";
               add_header X-Robots-Tag none;


### PR DESCRIPTION
This patch removes the incorrect line-breaks in the Strict-Transport-Security Headers.
Just removing the comment at the beginning of the line (and therefore having a line-break in the header field) leads to various kinds of failures across different clients and browsers.

While this syntax error had already been fixed in https://github.com/nextcloud/documentation/pull/594 , it apparently snuck its way back in.