### PR TITLE
Mentions `app:remove`

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -198,7 +198,8 @@ The ``app`` commands list, enable, and disable apps::
   app:enable       enable an app
   app:getpath      get an absolute path to the app directory
   app:list         list all available apps
-  app:update       update an app or all apps 
+  app:update       update an app or all apps
+  app:remove       disable and remove an app
 
 List all of your installed apps, and show whether they are 
 enabled or disabled::


### PR DESCRIPTION
Just stumbled upon #2054, which mentions removing and installing the app again as a solution. Checked this page, which didn't mention anything about app removal.

I basically winged it with `app:remove` and it worked:

```bash
$ php occ app:remove calendar
calendar disabled
calendar removed
$ php occ app:install calendar
calendar installed
calendar enabled
```

This PR just adds app:remove under app commands list.