### PR TITLE
Fix resource-accessability

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -118,10 +118,6 @@ webroot of your nginx installation. In this example it is
       # This module is currently not supported.
       #pagespeed off;
 
-      location / {
-          rewrite ^ /index.php;
-      }
-
       location ~ ^\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
           deny all;
       }
@@ -179,10 +175,17 @@ webroot of your nginx installation. In this example it is
           access_log off;
       }
 
-      location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$ {
-          try_files $uri /index.php$request_uri;
-          # Optional: Don't log access to other assets
-          access_log off;
+      location / {
+          location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$ {
+              # Optional: Don't log access to other assets
+              access_log off;
+          }
+
+          try_files $uri @fallback;
+      }
+
+      location @fallback {
+          rewrite ^ /index.php;
       }
   }
 


### PR DESCRIPTION
Hey guys
This PR is related to following issue in the https://github.com/nextcloud/docker repository:
https://github.com/nextcloud/docker/issues/1055
A pull request concerning this issue is already present:
https://github.com/nextcloud/docker/pull/1056
I was facing the issue that sometimes when loading ressources an HTTP 302 code was returned which redirected me to the main page.

Rather than solving this issue by adding `.mp4` and `.webm` to the location-directive I'd rather recommend to pass all requests to the files directly.

This change can be implemented by accepting this PR.