### PR TITLE
admin/configuration/caching: Added possibility that apc.enable_cli is configurable for cron job call only

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -59,7 +59,7 @@ Refresh your Nextcloud admin page, and the cache warning should disappear.
 
 .. warning:: APCu is disabled by default on CLI which could cause issues with nextcloud's
    cron jobs. Please make sure you set the ``apc.enable_cli`` to ``1`` on your ``php.ini``
-   config file.
+   config file or append ``--define apc.enable_cli=1`` to the cron job call.
 
 Redis
 -----


### PR DESCRIPTION
See man page `php(1)`:
```
--define foo[=bar]
-d foo[=bar]   Define INI entry foo with value bar
```

Some, like me, may find it is be better to enable APCu on php-cli only for certain services/cases and not globally. This PR adds the explanation how this can be achieved to the manual.

I tested this way on my Nextcloud's instances without any error thrown.