### PR TITLE
Add hash module to required list

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -105,6 +105,7 @@ Required:
 * PHP module curl
 * PHP module dom
 * PHP module GD
+* PHP module hash
 * PHP module iconv
 * PHP module JSON
 * PHP module libxml (Linux package libxml2 must be >=2.7.0)

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -105,7 +105,7 @@ Required:
 * PHP module curl
 * PHP module dom
 * PHP module GD
-* PHP module hash
+* PHP module hash (only on FreeBSD)
 * PHP module iconv
 * PHP module JSON
 * PHP module libxml (Linux package libxml2 must be >=2.7.0)


### PR DESCRIPTION
Added the PHP hash module to the list of required modules. 

Nextcloud won't work without the PHP module for hashing.