### PR TITLE
specify needed phpunit version

### DIFF
--- a/developer_manual/app/tutorial.rst
+++ b/developer_manual/app/tutorial.rst
@@ -832,7 +832,7 @@ We can and should also create a test for the **NoteService** class:
 
     }
 
-If `PHPUnit is installed <https://phpunit.de/>`_ we can run the tests inside **notestutorial/** with the following command::
+If `PHPUnit in version 8 is installed <https://phpunit.de/>`_ we can run the tests inside **notestutorial/** with the following command::
 
     phpunit
 


### PR DESCRIPTION
There is no mentioning, that one needs phpunit in an old version. Tutorials are for noobs like me and this eats a lot of time figuring out. 
https://help.nextcloud.com/t/generated-app-fails-phpunit-with-phpunit-autoload-php/30703