### PR TITLE
add section on moving into our organization

### DIFF
--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -89,7 +89,7 @@ To deliver on the promises above, we have two simple rules.
 * You participate in our `collaborative development model <../general/code-of-conduct.html>`_
 * When you are no longer active, our admins can decide to hand over maintainership to another contributor
 
-We want to make sure that when you find other things in life which are more urgent or otherwise are unable to help your project anymore, it does not become 'dead code' as long as there are people who want to keep it alive.
+We want to make sure that when you find other things in life which are more urgent or otherwise are unable to help your project anymore, it does not become 'dead code' as long as there are people who want to keep it alive. This is not fair to users, who would be forced to remove the app and install another.
 
 Please note that the role of a maintainer is not to be the most active or prolific contributor to a project! Worlds' `most famous maintainer of an open source project <https://en.wikipedia.org/wiki/Linus_Torvalds>`_ has not appeared in the top-100 of contributors by lines of code for decades, yet he runs the largest single software development project in the history of mankind. Being friendly, welcoming and responsive are what it takes to be a successful maintainer. Not being the most brilliant developer ever, or spending nights and weekends coding!
 

--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -70,15 +70,15 @@ Respect the users
 
 Apps which break the guidelines will lose their 'approved' or 'official' state; and might be blocked from the app store altogether. This also has repercussions for the author, especially in case of security concerns, he/she might find themselves blocked from submitting applications.
 
-Putting your repo in the Nextcloud Project
+Moving your repo to the Nextcloud organization
 ------------------------------------------
-We're always delighted to hear app develpers are interested in moving their app into the Nextcloud Project in `github.com/nextcloud <https://github.com/nextcloud>`_! There are benefits for users and developers in being there. However, it comes with some requirements as well.
+We're always delighted to hear app developers are interested in moving their app to the Nextcloud organization at `github.com/nextcloud <https://github.com/nextcloud>`_! There are benefits for users and developers in being there. However, it comes with some requirements as well.
 
 Benefits
 ^^^^^^^^
 
 * You can use the tools and bots we have set up, including translations and such
-* Everybody in the Nextcloud project can more easily contribute
+* Everybody in the Nextcloud organization can contribute more easily
 * Your visibility to app developers increases
 * Users can expect apps in our project to be better maintained
 
@@ -86,7 +86,7 @@ Requirements
 ^^^^^^^^^^^^
 To deliver on the promises above, we have two simple rules.
 
-* You participate in our `collaborative development model <../general/code-of-conduct.html>`_
+* You work and communicate according to the values of our `Code of Conduct <../general/code-of-conduct.html>`_
 * When you are no longer active, our admins can decide to hand over maintainership to another contributor
 
 We want to make sure that when you find other things in life which are more urgent or otherwise are unable to help your project anymore, it does not become 'dead code' as long as there are people who want to keep it alive. This is not fair to users, who would be forced to remove the app and install another.
@@ -98,4 +98,4 @@ The goal of these rules is simple: help your project be more successful. We also
 How to move
 ^^^^^^^^^^^
 
-To move into our github repo, just ask any of our contributors, `especially those who are admin. <https://github.com/orgs/nextcloud/people?utf8=%E2%9C%93&query=+role%3Aowner>`_ They will be happy to help!
+To move your repository to our Github organization, just ask any of our contributors, `especially those who are admin. <https://github.com/orgs/nextcloud/people?utf8=%E2%9C%93&query=+role%3Aowner>`_ They will be happy to help!

--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -91,7 +91,7 @@ To deliver on the promises above, we have two simple rules.
 
 We want to make sure that when you find other things in life which are more urgent or otherwise are unable to help your project anymore, it does not become 'dead code' as long as there are people who want to keep it alive. This is not fair to users, who would be forced to remove the app and install another.
 
-Please note that the role of a maintainer is not to be the most active or prolific contributor to a project! Worlds' `most famous maintainer of an open source project <https://en.wikipedia.org/wiki/Linus_Torvalds>`_ has not appeared in the top-100 of contributors by lines of code for decades, yet he runs the largest single software development project in the history of mankind. Being friendly, welcoming and responsive are what it takes to be a successful maintainer. Not being the most brilliant developer ever, or spending nights and weekends coding!
+Please note that the role of a maintainer is not to be the most active or prolific contributor to a project! Being friendly, welcoming and responsive are what it takes to be a successful maintainer. Not being the most brilliant developer ever, or spending nights and weekends coding!
 
 The goal of these rules is simple: help your project be more successful. We also suggest you watch this talk by `Jan about building a great community. <https://www.youtube.com/watch?v=UtAoRIKVpW4>`_
 

--- a/developer_manual/app/publishing.rst
+++ b/developer_manual/app/publishing.rst
@@ -69,3 +69,33 @@ Respect the users
 * App authors must provide means to contact them, be it through a bug tracker, forum or mail.
 
 Apps which break the guidelines will lose their 'approved' or 'official' state; and might be blocked from the app store altogether. This also has repercussions for the author, especially in case of security concerns, he/she might find themselves blocked from submitting applications.
+
+Putting your repo in the Nextcloud Project
+------------------------------------------
+We're always delighted to hear app develpers are interested in moving their app into the Nextcloud Project in `github.com/nextcloud <https://github.com/nextcloud>`_! There are benefits for users and developers in being there. However, it comes with some requirements as well.
+
+Benefits
+^^^^^^^^
+
+* You can use the tools and bots we have set up, including translations and such
+* Everybody in the Nextcloud project can more easily contribute
+* Your visibility to app developers increases
+* Users can expect apps in our project to be better maintained
+
+Requirements
+^^^^^^^^^^^^
+To deliver on the promises above, we have two simple rules.
+
+* You participate in our `collaborative development model <../general/code-of-conduct.html>`_
+* When you are no longer active, our admins can decide to hand over maintainership to another contributor
+
+We want to make sure that when you find other things in life which are more urgent or otherwise are unable to help your project anymore, it does not become 'dead code' as long as there are people who want to keep it alive.
+
+Please note that the role of a maintainer is not to be the most active or prolific contributor to a project! Worlds' `most famous maintainer of an open source project <https://en.wikipedia.org/wiki/Linus_Torvalds>`_ has not appeared in the top-100 of contributors by lines of code for decades, yet he runs the largest single software development project in the history of mankind. Being friendly, welcoming and responsive are what it takes to be a successful maintainer. Not being the most brilliant developer ever, or spending nights and weekends coding!
+
+The goal of these rules is simple: help your project be more successful. We also suggest you watch this talk by `Jan about building a great community. <https://www.youtube.com/watch?v=UtAoRIKVpW4>`_
+
+How to move
+^^^^^^^^^^^
+
+To move into our github repo, just ask any of our contributors, `especially those who are admin. <https://github.com/orgs/nextcloud/people?utf8=%E2%9C%93&query=+role%3Aowner>`_ They will be happy to help!


### PR DESCRIPTION
We recently discussed a repo which has gone repeatedly inactive yet its maintainer insists that nobody else touches their code. That is not healthy and not what it means to be in our repo: being in our repo means we develop the code together and if another has to take over, that is OK. We don't let apps go unmaintained while there are multiple people who could take over. That is just not nice for users.

Is this description OK?