### PR TITLE
\OCP\BackgroundJob\Job::run is neither public nor static

### DIFF
--- a/developer_manual/app/backgroundjobs.rst
+++ b/developer_manual/app/backgroundjobs.rst
@@ -45,7 +45,7 @@ your job class of choice.
             parent::setInterval(3600);
         }
 
-        public static function run($arguments) {
+        protected function run($arguments) {
             $this->myService->doCron($arguments['uid']);
         }
 


### PR DESCRIPTION
Ref https://help.nextcloud.com/t/cannot-develop-own-backgroundtask-when-using-nextcloud-developer-documentation/83411
