### PR TITLE
Fix formatting of occ log:manage options

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -913,8 +913,8 @@ different log file path. Set your rotation by log file size in bytes with
 ``log:manage`` sets your logging backend, log level, and timezone. The defaults 
 are ``file``, ``warning``, and ``UTC``. Available options are:
 
-* --backend [file, syslog, errorlog, systemd]
-* --level [debug, info, warning, error, fatal]
+* ``--backend`` [file, syslog, errorlog, systemd]
+* ``--level`` [debug, info, warning, error, fatal]
 
 .. _maintenance_commands_label:
    

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -913,8 +913,8 @@ different log file path. Set your rotation by log file size in bytes with
 ``log:manage`` sets your logging backend, log level, and timezone. The defaults 
 are ``file``, ``warning``, and ``UTC``. Available options are:
 
-* ``--backend`` [file, syslog, errorlog, systemd]
-* ``--level`` [debug, info, warning, error, fatal]
+* ``--backend [file, syslog, errorlog, systemd]``
+* ``--level [debug|info|warning|error|fatal]``
 
 .. _maintenance_commands_label:
    


### PR DESCRIPTION
The double dash (--) wasn’t being rendered correctly in the [admin manual/occ logging command section](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/occ_command.html?#logging-commands-label):

• –backend [file, syslog, errorlog, systemd]
• –level [debug, info, warning, error]

is now

• `–-backend` [file, syslog, errorlog, systemd]
• `–-level` [debug, info, warning, error]