### PR TITLE
Remove SAMEORIGIN header from nginx config doc

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -170,7 +170,6 @@ webroot of your nginx installation. In this example it is
           add_header Referrer-Policy "no-referrer" always;
           add_header X-Content-Type-Options "nosniff" always;
           add_header X-Download-Options "noopen" always;
-          add_header X-Frame-Options "SAMEORIGIN" always;
           add_header X-Permitted-Cross-Domain-Policies "none" always;
           add_header X-Robots-Tag "none" always;
           add_header X-XSS-Protection "1; mode=block" always;
@@ -231,7 +230,6 @@ your nginx installation.
       add_header Referrer-Policy "no-referrer" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-Download-Options "noopen" always;
-      add_header X-Frame-Options "SAMEORIGIN" always;
       add_header X-Permitted-Cross-Domain-Policies "none" always;
       add_header X-Robots-Tag "none" always;
       add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
Removes the SAMEORIGIN header from the nginx configuration documentation as this is handled by PHP directly.

Fixes #1701