### PR TITLE
Adds a link to translation page

### DIFF
--- a/user_manual/index.rst
+++ b/user_manual/index.rst
@@ -24,3 +24,5 @@ their respective manuals:
 
 .. _`Nextcloud Desktop Client`: https://docs.nextcloud.com/desktop/2.3/
 .. _`Nextcloud Android App`: https://docs.nextcloud.com/android/
+
+`Help translate <https://www.transifex.com/indiehosters/nextcloud-user-documentation/>`_.


### PR DESCRIPTION
Relates to https://github.com/nextcloud/documentation/issues/216

I think it would make sense to put this transifex project under Nextcloud organisation. But I can keep it if you prefer, as you want.