### PR TITLE
add a section about GDPR relevant information

### DIFF
--- a/admin_manual/contents.rst
+++ b/admin_manual/contents.rst
@@ -18,3 +18,4 @@ Table of contents
     configuration_mimetypes/index
     maintenance/index
     issues/index
+    gdpr/index

--- a/admin_manual/gdpr/cookies.rst
+++ b/admin_manual/gdpr/cookies.rst
@@ -1,0 +1,32 @@
+=======
+Cookies
+=======
+
+.. sectionauthor:: Björn Schießle <bjoern@nextcloud.com>
+.. _cookies:
+
+Nextcloud only stores cookies needed for Nextcloud to work properly. All cookies comes from your Nextcloud server directly, no 3rd-party cookies will be send to your system. Regarding GDPR, `only data which contain personal data are relevant`_.
+
+.. _`only data which contain personal data are relevant`: https://gdpr-info.eu/recitals/no-26/
+
+
+Cookies stored by Nextcloud
+===========================
+
+====================  ====================================  ================
+ Cookie               Data Stored                             Lifetime
+====================  ====================================  ================
+ Session cookie        - session ID                          24 minutes
+                       - secret token (used to decrypt 
+                         the session on the server)
+ Same-site cookies     no user-related data are stored,      forever
+                       all same-site cookies are the same
+                       for all users on all Nextcloud 
+                       instances
+ Remember-me cookie    - user id                             15 days (can be
+                       - original session id                 configured)
+                       - remember token                       
+====================  ====================================  ================
+
+The same-site cookies are used to determine how a request reaches the Nextcloud server. We use to prevest CSRF attacks. No identifable information is stored in those.
+The rest of the cookies are strickly used to identify the user to the system.

--- a/admin_manual/gdpr/index.rst
+++ b/admin_manual/gdpr/index.rst
@@ -1,0 +1,9 @@
+====
+GDPR
+==== 
+
+.. toctree::
+    :maxdepth: 2
+
+    cookies
+    


### PR DESCRIPTION
start with documentation about cookies, more can be added later. E.g. it might make sense to also have a few sentence about our GDPR tools

@NinaNC what do you think?
@rullzer can you double-check the technical details?