### PR TITLE
Update access_webdav.rst

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -207,16 +207,14 @@ To access files through the macOS Finder:
   .. image:: ../images/osx_webdav1.png
      :alt: Screenshot of entering your Nextcloud server address on macOS
 
-2. The **Connect to Server...** window opens.
+2. When the **Connect to Server...** window opens, enter your Nexcloud server’s WebDAV address in the **Server Address:** field, ie:
+
+    https://cloud.YOURDOMAIN.com/remote.php/dav/files/USERNAME/
 
   .. image:: ../images/osx_webdav2.png
      :alt: Screenshot: Enter Nextcloud server address in “Connect to Server...” dialog box
 
-3. As pictured above, enter your Nexcloud server’s WebDAV address in the **Server Address:** field, ie:
-
-    https://cloud.YOURDOMAIN.com/remote.php/dav/files/USERNAME/
-
-4. Click **Connect**. Your WebDAV server should appear on the Desktop as a shared disk drive.
+3. Click **Connect**. Your WebDAV server should appear on the Desktop as a shared disk drive.
 
 
 Accessing files using Microsoft Windows

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -198,35 +198,26 @@ path of your certificate as in this example::
 Accessing files using macOS
 ---------------------------
 
-.. note:: The macOS Finder suffers from a `series of implementation problems
-   <http://sabre.io/dav/clients/finder/>`_ and should only be used if the
-   Nextcloud server runs on **Apache** and **mod_php**, or **Nginx 1.3.8+**.
+.. note:: The macOS Finder suffers from a `series of implementation problems <http://sabre.io/dav/clients/finder/>`_ and should only be used if the Nextcloud server runs on **Apache** and **mod_php**, or **Nginx 1.3.8+**. Alternative macOS-compatible clients capable of accessing WebDAV shares include open source apps like `Cyberduck <http://sabre.io/dav/clients/finder/>`_ and `Filezilla <https://filezilla-project.org>`_. Commercial clients include `Mountain Duck <https://mountainduck.io/>`_, `Forklift <https://binarynights.com/>`_, `Transmit <https://panic.com/>`_, and `Commander One <https://mac.eltima.com/>`_.
 
 To access files through the macOS Finder:
 
-1. Choose **Go > Connect to Server**.
-
-  The "Connect to Server" window opens.
-
-2. Specify the address of the server in the **Server Address** field.
+1. From the Finder’s top menu bar, choose **Go > Connect to Server...**
 
   .. image:: ../images/osx_webdav1.png
      :alt: Screenshot of entering your Nextcloud server address on macOS
 
-  For example, the URL used to connect to the Nextcloud server
-  from the macOS Finder is::
-
-    https://example.com/nextcloud/remote.php/dav/files/USERNAME/
+2. The **Connect to Server...** window opens.
 
   .. image:: ../images/osx_webdav2.png
+     :alt: Screenshot: Enter Nextcloud server address in “Connect to Server” dialog box
 
-3. Click **Connect**.
+3. Enter your Nexcloud server’s WebDAV address in the **Server Address:** field, ie:
 
-  The device connects to the server.
+    https://cloud.nextcloud.com/nextcloud/remote.php/dav/files/USERNAME/
 
-For added details about how to connect to an external server using macOS,
-check the `vendor documentation
-<http://docs.info.apple.com/article.html?path=Mac/10.6/en/8160.html>`_ .
+4. Click **Connect**. The WebDAV server will appear on the Desktop as a shared disk drive.
+
 
 Accessing files using Microsoft Windows
 ---------------------------------------
@@ -310,7 +301,7 @@ To map a drive using the Microsoft Windows Explorer:
 Accessing files using Cyberduck
 -------------------------------
 
-`Cyberduck <https://cyberduck.io/?l=en>`_ is an open source FTP and SFTP,
+`Cyberduck <https://cyberduck.io/>`_ is an open source FTP and SFTP,
 WebDAV, OpenStack Swift, and Amazon S3 browser designed for file transfers on
 macOS and Windows.
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -198,7 +198,7 @@ path of your certificate as in this example::
 Accessing files using macOS
 ---------------------------
 
-.. note:: The macOS Finder suffers from a `series of implementation problems <http://sabre.io/dav/clients/finder/>`_ and should only be used if the Nextcloud server runs on **Apache** and **mod_php**, or **Nginx 1.3.8+**. Alternative macOS-compatible clients capable of accessing WebDAV shares include open source apps like `Cyberduck <http://sabre.io/dav/clients/finder/>`_ and `Filezilla <https://filezilla-project.org>`_. Commercial clients include `Mountain Duck <https://mountainduck.io/>`_, `Forklift <https://binarynights.com/>`_, `Transmit <https://panic.com/>`_, and `Commander One <https://mac.eltima.com/>`_.
+.. note:: The macOS Finder suffers from a `series of implementation problems <http://sabre.io/dav/clients/finder/>`_ and should only be used if the Nextcloud server runs on **Apache** and **mod_php**, or **Nginx 1.3.8+**. Alternative macOS-compatible clients capable of accessing WebDAV shares include open source apps like `Cyberduck <http://sabre.io/dav/clients/finder/>`_ (see instructions `here <https://docs.nextcloud.com/server/14/user_manual/files/access_webdav.html#accessing-files-using-cyberduck>`_) and `Filezilla <https://filezilla-project.org>`_. Commercial clients include `Mountain Duck <https://mountainduck.io/>`_, `Forklift <https://binarynights.com/>`_, `Transmit <https://panic.com/>`_, and `Commander One <https://mac.eltima.com/>`_.
 
 To access files through the macOS Finder:
 
@@ -216,7 +216,7 @@ To access files through the macOS Finder:
 
     https://cloud.YOURDOMAIN.com/remote.php/dav/files/USERNAME/
 
-4. Click **Connect**. The WebDAV server will appear on the Desktop as a shared disk drive.
+4. Click **Connect**. Your WebDAV server should appear on the Desktop as a shared disk drive.
 
 
 Accessing files using Microsoft Windows

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -210,11 +210,11 @@ To access files through the macOS Finder:
 2. The **Connect to Server...** window opens.
 
   .. image:: ../images/osx_webdav2.png
-     :alt: Screenshot: Enter Nextcloud server address in “Connect to Server” dialog box
+     :alt: Screenshot: Enter Nextcloud server address in “Connect to Server...” dialog box
 
 3. Enter your Nexcloud server’s WebDAV address in the **Server Address:** field, ie:
 
-    https://cloud.nextcloud.com/nextcloud/remote.php/dav/files/USERNAME/
+    https://cloud.nextcloud.com/remote.php/dav/files/USERNAME/
 
 4. Click **Connect**. The WebDAV server will appear on the Desktop as a shared disk drive.
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -214,7 +214,7 @@ To access files through the macOS Finder:
 
 3. Enter your Nexcloud server’s WebDAV address in the **Server Address:** field, ie:
 
-    https://cloud.nextcloud.com/remote.php/dav/files/USERNAME/
+    https://cloud.YOURDOMAIN.com/remote.php/dav/files/USERNAME/
 
 4. Click **Connect**. The WebDAV server will appear on the Desktop as a shared disk drive.
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -212,7 +212,7 @@ To access files through the macOS Finder:
   .. image:: ../images/osx_webdav2.png
      :alt: Screenshot: Enter Nextcloud server address in “Connect to Server...” dialog box
 
-3. Enter your Nexcloud server’s WebDAV address in the **Server Address:** field, ie:
+3. As pictured above, enter your Nexcloud server’s WebDAV address in the **Server Address:** field, ie:
 
     https://cloud.YOURDOMAIN.com/remote.php/dav/files/USERNAME/
 


### PR DESCRIPTION
There’s more explanation here than there are changes to the docs! But, in the interest of fully explaining *why*:

I had a frustrating and time-consuming experience attempting to *unsuccessfully* get macOS 10.11.x-10.13.x to mount WebDAV shares. The opening “Note” of “Accessing files using macOS” re Finder’s “series of implementation problems” is valuable. While my rewrite does *not* employ stronger language to *dissuade* Mac users from wrestling Finder, I’m convinced it should. I understand that docs maintainers probably want to avoid negative commentary re product manufacturers for many reasons, but the alternative to tight-lipped disclosure is user disillusionment. The opening warning would serve Apple folk better if it more-plainly warned of the high likelihood of Finder failure and more-thoroughly offered, even recommended, alternative apps to successfully achieve WebDAV access. Though Cyberduck instructions follow *later* in the article, it benefits the Mac user *here* (and other users in their respective sections) as they will likely seek out and focus specifically, perhaps *only*, on these instructions which are so clearly titled for and targeted at them: “Accessing files using **macOS**.” Unfortunately — even though these steps *should* work — they probably will *not*. Readers, exacerbated, may only find the Cyberduck info later, after returning to the instructions for further illumination, feeling slighted it wasn’t there to begin with. Recommending the open source Cyberduck as a candidate to replace Finder’s failures is helpful. Understandably, there may be resistance to mentioning commercial apps at the risk of perceived endorsement, but I have. I also added another open source app. Arming readers with more knowledge, more details, and more tools *up front* secures a higher rate of informed execution and success.

Nuts and bolts: I offer minor reordering of graphics and text to hopefully present a clearer flow of the existing steps. That includes changing example.com/nextcloud to cloud.nextcloud.com as most people who have registered domains can easily add subdomains. Subdomains can also efficiently be reverse-proxied to internal servers *without* opening external ports visible to hackers. Call it subliminal security reinforcement.

I optimized the original “osx_webdav1.png,” compressing it from 381K to 94K, with negligible visual loss. And I created a new screenshot to replace the existing osx_webdav2.png “Connect to Server” image which graphically matches the sample text URL. (The existing sample URL and its screenshot don’t match.) The original osx_webdav2.png dialog box had been reduced in size, introducing minor but visible blur. The new optimized version is actual-size-crisp and only 16K, vs the original’s 66K size. (I don’t see where to attach these new graphics. I’m new to pull requests, and hope in subsequent steps I can.)

Finally, I removed a deprecated link to a now-defunct Apple help page at the section’s end (I searched in vain hoping it had been relocated elsewhere), and shortened the Cyberduck website link by removing the English language specifier, which may make it friendlier to international speakers.