### PR TITLE
Replace Workflow with Tag Management (v17)

### DIFF
--- a/admin_manual/file_workflows/retention.rst
+++ b/admin_manual/file_workflows/retention.rst
@@ -9,7 +9,7 @@ Example
 -------
 
 After installing the Retention app as described in :doc:`../apps_management`
-navigate to the configuration and locate the Workflow settings.
+navigate to the configuration and locate the Tag management settings.
 
     .. figure:: images/retention_sample.png
        :alt: Sample rule to delete files after 14 days.


### PR DESCRIPTION
For v16 and v17 it shouldn't be "Workflow". It is located in Tag management instead. Probably the same for older versions, can't tell.