### PR TITLE
Add MySQL Header and MariaDB note

### DIFF
--- a/admin_manual/configuration_database/mysql_4byte_support.rst
+++ b/admin_manual/configuration_database/mysql_4byte_support.rst
@@ -2,6 +2,12 @@
 Enabling MySQL 4-byte support
 =============================
 
+MySQL
+---------------
+
+.. note::
+    See below if you are using MariaDB
+
 .. note::
 
     Be sure to backup your database before performing this database upgrade.


### PR DESCRIPTION
Add MySQL Header and MariaDB note to ensure users will know there are separate steps provided for MariaDB installations.