### PR TITLE
Adapt Updates to nginx configuration

### DIFF
--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -12,10 +12,8 @@ versions linked.
 Updates to Nginx configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* In the Nginx configuration the Same-Origin header was removed. This is now
-  handled in PHP and keeping it will result in a wrong header. Please remove
-  those lines in your Nginx config:
-  ``add_header X-Frame-Options "SAMEORIGIN";``
+* In the Nginx configuration the Same-Origin header was added. Please add
+  this line to your Nginx config: ``add_header X-Frame-Options "SAMEORIGIN" always;``
   See :doc:`installation/nginx`
 * For improvements in serving HTTP requests the Nginx configuration now has
   HTTP 2 enabled. Please update your Nginx config accordingly. See


### PR DESCRIPTION
Signed-off-by: Bernhard Ostertag <bernieo.github@gmx.de>

Nextcloud 17 adds the Same-Origin header which was removed with Nextcloud 12.
ref #1597 (which should IMHO be merged before release of Nextcloud 17)