### PR TITLE
Fix database file name in backup documentation

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -52,7 +52,7 @@ SQLite
 ^^^^^^
 ::
 
-    sqlite3 data/owncloud.db .dump > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
+    sqlite3 data/nextcloud.db .dump > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
 PostgreSQL
 ^^^^^^^^^^


### PR DESCRIPTION
I tried following the documentation and realized the file name was wrong (owncloud instead of nextcloud).