### PR TITLE
Add example of client which doesn't support 2FA

### DIFF
--- a/user_manual/user_2fa.rst
+++ b/user_manual/user_2fa.rst
@@ -78,6 +78,7 @@ Using client applications with two-factor authentication
 
 Once you have enabled 2FA, your clients will no longer be able to connect with
 just your password unless they also have support for two-factor authentication.
+One example of a client which don't support 2FA include the Calendar app on MacOS.
 To solve this, you should generate device specific passwords for them. See 
 :doc:`session_management` for more information on how to do this.
 


### PR DESCRIPTION
More info, see https://github.com/nextcloud/twofactor_gateway/issues/249#event-2443339194

It was confusing/difficult for me to set up my CalDav client on macOS, as I was completely unaware of app passwords. This is an attempt to improve documentation to help other people down the line.

