### PR TITLE
add rh-php72-php-pecl-apcu for centos too

### DIFF
--- a/admin_manual/installation/php_72_installation.rst
+++ b/admin_manual/installation/php_72_installation.rst
@@ -69,7 +69,7 @@ Follow these steps to install PHP 7.2 from SCL. First install the SCL repository
 
 Then install PHP 7.2 and these modules::
 
- yum install rh-php72 rh-php72-php rh-php72-php-gd rh-php72-php-mbstring rh-php72-php-intl
+ yum install rh-php72 rh-php72-php rh-php72-php-gd rh-php72-php-mbstring rh-php72-php-intl rh-php72-php-pecl-apcu
 
 You must also install the updated database module for your database. This installs the new PHP 7.2 module for MySQL/MariaDB:: 
 


### PR DESCRIPTION
add rh-php72-php-pecl-apcu for centos too
Roeland added this only for RHEL, but not for CentOS
cc @rullzer @MorrisJobke @hanserasmus 
