### PR TITLE
LDAP configuration: clarify effect of "Turn off SSL certificate verification" checkbox

### DIFF
--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -272,6 +272,15 @@ Disable Main Server:
 
 Turn off SSL certificate validation:
   Turns off SSL certificate checking. Use it for testing only!
+  *Note*: The effect of this setting depdends on the PHP system configuration.
+  It does for example not work with the
+  [official Nextcloud container image](https://github.com/nextcloud/docker).
+  To disable certificate verification for a particular use, append the following
+  configuration line to your `/etc/ldap/ldap.conf`:
+
+  ```
+  TLS_REQCERT ALLOW
+  ```
 
 Cache Time-To-Live:
   A cache is introduced to avoid unnecessary LDAP traffic, for example caching
@@ -739,7 +748,7 @@ avoid unnecessary connection attempts.
 Note
 ----
 
-When a LDAP object's name or surname, that is display name attribute, by default 
+When a LDAP object's name or surname, that is display name attribute, by default
 "displayname", is left empty, Nextcloud will treat it as an empty object, therefore
-no results from this user or AD-Object will be shown to avoid gathering of 
+no results from this user or AD-Object will be shown to avoid gathering of
 technical accounts.


### PR DESCRIPTION
This patch adds an alternate possibility to disable ssl certificate
verification in LDAP connections for a particular host.

As discussed in https://github.com/nextcloud/server/issues/14821

For reference: https://stackoverflow.com/a/13593766/4159145