### PR TITLE
Added undocumented 'jpeg_quality' setting to the docs

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -1067,6 +1067,15 @@ Defaults to ``50`` megabytes
 
 ::
 
+	'jpeg_quality' => 90,
+	
+By default Nextcloud generates previews with a JPEG quality of 90 %.
+If you want to save disk space and network traffic, lower this value to about 70-50.
+
+Defaults to ``90`` %
+
+::
+
 	'preview_libreoffice_path' => '/usr/bin/libreoffice',
 
 custom path for LibreOffice/OpenOffice binary


### PR DESCRIPTION
This option is really useful for people like me, who like the preview folder to be half as large as the orginal image folder.
I found this setting by coincidence and added it to the documentation.