### PR TITLE
Removed `X-Frame-Options: SAMEORIGIN` header

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -69,7 +69,6 @@ webroot of your nginx installation. In this example it is
       add_header Referrer-Policy "no-referrer" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-Download-Options "noopen" always;
-      add_header X-Frame-Options "SAMEORIGIN" always;
       add_header X-Permitted-Cross-Domain-Policies "none" always;
       add_header X-Robots-Tag "none" always;
       add_header X-XSS-Protection "1; mode=block" always;
@@ -170,7 +169,6 @@ webroot of your nginx installation. In this example it is
           add_header Referrer-Policy "no-referrer" always;
           add_header X-Content-Type-Options "nosniff" always;
           add_header X-Download-Options "noopen" always;
-          add_header X-Frame-Options "SAMEORIGIN" always;
           add_header X-Permitted-Cross-Domain-Policies "none" always;
           add_header X-Robots-Tag "none" always;
           add_header X-XSS-Protection "1; mode=block" always;
@@ -231,7 +229,6 @@ your nginx installation.
       add_header Referrer-Policy "no-referrer" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-Download-Options "noopen" always;
-      add_header X-Frame-Options "SAMEORIGIN" always;
       add_header X-Permitted-Cross-Domain-Policies "none" always;
       add_header X-Robots-Tag "none" always;
       add_header X-XSS-Protection "1; mode=block" always;
@@ -336,7 +333,6 @@ your nginx installation.
               add_header Referrer-Policy "no-referrer" always;
               add_header X-Content-Type-Options "nosniff" always;
               add_header X-Download-Options "noopen" always;
-              add_header X-Frame-Options "SAMEORIGIN" always;
               add_header X-Permitted-Cross-Domain-Policies "none" always;
               add_header X-Robots-Tag "none" always;
               add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
Some headers don't need to be set in nginx anymore, since they are hardcoded into Nextcloud. This causes problems with the header `X-Frame-Options: SAMEORIGIN`, which should not be set twice.

See:
* https://docs.nextcloud.com/server/17/admin_manual/installation/harden_server.html#serve-security-related-headers-by-the-web-server
* https://docs.nextcloud.com/server/12/admin_manual/release_notes.html#updates-to-nginx-configuration
* https://github.com/nextcloud/server/issues/4764
* https://blog.qualys.com/securitylabs/2015/10/20/clickjacking-a-common-implementation-mistake-that-can-put-your-websites-in-danger