### PR TITLE
Added info about the optional nextcloud path

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -8,9 +8,9 @@ connect Linux, macOS, Windows, and mobile devices to your Nextcloud server via
 WebDAV. Before we get into configuring WebDAV, let's take a quick look at the
 recommended way of connecting client devices to your Nextcloud servers.
 
-.. note:: In the following examples, you should adjust **example.com/nextcloud** to the
-   URL of your Nextcloud server installation (omit the directory if in root of doamin), and 
-   USERNAME with the username of the connecting user.
+.. note:: In the following examples, you should replace **example.com/nextcloud** with the
+   URL of your Nextcloud server (omit the directory part if the installation is 
+   in the root of your domain), and "USERNAME" with the username of the connecting user.
 
    See the webdav url (bottom left, settings) on your Nextcloud.
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -8,9 +8,9 @@ connect Linux, macOS, Windows, and mobile devices to your Nextcloud server via
 WebDAV. Before we get into configuring WebDAV, let's take a quick look at the
 recommended way of connecting client devices to your Nextcloud servers.
 
-.. note:: In the following examples, You must adjust **example.com/** to the
-   URL of your Nextcloud server installation. And USERNAME is the userid of the
-   connecting user.
+.. note:: In the following examples, you should adjust **example.com/nextcloud** to the
+   URL of your Nextcloud server installation (omit the directory if in root of doamin), and 
+   USERNAME with the username of the connecting user.
 
    See the webdav url (bottom left, settings) on your Nextcloud.
 


### PR DESCRIPTION
The current document does not mention that "/nextcloud" path is only optional, and not needed if the installation is present at the root directory of the domain. Also, the wording was quite off, cleaned it up a bit.