### PR TITLE
misspelled Imagemagik

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -88,7 +88,7 @@ Manually building redis/imagick (optional)
 
     dnf config-manager --set-enabled PowerTools
 
-    dnf install -y Imagemagick ImageMagick-devel
+    dnf install -y ImageMagick ImageMagick-devel
     
     pecl install imagick
 


### PR DESCRIPTION
dnf complains about not finding `Imagemagik` and suggests you would install `ImageMagik`