### PR TITLE
Update to rsync command for backups

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -33,7 +33,7 @@ Backup folders
 Simply copy your config, data and theme folders (or even your whole Nextcloud install and data folder) to a place outside of
 your Nextcloud environment. You could use this command::
 
-    rsync -Aavx nextcloud/ nextcloud-dirbkp_`date +"%Y%m%d"`/
+    sudo rsync -av nextcloud/ nextcloud-dirbkp_`date +"%Y%m%d"`/
 
 Backup database
 ---------------


### PR DESCRIPTION
Firstly, I removed -A because the man page prohibits the use of -A and -a together. The need for -a for archiving is clear. The need for ACL in this command provided by the documentation is not clear. In this sense the need for -a wins over -A.

Secondly, I removed -x as users may have mounted drives or semantic links to other drives. The explicit prohibition of rsync accessing those drives in this documentation page isn't clear.

Lastly, I added the requirement of sudo as the Nextcloud folder in /var/www/nextcloud is owned by the Apache www-data group. Without sudo a privilege related error occurs.