### PR TITLE
Update system_requirements.rst

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -53,6 +53,7 @@ The following is currently required if you're running Nextcloud together with a 
 * "READ COMMITED" transaction isolation level (See: :ref:`db-transaction-label`)
 * Disabled or BINLOG_FORMAT = ROW configured Binary Logging (See: https://dev.mysql.com/doc/refman/5.7/en/binary-log-formats.html)
 * For **Emoji (UTF8 4-byte) support** see :doc:`../configuration_database/mysql_4byte_support`
+* Please make sure to create a database and a database user before installing Nextcloud. Nextcloud will not create the database by their own.
 
 Desktop client
 --------------


### PR DESCRIPTION
A partner had some problems installing Nextcloud, at the end we figured out they created a db user but not the database as such because it was never mentioned in our documentation. Not sure what's the right place and if we should have more detailed documentation for different databases. For now I added it to the requirements as a additional bullet point