### PR TITLE
Bump minium pqsql version to 9.5

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -23,7 +23,7 @@ For best performance, stability and functionality we have documented some recomm
 +------------------+-----------------------------------------------------------------------+
 | Database         | - **MySQL or MariaDB 5.5+** (recommended)                             |
 |                  | - Oracle Database 11g (*only as part of an enterprise subscription*)  |
-|                  | - PostgreSQL 9/10                                                     |
+|                  | - PostgreSQL 9.5/9.6/10                                               |
 |                  | - SQLite (*only recommended for testing and minimal-instances*)       |             
 +------------------+-----------------------------------------------------------------------+
 | Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |


### PR DESCRIPTION
Ref: https://github.com/nextcloud/server/issues/15613

Nextcloud 16+ uses upsert for some queries on postgresql. Upsert is available since postgres 9.5. 