### PR TITLE
Update nginx.rst -- Reworked the Nginx configs

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -76,11 +76,11 @@ webroot of your nginx installation. In this example it is
       gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
       gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
-      # Pagespeed is not supported by NextCloud, so if your server is built
+      # Pagespeed is not supported by Nextcloud, so if your server is built
       # with the `ngx_pagespeed` module, uncomment this line to disable it.
       #pagespeed off;
       
-      # HTTP response headers borrowed from NextCloud `.htaccess`
+      # HTTP response headers borrowed from Nextcloud `.htaccess`
       add_header Referrer-Policy                      "no-referrer"   always;
       add_header X-Content-Type-Options               "nosniff"       always;
       add_header X-Download-Options                   "noopen"        always;
@@ -188,7 +188,7 @@ Nextcloud in a subdir of the nginx webroot
 
 The following config should be used when Nextcloud is placed within a subdir of
 the webroot of your nginx installation.
-In this example the NextCloud files are located at
+In this example the Nextcloud files are located at
 ``/var/www/nextcloud`` and the Nextcloud instance is accessed via ``http(s)://cloud.example.com/nextcloud/``.
 The configuration differs from the "Nextcloud in webroot" configuration above in the following ways:
 
@@ -196,7 +196,7 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
 - The string ``/nextcloud`` is prepended to all prefix paths.
 - The URI ``/nextcloud`` is *aliased* to ``/var/www/nextcloud``, rather than the domain itself being *rooted* at ``/var/www/nextcloud``.
 - The blocks that handle requests for paths outside of ``/nextcloud``, i.e. ``/robots.txt``, ``/.well-known``, and hidden files, are pulled out of the ``location ~ ^/nextcloud($|/)`` block.
-- The block which handles `/.well-known` doesn't need a regex exception, since the rule which prevents users from accessing hidden folders at the root of the NextCloud installation no longer matches that path.
+- The block which handles `/.well-known` doesn't need a regex exception, since the rule which prevents users from accessing hidden folders at the root of the Nextcloud installation no longer matches that path.
 
 .. code-block:: nginx
 
@@ -267,11 +267,11 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
           gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
-          # Pagespeed is not supported by NextCloud, so if your server is built
+          # Pagespeed is not supported by Nextcloud, so if your server is built
           # with the `ngx_pagespeed` module, uncomment this line to disable it.
           #pagespeed off;
           
-          # HTTP response headers borrowed from NextCloud `.htaccess`
+          # HTTP response headers borrowed from Nextcloud `.htaccess`
           add_header Referrer-Policy                      "no-referrer"   always;
           add_header X-Content-Type-Options               "nosniff"       always;
           add_header X-Download-Options                   "noopen"        always;

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -41,67 +41,29 @@ webroot of your nginx installation. In this example it is
       listen 80;
       listen [::]:80;
       server_name cloud.example.com;
-      # enforce https
-      return 301 https://$server_name:443$request_uri;
+      
+      # Enforce HTTPS
+      return 301 https://$server_name$request_uri;
   }
 
   server {
-      listen 443 ssl http2;
+      listen 443      ssl http2;
       listen [::]:443 ssl http2;
       server_name cloud.example.com;
 
       # Use Mozilla's guidelines for SSL/TLS settings
       # https://mozilla.github.io/server-side-tls/ssl-config-generator/
-      # NOTE: some settings below might be redundant
-      ssl_certificate /etc/ssl/nginx/cloud.example.com.crt;
+      ssl_certificate     /etc/ssl/nginx/cloud.example.com.crt;
       ssl_certificate_key /etc/ssl/nginx/cloud.example.com.key;
 
-      # Add headers to serve security related headers
-      # Before enabling Strict-Transport-Security headers please read into this
-      # topic first.
-      #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-      #
+      # HSTS settings
       # WARNING: Only add the preload option once you read about
       # the consequences in https://hstspreload.org/. This option
       # will add the domain to a hardcoded list that is shipped
       # in all major browsers and getting removed from this list
       # could take several months.
-      add_header Referrer-Policy "no-referrer" always;
-      add_header X-Content-Type-Options "nosniff" always;
-      add_header X-Download-Options "noopen" always;
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header X-Permitted-Cross-Domain-Policies "none" always;
-      add_header X-Robots-Tag "none" always;
-      add_header X-XSS-Protection "1; mode=block" always;
-
-      # Remove X-Powered-By, which is an information leak
-      fastcgi_hide_header X-Powered-By;
-
-      # Path to the root of your installation
-      root /var/www/nextcloud;
-
-      location = /robots.txt {
-          allow all;
-          log_not_found off;
-          access_log off;
-      }
-
-      # The following 2 rules are only needed for the user_webfinger app.
-      # Uncomment it if you're planning to use this app.
-      #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-      #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-      # The following rule is only needed for the Social app.
-      # Uncomment it if you're planning to use this app.
-      #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-      location = /.well-known/carddav {
-        return 301 $scheme://$host:$server_port/remote.php/dav;
-      }
-      location = /.well-known/caldav {
-        return 301 $scheme://$host:$server_port/remote.php/dav;
-      }
-
+      #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
+      
       # set max upload size
       client_max_body_size 512M;
       fastcgi_buffers 64 4K;
@@ -114,75 +76,109 @@ webroot of your nginx installation. In this example it is
       gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
       gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
-      # Uncomment if your server is build with the ngx_pagespeed module
-      # This module is currently not supported.
+      # Pagespeed is not supported by NextCloud, so if your server is built
+      # with the `ngx_pagespeed` module, uncomment this line to disable it.
       #pagespeed off;
-
-      location / {
-          rewrite ^ /index.php;
+      
+      # HTTP response headers borrowed from NextCloud `.htaccess`
+      add_header Referrer-Policy                      "no-referrer"   always;
+      add_header X-Content-Type-Options               "nosniff"       always;
+      add_header X-Download-Options                   "noopen"        always;
+      add_header X-Frame-Options                      "SAMEORIGIN"    always;
+      add_header X-Permitted-Cross-Domain-Policies    "none"          always;
+      add_header X-Robots-Tag                         "none"          always;
+      add_header X-XSS-Protection                     "1; mode=block" always;
+      
+      # Remove X-Powered-By, which is an information leak
+      fastcgi_hide_header X-Powered-By;
+      
+      # Path to the root of your installation
+      root /var/www/nextcloud;
+      
+      # Specify how to handle directories -- specifying `/index.php$request_uri`
+      # here as the fallback means that Nginx always exhibits the desired behaviour
+      # when a client requests a path that corresponds to a directory that exists
+      # on the server. In particular, if that directory contains an index.php file,
+      # that file is correctly served; if it doesn't, then the request is passed to
+      # the front-end controller. This consistent behaviour means that we don't need
+      # to specify custom rules for certain paths (e.g. images and other assets,
+      # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+      # `try_files $uri $uri/ /index.php$request_uri`
+      # always provides the desired behaviour.
+      index index.php index.html index.htm /index.php$request_uri;
+      
+      # Default Cache-Control policy
+      expires 1m;
+      
+      # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
+      if ( $http_user_agent ~ DavClnt ) { rewrite ^/$ /remote.php/webdav/ redirect; }
+      
+      location = /robots.txt {
+          allow all;
+          log_not_found off;
+          access_log off;
       }
-
-      location ~ ^\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
-          deny all;
+      
+      # Make a regex exception for `/.well-known` so that clients can still
+      # access it despite the existence of the regex rule `location ~ /\.`
+      # which would otherwise handle requests for `/.well-known`.
+      location ^~ /.well-known {
+          # The following 6 rules are borrowed from `.htaccess`
+      
+          rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
+          rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
+          rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
+          rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
+          
+          location /.well-known/carddav   { return 301 /remote.php/dav/; }
+          location /.well-known/caldav    { return 301 /remote.php/dav/; }
       }
-      location ~ ^\/(?:\.|autotest|occ|issue|indie|db_|console) {
-          deny all;
-      }
-
-      location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy)\.php(?:$|\/) {
-          fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
+      
+      # Rules borrowed from `.htaccess` to hide certain paths from clients
+      location ~ ^/(build|tests|config|lib|3rdparty|templates|data)($|/)  { return 404; }
+      location ~ ^/(autotest|occ|issue|indie|db_|console)                 { return 404; }
+      
+      # Respond with HTTP 404 to *all* requests for hidden files;
+      # not just hidden files that reside in the root directory.
+      location ~ /\. { return 404; }
+      
+      # Ensure this block, which passes PHP files to the PHP process, is above the blocks
+      # which handle static assets (as seen below). If this block is not declared first,
+      # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
+      # to the URI, resulting in a HTTP 500 error response.
+      location ~ \.php($|/) {
+          fastcgi_split_path_info ^(.+?\.php)(/.*|)$;
           set $path_info $fastcgi_path_info;
+          
           try_files $fastcgi_script_name =404;
+          
           include fastcgi_params;
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_param PATH_INFO $path_info;
           fastcgi_param HTTPS on;
-          # Avoid sending the security headers twice
-          fastcgi_param modHeadersAvailable true;
-          # Enable pretty urls
-          fastcgi_param front_controller_active true;
+          
+          fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
+          fastcgi_param front_controller_active true;     # Enable pretty urls
           fastcgi_pass php-handler;
+          
           fastcgi_intercept_errors on;
           fastcgi_request_buffering off;
       }
-
-      location ~ ^\/(?:updater|oc[ms]-provider)(?:$|\/) {
-          try_files $uri/ =404;
-          index index.php;
+      
+      location ~ \.(css|js|svg|gif)$ {
+          try_files $uri $uri/ /index.php$request_uri;
+          expires 6M;         # Cache-Control policy borrowed from `.htaccess`
+          access_log off;     # Optional: Don't log access to assets
       }
-
-      # Adding the cache control header for js, css and map files
-      # Make sure it is BELOW the PHP block
-      location ~ \.(?:css|js|woff2?|svg|gif|map)$ {
-          try_files $uri /index.php$request_uri;
-          add_header Cache-Control "public, max-age=15778463";
-          # Add headers to serve security related headers (It is intended to
-          # have those duplicated to the ones above)
-          # Before enabling Strict-Transport-Security headers please read into
-          # this topic first.
-          #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-          #
-          # WARNING: Only add the preload option once you read about
-          # the consequences in https://hstspreload.org/. This option
-          # will add the domain to a hardcoded list that is shipped
-          # in all major browsers and getting removed from this list
-          # could take several months.
-          add_header Referrer-Policy "no-referrer" always;
-          add_header X-Content-Type-Options "nosniff" always;
-          add_header X-Download-Options "noopen" always;
-          add_header X-Frame-Options "SAMEORIGIN" always;
-          add_header X-Permitted-Cross-Domain-Policies "none" always;
-          add_header X-Robots-Tag "none" always;
-          add_header X-XSS-Protection "1; mode=block" always;
-
-          # Optional: Don't log access to assets
-          access_log off;
+      
+      location ~ \.woff2?$ {
+          try_files $uri $uri/ /index.php$request_uri;
+          expires 7d;         # Cache-Control policy borrowed from `.htaccess`
+          access_log off;     # Optional: Don't log access to assets
       }
-
-      location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm|mp3|ogg|wav)$ {
-          try_files $uri /index.php$request_uri;
-          # Optional: Don't log access to other assets
-          access_log off;
+      
+      location / {
+          try_files $uri $uri/ /index.php$request_uri;
       }
   }
 
@@ -191,8 +187,14 @@ Nextcloud in a subdir of the nginx webroot
 
 The following config should be used when Nextcloud is placed within a subdir of
 the webroot of your nginx installation.
-In this example the webroot is located at
-``/var/www`` and the Nextcloud instance is accessed via ``http(s)://cloud.example.com/nextcloud/``
+In this example the NextCloud files are located at
+``/var/www/nextcloud`` and the Nextcloud instance is accessed via ``http(s)://cloud.example.com/nextcloud/``.
+The configuration differs from the "Nextcloud in webroot" configuration above in the following ways:
+
+- All requests for ``/nextcloud`` are encapsulated within a single ``location`` block, namely ``location ~ ^/nextcloud($|/)``.
+- The string ``/nextcloud`` is prepended to all prefix paths.
+- The URI ``/nextcloud`` is *aliased* to ``/var/www/nextcloud``, rather than the domain itself being *rooted* at ``/var/www/nextcloud``.
+- The blocks that handle requests for paths outside of ``/nextcloud``, i.e. ``/robots.txt``, ``/.well-known``, and hidden files, are pulled out of the ``location ~ ^/nextcloud($|/)`` block.
 
 .. code-block:: nginx
 
@@ -205,71 +207,60 @@ In this example the webroot is located at
       listen 80;
       listen [::]:80;
       server_name cloud.example.com;
-      # enforce https
-      return 301 https://$server_name:443$request_uri;
+
+      # Enforce HTTPS just for `/nextcloud`
+      location /nextcloud {
+          return 301 https://$server_name$request_uri;
+      }
   }
 
   server {
-      listen 443 ssl http2;
+      listen 443      ssl http2;
       listen [::]:443 ssl http2;
       server_name cloud.example.com;
 
       # Use Mozilla's guidelines for SSL/TLS settings
       # https://mozilla.github.io/server-side-tls/ssl-config-generator/
-      # NOTE: some settings below might be redundant
-      ssl_certificate /etc/ssl/nginx/cloud.example.com.crt;
+      ssl_certificate     /etc/ssl/nginx/cloud.example.com.crt;
       ssl_certificate_key /etc/ssl/nginx/cloud.example.com.key;
 
-      # Add headers to serve security related headers
-      # Before enabling Strict-Transport-Security headers please read into this
-      # topic first.
-      #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-      #
+      # HSTS settings
       # WARNING: Only add the preload option once you read about
       # the consequences in https://hstspreload.org/. This option
       # will add the domain to a hardcoded list that is shipped
       # in all major browsers and getting removed from this list
       # could take several months.
-      add_header Referrer-Policy "no-referrer" always;
-      add_header X-Content-Type-Options "nosniff" always;
-      add_header X-Download-Options "noopen" always;
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header X-Permitted-Cross-Domain-Policies "none" always;
-      add_header X-Robots-Tag "none" always;
-      add_header X-XSS-Protection "1; mode=block" always;
-
-      # Remove X-Powered-By, which is an information leak
-      fastcgi_hide_header X-Powered-By;
-
-      # Path to the root of your installation
-      root /var/www;
-
+      #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
+      
       location = /robots.txt {
           allow all;
           log_not_found off;
           access_log off;
       }
+      
+      # Make a regex exception for `/.well-known` so that clients can still
+      # access it despite the existence of the regex rule `location ~ /\.`
+      # which would otherwise handle requests for `/.well-known`.
+      location ^~ /.well-known {
+          # The following 6 rules are borrowed from `.htaccess`
 
-      # The following 2 rules are only needed for the user_webfinger app.
-      # Uncomment it if you're planning to use this app.
-      #rewrite ^/.well-known/host-meta /nextcloud/public.php?service=host-meta last;
-      #rewrite ^/.well-known/host-meta.json /nextcloud/public.php?service=host-meta-json last;
+          rewrite ^/\.well-known/host-meta\.json  /nextcloud/public.php?service=host-meta-json    last;
+          rewrite ^/\.well-known/host-meta        /nextcloud/public.php?service=host-meta         last;
+          rewrite ^/\.well-known/webfinger        /nextcloud/public.php?service=webfinger         last;
+          rewrite ^/\.well-known/nodeinfo         /nextcloud/public.php?service=nodeinfo          last;
 
-      # The following rule is only needed for the Social app.
-      # Uncomment it if you're planning to use this app.
-      #rewrite ^/.well-known/webfinger /nextcloud/public.php?service=webfinger last;
+          location /.well-known/carddav   { return 301 /nextcloud/remote.php/dav/; }
+          location /.well-known/caldav    { return 301 /nextcloud/remote.php/dav/; }
 
-      location = /.well-known/carddav {
-        return 301 $scheme://$host:$server_port/nextcloud/remote.php/dav;
+          try_files $uri $uri/ /nextcloud/index.php$request_uri;
       }
-      location = /.well-known/caldav {
-        return 301 $scheme://$host:$server_port/nextcloud/remote.php/dav;
-      }
-
-      location /.well-known/acme-challenge { }
-
-      location ^~ /nextcloud {
-
+      
+      # Respond with HTTP 404 to *all* requests for hidden files;
+      # not just hidden files that reside in the root directory of
+      # the NextCloud installation.
+      location ~ /\. { return 404; }
+      
+      location ~ ^/nextcloud($|/) {
           # set max upload size
           client_max_body_size 512M;
           fastcgi_buffers 64 4K;
@@ -282,75 +273,85 @@ In this example the webroot is located at
           gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
           gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
-          # Uncomment if your server is build with the ngx_pagespeed module
-          # This module is currently not supported.
+          # Pagespeed is not supported by NextCloud, so if your server is built
+          # with the `ngx_pagespeed` module, uncomment this line to disable it.
           #pagespeed off;
+          
+          # HTTP response headers borrowed from NextCloud `.htaccess`
+          add_header Referrer-Policy                      "no-referrer"   always;
+          add_header X-Content-Type-Options               "nosniff"       always;
+          add_header X-Download-Options                   "noopen"        always;
+          add_header X-Frame-Options                      "SAMEORIGIN"    always;
+          add_header X-Permitted-Cross-Domain-Policies    "none"          always;
+          add_header X-Robots-Tag                         "none"          always;
+          add_header X-XSS-Protection                     "1; mode=block" always;
+          
+          # Remove X-Powered-By, which is an information leak
+          fastcgi_hide_header X-Powered-By;
+          
+          # Path to the root of your installation
+          # Notice that this is an `alias` directive, not a `root` directive
+          alias /var/www/nextcloud;
+          
+          # Specify how to handle directories -- specifying `/nextcloud/index.php$request_uri`
+          # here as the fallback means that Nginx always exhibits the desired behaviour
+          # when a client requests a path that corresponds to a directory that exists
+          # on the server. In particular, if that directory contains an index.php file,
+          # that file is correctly served; if it doesn't, then the request is passed to
+          # the front-end controller. This consistent behaviour means that we don't need
+          # to specify custom rules for certain paths (e.g. images and other assets,
+          # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+          # `try_files $uri $uri/ /nextcloud/index.php$request_uri`
+          # always provides the desired behaviour.
+          index index.php index.html index.htm /nextcloud/index.php$request_uri;
+          
+          # Default Cache-Control policy
+          expires 1m;
 
-          location /nextcloud {
-              rewrite ^ /nextcloud/index.php;
-          }
-
-          location ~ ^\/nextcloud\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
-              deny all;
-          }
-          location ~ ^\/nextcloud\/(?:\.|autotest|occ|issue|indie|db_|console) {
-              deny all;
-          }
-
-          location ~ ^\/nextcloud\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy)\.php(?:$|\/) {
-              fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
+          # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
+          if ( $http_user_agent ~ DavClnt ) { rewrite ^/nextcloud/?$ /nextcloud/remote.php/webdav/ redirect; }
+          
+          # Rules borrowed from `.htaccess` to hide certain paths from clients
+          location ~ ^/nextcloud/(build|tests|config|lib|3rdparty|templates|data)($|/)    { return 404; }
+          location ~ ^/nextcloud/(autotest|occ|issue|indie|db_|console)                   { return 404; }
+          
+          # Ensure this block, which passes PHP files to the PHP process, is above the blocks
+          # which handle static assets (as seen below). If this block is not declared first,
+          # then Nginx will encounter an infinite rewriting loop when it prepends
+          # `/nextcloud/index.php` to the URI, resulting in a HTTP 500 error response.
+          location ~ \.php($|/) {
+              fastcgi_split_path_info ^(.+?\.php)(/.*|)$;
               set $path_info $fastcgi_path_info;
+              
               try_files $fastcgi_script_name =404;
+              
               include fastcgi_params;
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               fastcgi_param PATH_INFO $path_info;
               fastcgi_param HTTPS on;
-              # Avoid sending the security headers twice
-              fastcgi_param modHeadersAvailable true;
-              # Enable pretty urls
-              fastcgi_param front_controller_active true;
+              
+              fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
+              fastcgi_param front_controller_active true;     # Enable pretty urls
               fastcgi_pass php-handler;
+              
               fastcgi_intercept_errors on;
               fastcgi_request_buffering off;
           }
-
-          location ~ ^\/nextcloud\/(?:updater|oc[ms]-provider)(?:$|\/) {
-              try_files $uri/ =404;
-              index index.php;
+          
+          location ~ \.(css|js|svg|gif)$ {
+              try_files $uri $uri/ /nextcloud/index.php$request_uri;
+              expires 6M;         # Cache-Control policy borrowed from `.htaccess`
+              access_log off;     # Optional: Don't log access to assets
           }
-
-          # Adding the cache control header for js, css and map files
-          # Make sure it is BELOW the PHP block
-          location ~ ^\/nextcloud\/.+[^\/]\.(?:css|js|woff2?|svg|gif|map)$ {
-              try_files $uri /nextcloud/index.php$request_uri;
-              add_header Cache-Control "public, max-age=15778463";
-              # Add headers to serve security related headers  (It is intended
-              # to have those duplicated to the ones above)
-              # Before enabling Strict-Transport-Security headers please read
-              # into this topic first.
-              #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-              #
-              # WARNING: Only add the preload option once you read about
-              # the consequences in https://hstspreload.org/. This option
-              # will add the domain to a hardcoded list that is shipped
-              # in all major browsers and getting removed from this list
-              # could take several months.
-              add_header Referrer-Policy "no-referrer" always;
-              add_header X-Content-Type-Options "nosniff" always;
-              add_header X-Download-Options "noopen" always;
-              add_header X-Frame-Options "SAMEORIGIN" always;
-              add_header X-Permitted-Cross-Domain-Policies "none" always;
-              add_header X-Robots-Tag "none" always;
-              add_header X-XSS-Protection "1; mode=block" always;
-
-              # Optional: Don't log access to assets
-              access_log off;
+          
+          location ~ \.woff2?$ {
+              try_files $uri $uri/ /nextcloud/index.php$request_uri;
+              expires 7d;         # Cache-Control policy borrowed from `.htaccess`
+              access_log off;     # Optional: Don't log access to assets
           }
-
-          location ~ ^\/nextcloud\/.+[^\/]\.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm|mp3|ogg|wav)$ {
-              try_files $uri /nextcloud/index.php$request_uri;
-              # Optional: Don't log access to other assets
-              access_log off;
+          
+          location /nextcloud {
+              try_files $uri $uri/ /nextcloud/index.php$request_uri;
           }
       }
   }

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -135,7 +135,7 @@ webroot of your nginx installation. In this example it is
       }
       
       # Rules borrowed from `.htaccess` to hide certain paths from clients
-      location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)($|/)  { return 404; }
+      location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)  { return 404; }
       location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)              { return 404; }
       
       # Ensure this block, which passes PHP files to the PHP process, is above the blocks
@@ -305,7 +305,7 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           }
           
           # Rules borrowed from `.htaccess` to hide certain paths from clients
-          location ~ ^/nextcloud/(?:build|tests|config|lib|3rdparty|templates|data)($|/)    { return 404; }
+          location ~ ^/nextcloud/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)    { return 404; }
           location ~ ^/nextcloud/(?:\.|autotest|occ|issue|indie|db_|console)                { return 404; }
           
           # Ensure this block, which passes PHP files to the PHP process, is above the blocks

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -137,6 +137,8 @@ webroot of your nginx installation. In this example it is
           
           location /.well-known/carddav   { return 301 /remote.php/dav/; }
           location /.well-known/caldav    { return 301 /remote.php/dav/; }
+
+          try_files $uri $uri/ =404;
       }
       
       # Rules borrowed from `.htaccess` to hide certain paths from clients
@@ -251,10 +253,10 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           location /.well-known/carddav   { return 301 /nextcloud/remote.php/dav/; }
           location /.well-known/caldav    { return 301 /nextcloud/remote.php/dav/; }
 
-          try_files $uri $uri/ /nextcloud/index.php$request_uri;
+          try_files $uri $uri/ =404;
       }
       
-      location ~ ^/nextcloud($|/) {
+      location ^~ /nextcloud {
           # set max upload size
           client_max_body_size 512M;
           fastcgi_buffers 64 4K;

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -190,7 +190,7 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
 - All requests for ``/nextcloud`` are encapsulated within a single ``location`` block, namely ``location ^~ /nextcloud``.
 - The string ``/nextcloud`` is prepended to all prefix paths.
 - The URI ``/nextcloud`` is *aliased* to ``/var/www/nextcloud``, rather than the domain itself being *rooted* at ``/var/www/nextcloud``.
-- The blocks that handle requests for paths outside of ``/nextcloud``, i.e. ``/robots.txt``, ``/.well-known``, and hidden files, are pulled out of the ``location ^~ /nextcloud`` block.
+- The blocks that handle requests for paths outside of ``/nextcloud`` (i.e. ``/robots.txt`` and ``/.well-known``) are pulled out of the ``location ^~ /nextcloud`` block.
 - The block which handles `/.well-known` doesn't need a regex exception, since the rule which prevents users from accessing hidden folders at the root of the Nextcloud installation no longer matches that path.
 
 .. code-block:: nginx

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -187,10 +187,10 @@ In this example the Nextcloud files are located at
 ``/var/www/nextcloud`` and the Nextcloud instance is accessed via ``http(s)://cloud.example.com/nextcloud/``.
 The configuration differs from the "Nextcloud in webroot" configuration above in the following ways:
 
-- All requests for ``/nextcloud`` are encapsulated within a single ``location`` block, namely ``location ~ ^/nextcloud($|/)``.
+- All requests for ``/nextcloud`` are encapsulated within a single ``location`` block, namely ``location ^~ /nextcloud``.
 - The string ``/nextcloud`` is prepended to all prefix paths.
 - The URI ``/nextcloud`` is *aliased* to ``/var/www/nextcloud``, rather than the domain itself being *rooted* at ``/var/www/nextcloud``.
-- The blocks that handle requests for paths outside of ``/nextcloud``, i.e. ``/robots.txt``, ``/.well-known``, and hidden files, are pulled out of the ``location ~ ^/nextcloud($|/)`` block.
+- The blocks that handle requests for paths outside of ``/nextcloud``, i.e. ``/robots.txt``, ``/.well-known``, and hidden files, are pulled out of the ``location ^~ /nextcloud`` block.
 - The block which handles `/.well-known` doesn't need a regex exception, since the rule which prevents users from accessing hidden folders at the root of the Nextcloud installation no longer matches that path.
 
 .. code-block:: nginx

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -189,7 +189,7 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
 
 - All requests for ``/nextcloud`` are encapsulated within a single ``location`` block, namely ``location ^~ /nextcloud``.
 - The string ``/nextcloud`` is prepended to all prefix paths.
-- The URI ``/nextcloud`` is *aliased* to ``/var/www/nextcloud``, rather than the domain itself being *rooted* at ``/var/www/nextcloud``.
+- The root of the domain is mapped to ``/var/www`` rather than ``/var/www/nextcloud``, so that the URI ``/nextcloud`` is mapped to the server directory ``/var/www/nextcloud``.
 - The blocks that handle requests for paths outside of ``/nextcloud`` (i.e. ``/robots.txt`` and ``/.well-known``) are pulled out of the ``location ^~ /nextcloud`` block.
 - The block which handles `/.well-known` doesn't need a regex exception, since the rule which prevents users from accessing hidden folders at the root of the Nextcloud installation no longer matches that path.
 
@@ -228,6 +228,9 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
       # in all major browsers and getting removed from this list
       # could take several months.
       #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
+
+      # Path to the root of the domain
+      root /var/www;
       
       location = /robots.txt {
           allow all;
@@ -277,10 +280,6 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           
           # Remove X-Powered-By, which is an information leak
           fastcgi_hide_header X-Powered-By;
-          
-          # Path to the root of your installation
-          # Notice that this is an `alias` directive, not a `root` directive
-          alias /var/www/nextcloud;
           
           # Specify how to handle directories -- specifying `/nextcloud/index.php$request_uri`
           # here as the fallback means that Nginx always exhibits the desired behaviour


### PR DESCRIPTION
After inspecting the Nginx configs currently seen at [ https://docs.nextcloud.com/server/19/admin_manual/installation/nginx.html ], I have notice that they are very redundant in some areas, and handle specific paths in special ways which are not needed, and which run the risk of needing to become more specific down the road if NextCloud adds new features, as well as not handling all static filetypes. I have reworked the configs from scratch by directly adapting the `.htaccess` files, and this is the result. Comments are included in the file to give rationale/explanation for why things are written in this new way, and if the maintainers decide to accept this pull request, I will leave it up to them to decide whether to include these expository comments upstream.