### PR TITLE
Fix a link to point to correct version and remove TODO entry

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -766,6 +766,7 @@ Verify your app::
   
 When it returns nothing, your app is signed correctly. When it returns a message then there is an error. See `Code Signing 
 <https://docs.nextcloud.org/server/15/developer_manual/app/code_signing.html#how-to-get-your-app-signed>`_ in the Developer manual for more detailed information.
+.. TODO ON RELEASE: Update version number above on release
 
 ``integrity:sign-core`` is for Nextcloud core developers only.
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -765,8 +765,7 @@ Verify your app::
   sudo -u www-data php occ integrity:check-app --path=/pathto/app appname
   
 When it returns nothing, your app is signed correctly. When it returns a message then there is an error. See `Code Signing 
-<https://docs.nextcloud.org/server/14/developer_manual/app/code_signing.html#how-to-get-your-app-signed>`_ in the Developer manual for more detailed information.
-.. TODO ON RELEASE: Update version number above on release
+<https://docs.nextcloud.org/server/15/developer_manual/app/code_signing.html#how-to-get-your-app-signed>`_ in the Developer manual for more detailed information.
 
 ``integrity:sign-core`` is for Nextcloud core developers only.
 


### PR DESCRIPTION
This PR corrects a link to point to most recent version of documentation and removes a leftover TODO-marker 