### PR TITLE
Modify host variable in NGINX config

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -248,10 +248,10 @@ your nginx installation.
       # rewrite ^/.well-known/webfinger /nextcloud/public.php?service=webfinger last;
 
       location = /.well-known/carddav {
-        return 301 $scheme://$host/nextcloud/remote.php/dav;
+        return 301 $scheme://$http_host/nextcloud/remote.php/dav;
       }
       location = /.well-known/caldav {
-        return 301 $scheme://$host/nextcloud/remote.php/dav;
+        return 301 $scheme://$http_host/nextcloud/remote.php/dav;
       }
 
       location /.well-known/acme-challenge { }


### PR DESCRIPTION
`$host` doesn't contain port field, while `$http_host` contains port which is useful when you use a non-standard port.