### PR TITLE
Add leading slashes to class in examples

### DIFF
--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -60,7 +60,7 @@ The class to be used is :code:`\\OC\\Files\\ObjectStore\\Swift`
 ::
 
 	'objectstore' => array(
-		'class' => 'OC\\Files\\ObjectStore\\Swift',
+		'class' => '\\OC\\Files\\ObjectStore\\Swift',
 		'arguments' => array(
 			'username' => 'username',
 			'password' => 'Secr3tPaSSWoRdt7',
@@ -91,7 +91,7 @@ The class to be used is :code:`\\OC\\Files\\ObjectStore\\S3`
 ::
 
 	'objectstore' => array(
-		'class' => 'OC\\Files\\ObjectStore\\S3',
+		'class' => '\\OC\\Files\\ObjectStore\\S3',
 		'arguments' => array(
 			'bucket' => 'nextcloud',
 			'autocreate' => true,


### PR DESCRIPTION
Leading slashes were missing from 'class' in the object storage configuration examples (i.e. \\OC\\...) though they were called out correctly above the examples.