### PR TITLE
Add jpeg quality documentation

### DIFF
--- a/admin_manual/configuration_files/previews_configuration.rst
+++ b/admin_manual/configuration_files/previews_configuration.rst
@@ -95,3 +95,12 @@ to 'null':
 
   <?php
     'preview_max_scale_factor' => null,
+
+JPEG quality setting:
+^^^^^^^^^^^^^^^^^^^^^
+
+Default JPEG quality setting for preview images is '90'. You can change this with
+
+:: 
+
+  occ config:app:set preview jpeg_quality --value="60"

--- a/admin_manual/configuration_files/previews_configuration.rst
+++ b/admin_manual/configuration_files/previews_configuration.rst
@@ -99,7 +99,7 @@ to 'null':
 JPEG quality setting:
 ^^^^^^^^^^^^^^^^^^^^^
 
-Default JPEG quality setting for preview images is '90'. You can change this with
+Default JPEG quality setting for preview images is '90'. Change this with:
 
 :: 
 


### PR DESCRIPTION
Added a section on how to change the default jpeg quality for generated thumbnails. Default is 90, and it is worth noting that users can change this. 

https://github.com/nextcloud/server/commit/1e281bc616fc0034a4098999cf83d0d1115f5bb8
https://github.com/nextcloud/server/blob/b5a30d5cd6b53831c0d6d2fd074dc0000fa811de/tests/lib/ImageTest.php#L143