### PR TITLE
Varying capitalization

### DIFF
--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -134,7 +134,7 @@ VirtualHost file::
    all installed browsers.
 
 This example configuration will make all subdomains only accessible via HTTPS.
-If you have subdomains not accessible via HTTPS, remove ``includeSubdomains;``.
+If you have subdomains not accessible via HTTPS, remove ``includeSubDomains``.
 
 This requires the ``mod_headers`` extension in Apache.
 


### PR DESCRIPTION
Settled for "includeSubDomains" over "includeSubdomains" as also found on Mozilla docs https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

Furthermore removed semicolon as it doesn't appear in the Apache config