### PR TITLE
Correct error in .htaccess, revert #1069

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -271,11 +271,11 @@ document root of your Web server and add the following lines::
 
     <IfModule mod_rewrite.c>
       RewriteEngine on
-      RewriteRule ^/\.well-known/host-meta /nextcloud/public.php?service=host-meta [QSA,L]
-      RewriteRule ^/\.well-known/host-meta\.json /nextcloud/public.php?service=host-meta-json [QSA,L]
-      RewriteRule ^/\.well-known/webfinger /nextcloud/public.php?service=webfinger [QSA,L]
-      RewriteRule ^/\.well-known/carddav /nextcloud/remote.php/dav/ [R=301,L]
-      RewriteRule ^/\.well-known/caldav /nextcloud/remote.php/dav/ [R=301,L]
+      RewriteRule ^\.well-known/host-meta /nextcloud/public.php?service=host-meta [QSA,L]
+      RewriteRule ^\.well-known/host-meta\.json /nextcloud/public.php?service=host-meta-json [QSA,L]
+      RewriteRule ^\.well-known/webfinger /nextcloud/public.php?service=webfinger [QSA,L]
+      RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav/ [R=301,L]
+      RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav/ [R=301,L]
     </IfModule>
 
 Make sure to change /nextcloud to the actual subfolder your Nextcloud instance is running in.


### PR DESCRIPTION
The forward slashes are only needed if the rewrite rules are being put directly into the config file of the apache virtual host. They should not be added to the .htaccess file, as in this case the redirect is not working (this has been tested by me on multiple systems).

You can also see in the discussion of the bug report #1069 after it was merged, that the reporter actually put the rules into his apache conf, instead of a .htaccess and that somebody else was reporting, that it was only working without the forward slashes in a .htaccess file.