### PR TITLE
Add note about Collabora and OnlyOffice for external storage

### DIFF
--- a/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
+++ b/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
@@ -35,7 +35,8 @@ credentials of the user to connect to the storage. These are not stored anywhere
 on the server, but rather in the user session, giving increased security. The
 drawbacks are that sharing is disabled when this mechanism is in use, as
 Nextcloud has no access to the storage credentials, and background file scanning
-does not work.
+does not work. Other services that might request the file tough a different request 
+like Collabora Online or OnlyOffice will also not be able to open files in that case.
 
 The **Log-in credentials, save in database** mechanism uses the Nextcloud login
 credentials of the user to connect to the storage. These are stored in the


### PR DESCRIPTION
Since the Office suites to requests to Nextcloud themselves without the user session being active, they are not able to open files that are stored on external storage when the credentials are stored in the user session.