### PR TITLE
mysql_4byte_support: extra maintenance steps

### DIFF
--- a/admin_manual/configuration_database/mysql_4byte_support.rst
+++ b/admin_manual/configuration_database/mysql_4byte_support.rst
@@ -53,18 +53,27 @@ installation needs to be tweaked a bit.
         innodb_file_format=barracuda
         innodb_file_per_table=1
 
-3. Restart the MySQL server in case you changed the configuration in step 1.
-4. Change your databases character set and collation::
-
+3. Open a shell, change dir (change ``/var/www/nextcloud`` to your nextcloud location if needed), and put your nextcloud instance in maintenance mode, if it isn't already::
+  
+   $ cd /var/www/nextcloud
+   $ sudo -u www-data php occ maintenance:mode --on
+  
+4. Restart the MySQL server in case you changed the configuration in step 1.
+5. Change your databases character set and collation::
+  
     ALTER DATABASE nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-
-5. Set the ``mysql.utf8mb4`` config to true in your config.php::
+  
+6. Set the ``mysql.utf8mb4`` config to true in your config.php::
 
     $ sudo -u www-data php occ config:system:set mysql.utf8mb4 --type boolean --value="true"
 
-6. Convert all existing tables to the new collation by running the repair step::
+7. Convert all existing tables to the new collation by running the repair step::
 
     $ sudo -u www-data php occ maintenance:repair
+
+8. Disable maintenance mode::
+
+   $ sudo -u www-data php occ maintenance:mode --off
 
 Now you should be able to use Emojis in your file names, calendar events, comments and many more.
 

--- a/admin_manual/configuration_database/mysql_4byte_support.rst
+++ b/admin_manual/configuration_database/mysql_4byte_support.rst
@@ -53,7 +53,7 @@ installation needs to be tweaked a bit.
         innodb_file_format=barracuda
         innodb_file_per_table=1
 
-3. Open a shell, change dir (change ``/var/www/nextcloud`` to your nextcloud location if needed), and put your nextcloud instance in maintenance mode, if it isn't already::
+3. Open a shell, change dir (adjust ``/var/www/nextcloud`` to your nextcloud location if needed), and put your nextcloud instance in maintenance mode, if it isn't already::
   
    $ cd /var/www/nextcloud
    $ sudo -u www-data php occ maintenance:mode --on


### PR DESCRIPTION
Make sure we `cd` to our nextcloud location
Enable and disable maintenance mode explicitly
Fixes #1572