### PR TITLE
Document the need to symlink apps outside server root

### DIFF
--- a/admin_manual/apps_management.rst
+++ b/admin_manual/apps_management.rst
@@ -89,6 +89,13 @@ in that folder.
         ],
     ],
 
+.. note:: Apps paths can be located outside the server root.  However, for any
+   **path** outside the server root, you need to create a symlink in  the server
+   root that points **url** to **path**.
+   For instance, if **path** is ``/var/local/lib/nextcloud/apps``, and **url**
+   is ``/apps2``, then you would do this in the server root:
+   ``ln -sf /var/local/lib/nextcloud/apps ./apps2``
+
 Using a self hosted apps store
 ------------------------------
 


### PR DESCRIPTION
Document that any apps path outside the server root must be symlinked from inside the server root.

See https://github.com/nextcloud/server/issues/21292.