### PR TITLE
initial Flow 'documentation'

### DIFF
--- a/developer_manual/app/flow.rst
+++ b/developer_manual/app/flow.rst
@@ -4,5 +4,6 @@ Nextcloud Flow
 
 Nextcloud Flow is the workflow engine of Nextcloud. It offers flexible, user-defined event-based task automation. Apps can register events or triggers which can start a flow, as well as actions which get executed once a trigger is hit and the constraints are satisfied.
 
-At 36c3 Arthur gave a talk explaining Flow and `how to write actions and triggers. <https://mirror.eu.oneandone.net/projects/media.ccc.de/congress/2019/h264-sd/36c3-oio-174-eng-Building_Nextcloud_Flow_sd.mp4>`_.
+At 36c3 Arthur gave a talk explaining Flow and `how to write actions and triggers. <https://mirror.eu.oneandone.net/projects/media.ccc.de/congress/2019/h264-sd/36c3-oio-174-eng-Building_Nextcloud_Flow_sd.mp4>`_ You can `find the slides of his talk here. <https://nextcloud.com/wp-content/themes/next/assets/files/Building_nextcloud_flow.pdf>`_
 
+Contributions to this documentation are, as always, very welcome!

--- a/developer_manual/app/flow.rst
+++ b/developer_manual/app/flow.rst
@@ -1,0 +1,8 @@
+==============
+Nextcloud Flow
+==============
+
+Nextcloud Flow is the workflow engine of Nextcloud. It offers flexible, user-defined event-based task automation. Apps can register events or triggers which can start a flow, as well as actions which get executed once a trigger is hit and the constraints are satisfied.
+
+At 36c3 Arthur gave a talk explaining Flow and `how to write actions and triggers. <https://mirror.eu.oneandone.net/projects/media.ccc.de/congress/2019/h264-sd/36c3-oio-174-eng-Building_Nextcloud_Flow_sd.mp4>`_.
+

--- a/developer_manual/app/flow.rst
+++ b/developer_manual/app/flow.rst
@@ -4,6 +4,6 @@ Nextcloud Flow
 
 Nextcloud Flow is the workflow engine of Nextcloud. It offers flexible, user-defined event-based task automation. Apps can register events or triggers which can start a flow, as well as actions which get executed once a trigger is hit and the constraints are satisfied.
 
-At 36c3 Arthur gave a talk explaining Flow and `how to write actions and triggers. <https://mirror.eu.oneandone.net/projects/media.ccc.de/congress/2019/h264-sd/36c3-oio-174-eng-Building_Nextcloud_Flow_sd.mp4>`_ You can `find the slides of his talk here. <https://nextcloud.com/wp-content/themes/next/assets/files/Building_nextcloud_flow.pdf>`_
+At 36c3 blizzz gave a talk explaining Flow and `how to write actions and triggers. <https://mirror.eu.oneandone.net/projects/media.ccc.de/congress/2019/h264-sd/36c3-oio-174-eng-Building_Nextcloud_Flow_sd.mp4>`_ You can `find the slides of his talk here. <https://nextcloud.com/wp-content/themes/next/assets/files/Building_nextcloud_flow.pdf>`_
 
 Contributions to this documentation are, as always, very welcome!

--- a/developer_manual/app/index.rst
+++ b/developer_manual/app/index.rst
@@ -24,6 +24,7 @@ App development
    backgroundjobs
    settings
    notifications
+   flow
    logging
    repair
    publicpage


### PR DESCRIPTION
adds super basic description and link to Arthur's talk at 36C3. TODO:
* [x] add to navigation
* [x] add link to presentation

After that we'll turn this into some pretty text for those who don't like watching videos, but I'd like to get this at least live first. Something beats nothing, yes?

Signed-off-by: Jos Poortvliet <jospoortvliet@gmail.com>