### PR TITLE
Update example_ubuntu.rst for Ubuntu 20.04 LTS

### DIFF
--- a/admin_manual/installation/example_ubuntu.rst
+++ b/admin_manual/installation/example_ubuntu.rst
@@ -1,23 +1,40 @@
 .. _ubuntu_installation_label:
 
-Example installation on Ubuntu 18.04 LTS
+Example installation on Ubuntu 20.04 LTS
 ========================================
 
-Or you can use .deb packages to install the required and recommended modules for a typical Nextcloud
+You can use .deb packages to install the required and recommended modules for a typical Nextcloud
 installation, using Apache and MariaDB, by issuing the following commands in a
 terminal::
 
-    apt-get install apache2 mariadb-server libapache2-mod-php7.2
-    apt-get install php7.2-gd php7.2-json php7.2-mysql php7.2-curl php7.2-mbstring
-    apt-get install php7.2-intl php-imagick php7.2-xml php7.2-zip
+    apt install apache2 mariadb-server libapache2-mod-php7.4
+    apt install php7.4-gd php7.4-mysql php7.4-curl php7.4-mbstring php7.4-intl
+    apt install php7.4-gmp php7.4-bcmath php-imagick php7.4-xml php7.4-zip
 
 * This installs the packages for the Nextcloud core system. 
   If you are planning on running additional apps, keep in mind that they might require additional
   packages.  See :ref:`prerequisites_label` for details.
 
-* At the installation of the MySQL/MariaDB server, you will be prompted to
-  create a root password. Be sure to remember your password as you will need it
-  during Nextcloud database setup.
+Now you need to create a database user and the database itself by using the
+MySQL command line interface. The database tables will be created by Nextcloud
+when you login for the first time.
+
+To start the MySQL command line mode use the following command and press the enter key when prompted for a password::
+
+  mysql -uroot -p
+
+Then a **MariaDB [root]>** prompt will appear. Now enter the following lines, replacing username and password with appropriate values, and confirm them with the enter key:
+
+::
+
+  CREATE USER 'username'@'localhost' IDENTIFIED BY 'password';
+  CREATE DATABASE IF NOT EXISTS nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+  GRANT ALL PRIVILEGES ON nextcloud.* TO 'username'@'localhost';
+  FLUSH PRIVILEGES;
+
+You can quit the prompt by entering::
+
+  quit;
 
 Now download the archive of the latest Nextcloud version:
 


### PR DESCRIPTION
This documentation has been outdated since Ubuntu 18.04 LTS (mysql/mariadb don't prompt for a root password, so you need to create a Nextcloud user), but it doesn't work on Ubuntu 20.04 LTS because it uses explicit PHP version numbers and it omits some recommended PHP modules for Nextcloud Hub 18 and 19.  I've updated the instructions to run on Ubuntu 20.04 LTS and have tested each step.

This page now leaves a new Ubuntu 20.04 LTS system in a state to continue the "Installation on Linux" steps starting with configuring Apache2 without errors.

Signed-off-by: Nathan Haines <nhaines@ubuntu.com>