### PR TITLE
Fixed formatting that displayed off-screen

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -190,10 +190,11 @@ terminal::
 * This installs the packages for the Nextcloud core system.
   ``libapache2-mod-php7.2`` provides the following PHP extensions: ``bcmath bz2
   calendar Core ctype date dba dom ereg exif fileinfo filter ftp gettext hash
-  iconv libxml mhash openssl pcre Phar posix Reflection session shmop
-  SimpleXML soap sockets SPL standard sysvmsg sysvsem sysvshm tokenizer wddx
-  xmlreader xmlwriter zlib``. If you are planning
-  on running additional apps, keep in mind that they might require additional
+  iconv libxml 
+  mhash openssl pcre Phar posix Reflection session shmop SimpleXML soap sockets
+  SPL standard sysvmsg sysvsem sysvshm tokenizer wddx xmlreader xmlwriter zlib``. 
+  
+  If you are planning on running additional apps, keep in mind that they might require additional
   packages.  See :ref:`prerequisites_label` for details.
 
 * At the installation of the MySQL/MariaDB server, you will be prompted to

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -188,11 +188,11 @@ terminal::
     apt-get install php7.2-intl php-imagick php7.2-xml php7.2-zip
 
 * This installs the packages for the Nextcloud core system.
-  ``libapache2-mod-php7.2`` provides the following PHP extensions: ``bcmath bz2
-  calendar Core ctype date dba dom ereg exif fileinfo filter ftp gettext hash
-  iconv libxml 
-  mhash openssl pcre Phar posix Reflection session shmop SimpleXML soap sockets
-  SPL standard sysvmsg sysvsem sysvshm tokenizer wddx xmlreader xmlwriter zlib``. 
+  ``libapache2-mod-php7.2`` provides the following PHP extensions:: 
+  
+    bcmath bz2 calendar Core ctype date dba dom ereg exif fileinfo filter ftp gettext 
+    hash iconv libxml mhash openssl pcre Phar posix Reflection session shmop SimpleXML 
+    soap sockets SPL standard sysvmsg sysvsem sysvshm tokenizer wddx xmlreader xmlwriter zlib . 
   
   If you are planning on running additional apps, keep in mind that they might require additional
   packages.  See :ref:`prerequisites_label` for details.


### PR DESCRIPTION
The changes did not fit into the window when viewing the docs for Ubuntu install. Fixed it according to what I thought would be displayed better.

Previous version:

![image](https://user-images.githubusercontent.com/24249616/52323296-3716c700-29e5-11e9-9d9a-c33e6c015b1d.png)

According to the "Preview tab" whilst editing it, it should be OK now.