### PR TITLE
Added documentation about missing MIMEtype issues

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -374,3 +374,6 @@ block shown above not located **below** the:
 
 block. Other custom configurations like caching JavaScript (.js)
 or CSS (.css) files via gzip could also cause such issues.
+
+Another cause of this issue could be not properly including mimetypes in the
+http block, as shown `here. <https://www.nginx.com/resources/wiki/start/topics/examples/full/>`_


### PR DESCRIPTION
Ran into the issue that nginx didn't properly serve the js/css files, and could not find a fix anywhere. Having finally solved it myself, I would like to add this fix to the documentation.