### PR TITLE
Link to issue submission guidelines led to 404 error page

### DIFF
--- a/developer_manual/bugtracker/index.rst
+++ b/developer_manual/bugtracker/index.rst
@@ -20,7 +20,7 @@ Thank you for helping Nextcloud by reporting bugs. Before submitting an issue, p
   repository
 
 
-.. _Issue submission guidelines: https://github.com/nextcloud/server/blob/master/CONTRIBUTING.md#submitting-issues
+.. _Issue submission guidelines: https://github.com/nextcloud/server/blob/master/.github/CONTRIBUTING.md#submitting-issues
 .. _Server repository: https://github.com/nextcloud/server/issues
 .. _Client repository: https://github.com/nextcloud/client_theming/issues
 .. _main GitHub organization: https://github.com/nextcloud


### PR DESCRIPTION
The link was incorrect or outdated.