### PR TITLE
Docu: Change background job cycle from 5 min to 15 min

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -64,17 +64,17 @@ Using the operating system cron feature is the preferred method for executing
 regular tasks.  This method enables the execution of scheduled jobs without the
 inherent limitations the Web server might have.
 
-To run a cron job on a \*nix system, every 5 minutes, under the default Web
+To run a cron job on a \*nix system, every 15 minutes, under the default Web
 server user (often, ``www-data`` or ``wwwrun``), you must set up the following
 cron job to call the **cron.php** script::
 
   # crontab -u www-data -e
-  */5  *  *  *  * php -f /var/www/nextcloud/cron.php
+  */15  *  *  *  * php -f /var/www/nextcloud/cron.php
 
 You can verify if the cron job has been added and scheduled by executing::
 
   # crontab -u www-data -l
-  */5  *  *  *  * php -f /var/www/nextcloud/cron.php
+  */15  *  *  *  * php -f /var/www/nextcloud/cron.php
 
 .. note:: You have to replace the path ``/var/www/nextcloud/cron.php`` with the
           path to your current Nextcloud installation.
@@ -109,17 +109,17 @@ Replace the user ``www-data`` with the user of your http server and ``/var/www/n
 **nextcloudcron.timer** should look like this::
 
   [Unit]
-  Description=Run Nextcloud cron.php every 5 minutes
+  Description=Run Nextcloud cron.php every 15 minutes
   
   [Timer]
-  OnBootSec=5min
-  OnUnitActiveSec=5min
+  OnBootSec=15min
+  OnUnitActiveSec=15min
   Unit=nextcloudcron.service
   
   [Install]
   WantedBy=timers.target
 
-The important parts in the timer-unit are ``OnBootSec`` and ``OnUnitActiveSec``. ``OnBootSec`` will start the timer 5 minutes after boot, otherwise you would have to start it manually after every boot. ``OnUnitActiveSec`` will set a 5 minute timer after the service-unit was last activated.
+The important parts in the timer-unit are ``OnBootSec`` and ``OnUnitActiveSec``. ``OnBootSec`` will start the timer 15 minutes after boot, otherwise you would have to start it manually after every boot. ``OnUnitActiveSec`` will set a 15 minute timer after the service-unit was last activated.
 
 Now all that is left is to start and enable the timer by running this command::
 


### PR DESCRIPTION
The NC configuration page /index.php/settings/admin recommends a 15 min cycle for background jobs.
Change the documentation accordingly (from 5 min to 15 min).

fix  #1587