### PR TITLE
Update background_jobs_configuration.rst

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -96,6 +96,7 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
 
   [Unit]
   Description=Nextcloud cron.php job
+  After=mysql.service
   
   [Service]
   User=www-data

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -96,17 +96,13 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
 
   [Unit]
   Description=Nextcloud cron.php job
-  After=mysql.service
   
   [Service]
   User=www-data
   ExecStart=/usr/bin/php -f /var/www/nextcloud/cron.php            
-  
-  [Install]
-  WantedBy=basic.target
 
 Replace the user ``www-data`` with the user of your http server and ``/var/www/nextcloud/cron.php`` with the location of **cron.php** in your nextcloud directory.  
-Replace ``mysql.service`` with the name of the database service you are using. Note: ``mysql.service`` controls both the actual MySQL as well as MariaDB on Ubuntu so you can use the above line for either. For PostgreSQL you could use ``After=postgresql.service``. In the case of SQLite simply omit the line.
+Note that the **.service** unit file does not need an ``[Install]`` section. Please check your setup because we recommended it in earlier versions of this admin manual.  
 
 **nextcloudcron.timer** should look like this::
 
@@ -127,6 +123,6 @@ Now all that is left is to start and enable the timer by running this command::
 
   systemctl enable --now nextcloudcron.timer
 
-When the option ``--now`` is used with ``enable``, the resp. unit will also be started.
+When the option ``--now`` is used with ``enable``, the respective unit will also be started.
 
 .. note:: Selecting the option ``Cron`` in the admin menu for background jobs is not mandatory, because once `cron.php` is executed from the command line or cron service it will set it automatically to ``Cron``.

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -101,8 +101,9 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   User=www-data
   ExecStart=/usr/bin/php -f /var/www/nextcloud/cron.php            
 
-Replace the user ``www-data`` with the user of your http server and ``/var/www/nextcloud/cron.php`` with the location of **cron.php** in your nextcloud directory.  
-Note that the **.service** unit file does not need an ``[Install]`` section. Please check your setup because we recommended it in earlier versions of this admin manual.  
+Replace the user ``www-data`` with the user of your http server and ``/var/www/nextcloud/cron.php`` with the location of **cron.php** in your nextcloud directory.
+
+Note that the **.service** unit file does not need an ``[Install]`` section. Please check your setup because we recommended it in earlier versions of this admin manual.
 
 **nextcloudcron.timer** should look like this::
 

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -105,7 +105,8 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   [Install]
   WantedBy=basic.target
 
-Replace the user ``www-data`` with the user of your http server and ``/var/www/nextcloud/cron.php`` with the location of **cron.php** in your nextcloud directory.
+Replace the user ``www-data`` with the user of your http server and ``/var/www/nextcloud/cron.php`` with the location of **cron.php** in your nextcloud directory.  
+Replace ``mysql.service`` with the name of the database service you are using. Note: ``mysql.service`` controls both the actual MySQL as well as MariaDB on Ubuntu so you can use the above line for either. For PostgreSQL you could use ``After=postgresql.service``. In the case of SQLite simply omit the line.
 
 **nextcloudcron.timer** should look like this::
 


### PR DESCRIPTION
Adjust `nextcloudcron.service` to wait for `mysql.service` dependency before starting. This prevents errors during a reboot.  
This references: https://github.com/nextcloud/documentation/issues/1584#issuecomment-524545159