### PR TITLE
increase php version to 7.4 in NGINX configuration example

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -34,7 +34,7 @@ webroot of your nginx installation. In this example it is
 
   upstream php-handler {
       server 127.0.0.1:9000;
-      #server unix:/var/run/php/php7.2-fpm.sock;
+      #server unix:/var/run/php/php7.4-fpm.sock;
   }
 
   server {
@@ -198,7 +198,7 @@ In this example the webroot is located at
 
   upstream php-handler {
       server 127.0.0.1:9000;
-      #server unix:/var/run/php/php7.2-fpm.sock;
+      #server unix:/var/run/php/php7.4-fpm.sock;
   }
 
   server {


### PR DESCRIPTION
PHP7.2 will be EOL on 30 Nov 2020, so the examples and instructions should match the recommended settings.

Other installation instructions may also need an update.

Signed-off-by: Eduard Veit <developer@ev21.de>