### PR TITLE
Fixing small typo in docs

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -646,7 +646,7 @@ confirm your paths, for example::
 If any of your system environment variables are not present in the file then
 you must add them.
 
-Alternatively it is possible to use the environemt variables of your system by modifying
+Alternatively it is possible to use the environent variables of your system by modifying
 
     /etc/php/7.0/fpm/pool.d/www.conf
 

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -646,7 +646,7 @@ confirm your paths, for example::
 If any of your system environment variables are not present in the file then
 you must add them.
 
-Alternatively it is possible to use the environent variables of your system by modifying
+Alternatively it is possible to use the environment variables of your system by modifying
 
     /etc/php/7.0/fpm/pool.d/www.conf
 


### PR DESCRIPTION
'environment' was spelled 'environmemt' on line 649