### PR TITLE
Include info about Barracuda innodb_file_format

### DIFF
--- a/admin_manual/configuration_database/mysql_4byte_support.rst
+++ b/admin_manual/configuration_database/mysql_4byte_support.rst
@@ -2,10 +2,34 @@
 Enabling MySQL 4-byte support
 =============================
 
+.. note::
+
+    Be sure to backup your database before performing this database upgrade.
+
 In order to use Emojis (textbased smilies) on your Nextcloud server with a MySQL database, the
 installation needs to be tweaked a bit.
 
-1. Make sure the following InnoDB settings are set on your MySQL server:
+1. Make sure your database is set to use the Barracuda InnoDB file format:
+   
+   Login to your mysql database and run::
+   
+         mysql> show variables like 'innodb_file_format';
+         +--------------------+-----------+
+         | Variable_name      | Value     |
+         +--------------------+-----------+
+         | innodb_file_format | Barracuda |
+         +--------------------+-----------+
+         1 row in set (0.00 sec)
+      
+   If your `innodb_file_format` is set as 'Antelope' you must upgrade your file format using::
+     
+         mysql> SET GLOBAL innodb_file_format=Barracuda;
+     
+   .. note::
+   
+         On some shared hosts, you may not have the permissions to upgrade the InnoDB file format, meaning you are unable to use utf8mb4
+
+2. Make sure the following InnoDB settings are set on your MySQL server:
 
    a. MySQL 8.0 or later::
 
@@ -29,16 +53,16 @@ installation needs to be tweaked a bit.
         innodb_file_format=barracuda
         innodb_file_per_table=1
 
-2. Restart the MySQL server in case you changed the configuration in step 1.
-3. Change your databases character set and collation::
+3. Restart the MySQL server in case you changed the configuration in step 1.
+4. Change your databases character set and collation::
 
     ALTER DATABASE nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
-4. Set the ``mysql.utf8mb4`` config to true in your config.php::
+5. Set the ``mysql.utf8mb4`` config to true in your config.php::
 
     $ sudo -u www-data php occ config:system:set mysql.utf8mb4 --type boolean --value="true"
 
-5. Convert all existing tables to the new collation by running the repair step::
+6. Convert all existing tables to the new collation by running the repair step::
 
     $ sudo -u www-data php occ maintenance:repair
 


### PR DESCRIPTION
innodb_file_format=Barracuda is required for utf8mb4, some hosts/servers might not use this file format. It is important to check before upgrading.

See the issue on the Nextcloud forum here: https://help.nextcloud.com/t/revert-from-utfmb4/55164/2