### PR TITLE
Add new and changed apis in 19

### DIFF
--- a/developer_manual/app/upgrade-guide.rst
+++ b/developer_manual/app/upgrade-guide.rst
@@ -42,6 +42,26 @@ Symfony update
 
 Symfony was updated to `v4.4 <https://github.com/symfony/symfony/blob/4.4/CHANGELOG-4.4.md>`_. The most important change for apps is to return an int value from CLI commands. Returning null (explicitly or implicitly) won't be allowed in future versions of Symfony.
 
+New APIs
+********
+
+* ``\OCP\Authentication\Events\LoginFailedEvent`` class added
+* ``\OCP\Comments\IComment::getReferenceId`` method added
+* ``\OCP\Comments\IComment::setReferenceId`` method added
+* ``\OCP\Contacts\Events\ContactInteractedWithEvent`` class added
+* ``\OCP\EventDispatcher\IEventDispatcher::removeListener`` method added
+* ``\OCP\ITags::TAG_FAVORITE`` constant added
+* ``\OCP\Mail\Events\BeforeMessageSent`` class added
+* ``\OCP\Lock\LockedException::getExistingLock`` method added
+* ``\OCP\Share\Events\VerifyMountPointEvent`` class added
+* ``\OCP\Share\IManager::allowEnumeration`` method added
+* ``\OCP\Share\IManager::limitEnumerationToGroups`` method added
+
+Changed APIs
+************
+
+* ``\OCP\User\Events\BeforeUserLoggedInEvent::getUsername`` now correctly returns a string and not an `\OCP\IUser`
+
 
 Upgrading to Nextcloud 18
 -------------------------


### PR DESCRIPTION
These are all the changes I could find in `lib/public` between stable18 and 19

Ref https://github.com/nextcloud/server/pull/19845
Ref https://github.com/nextcloud/server/pull/19890
Ref https://github.com/nextcloud/server/pull/19075
Ref https://github.com/nextcloud/server/pull/19670
Ref https://github.com/nextcloud/server/pull/19412
Ref https://github.com/nextcloud/server/pull/14722
Ref https://github.com/nextcloud/server/pull/19746
Ref https://github.com/nextcloud/server/pull/19321
Ref https://github.com/nextcloud/server/pull/19569