### PR TITLE
Added missing import

### DIFF
--- a/developer_manual/digging_deeper/settings.rst
+++ b/developer_manual/digging_deeper/settings.rst
@@ -212,6 +212,7 @@ An example implementation of the IIconSection interface:
     namespace OCA\YourAppNamespace\Settings;
 
     use OCP\IL10N;
+    use OCP\IURLGenerator;
     use OCP\Settings\IIconSection;
 
     class AdminSection implements IIconSection {


### PR DESCRIPTION
The IURLGenerator class is used at the constructor parameter, but importing that namespace was missing.