### PR TITLE
iOS Files & Talk apps are requiring iOS 10.x

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -72,10 +72,10 @@ Mobile apps
 We strongly recommend using the latest version of your mobile operating system to get the full and most stable experience out
 of our mobile apps.
 
-- **iOS** 9.x+
+- **iOS** 10.x+
 - **Android** 4.x+
 
-.. note:: The separate Nextcloud Talk app requires iOS 9.x+ or Android 5.x+.
+.. note:: The separate Nextcloud Talk app requires iOS 10.x+ or Android 5.x+.
 
 Web browser
 -----------


### PR DESCRIPTION
Signed-off-by: Marius Blüm <marius@lineone.io>