### PR TITLE
Update example_centos.rst

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -82,13 +82,13 @@ Manually building redis/imagick (optional)
 
 ::
 
+    dnf config-manager --set-enabled PowerTools
+    
     dnf install -y php-pear gcc curl-devel php-devel zlib-devel pcre-devel make
     
     pecl install redis
-
-    dnf config-manager --set-enabled PowerTools
-
-    dnf install -y Imagemagick ImageMagick-devel
+    
+    dnf install -y ImageMagick ImageMagick-devel
     
     pecl install imagick
 


### PR DESCRIPTION
Enable PowerTools before php-devel / zlib-devel install so prerequisites (libedit-devel) can be installed.
Fix ImageMagick install (capitalization) to avoid "not found" error.