### PR TITLE
Update Primary Storage doc for OpenStack Swift v3

### DIFF
--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -91,7 +91,7 @@ V3 Authentication:
 		'arguments' => [
 			'autocreate' => true,
 			'user' => [
-				'name' => 'swift',
+				'name' => 'UserName',
 				'password' => 'Secr3tPaSSWoRdt7',
 				'domain' => [
 					'name' => 'Default',
@@ -99,7 +99,7 @@ V3 Authentication:
 			],
 			'scope' => [
 				'project' => [
-					'name' => 'OS_PROJECT_NAME',
+					'name' => 'TenantName',
 					'domain' => [
 						'name' => 'Default',
 					],


### PR DESCRIPTION
Add scope/project with TenantName, as discussed in #11264 comment https://github.com/nextcloud/server/issues/11264#issuecomment-457525893
This is necessary for OVH Object Storage. Not sure for other providers.


Followup to #1860 and #1850. It only adjusts the parameter names to be better readable.