### PR TITLE
Add NGINX reverse proxy code block

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -91,7 +91,7 @@ HAProxy
   http-request redirect location /remote.php/dav/ code 301 if url_discovery
 
 NGINX
-^^^^^^^
+^^^^^
 ::
 
     location /.well-known/carddav {

--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -90,6 +90,18 @@ HAProxy
   acl url_discovery path /.well-known/caldav /.well-known/carddav
   http-request redirect location /remote.php/dav/ code 301 if url_discovery
 
+NGINX
+^^^^^^^
+::
+
+    location /.well-known/carddav {
+        return 301 $scheme://$host/remote.php/dav;
+    }
+    
+    location /.well-known/caldav {
+        return 301 $scheme://$host/remote.php/dav;
+    }
+
 Example
 -------
 


### PR DESCRIPTION
Even if trivial, code block was missing for nginx as reverse proxy.