### PR TITLE
Revert "Fix database file name in backup documentation"

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -52,7 +52,7 @@ SQLite
 ^^^^^^
 ::
 
-    sqlite3 data/nextcloud.db .dump > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
+    sqlite3 data/owncloud.db .dump > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
 PostgreSQL
 ^^^^^^^^^^


### PR DESCRIPTION
Reverts nextcloud/documentation#1931, Close #1932, Close #1933, Close #1934 

The default name for sqlite database is still owncloud: https://github.com/nextcloud/server/blob/28f8eb5dba60a75f7e22debbdc26f1d3164deb18/lib/private/DB/ConnectionFactory.php#L44

Probably to not break installations on upgrade. It's possible to change that value. 