### PR TITLE
change nginx-config for subdir to resolve /ocm-provider properly

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -255,7 +255,7 @@ your nginx installation.
       location = /.well-known/caldav {
         return 301 $scheme://$host/nextcloud/remote.php/dav;
       }
-      location ~/(ocm-provider|ocs-provider)/ {
+      
       location ~ ^\/(?:ocm-provider|ocs-provider).* {
         rewrite ^ /nextcloud$request_uri;
       }

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -256,7 +256,8 @@ your nginx installation.
         return 301 $scheme://$host/nextcloud/remote.php/dav;
       }
       location ~/(ocm-provider|ocs-provider)/ {
-        return 301 $scheme://$host/nextcloud/$1/;
+      location ~ ^\/(?:ocm-provider|ocs-provider).* {
+        rewrite ^ /nextcloud$request_uri;
       }
 
       location /.well-known/acme-challenge { }

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -255,6 +255,9 @@ your nginx installation.
       location = /.well-known/caldav {
         return 301 $scheme://$host/nextcloud/remote.php/dav;
       }
+      location ~/(ocm-provider|ocs-provider)/ {
+        return 301 $scheme://$host/nextcloud/$1/;
+      }
 
       location /.well-known/acme-challenge { }
 


### PR DESCRIPTION
After upgrading to 15.0.5 this is shown in the Admin-panel:
```
Your web server is not properly set up to resolve “/ocm-provider/”. This is most likely related to a web server configuration that was not updated to deliver this folder directly. Please compare your configuration against the shipped rewrite rules in “.htaccess” for Apache or the provided one in the documentation for Nginx at it’s documentation page 1. On Nginx those are typically the lines starting with “location ~” that need an update.
```
I think for runnning nextcloud in a subdirectory of webroot, this redirect has to be added to the configuration

Also see here: https://help.nextcloud.com/t/your-web-server-is-not-properly-set-up-to-resolve-ocm-provider/48530
And here: https://github.com/nextcloud/server/issues/14445

signed-off by bernieo.github@gmx.de