### PR TITLE
Update example_centos.rst

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -84,15 +84,22 @@ Next install the PHP modules needed for this install. Remember, because this is 
         php-pecl-apcu php-mysqlnd php-opcache php-json php-zip
 
 
+
 Manually building redis/imagick (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    yum install -y php-pear gcc curl-devel php-devel zlib-devel pcre-devel make
+::
+
+    yum install -y php-pear gcc curl-devel zlib-devel pcre-devel make
     pecl install redis
 
+
+::
+
     yum config-manager --set-enabled PowerTools
-    yum install -y Imagemagick ImageMagick-devel
+    yum install -y Imagemagick ImageMagick-devel php-devel
     pecl install imagick
+
 
 After installing the extensions make sure to load the extensions in your php.ini file with:
 


### PR DESCRIPTION
Hi, while doing a test installation on Centos 8.1 x64, I noticed that php-devel package installation failed because PowerTools repo wasn't enabled, after enabling it installation worked fine; while doing this update in document (very useful indeed, anyway) I also fixed some minor flaws