### PR TITLE
Correctly Display Note about Basic Authentication and Windows in version 18 docs

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -231,13 +231,13 @@ files offline, use the Desktop Client to sync all files on your
 Nextcloud to one or more directories of your local hard drive.
 
 .. note:: Prior to mapping your drive, you must permit the use of Basic 
-Authentication in the Windows Registry: launch „regedit“ and navigate to 
-HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WebClient\Parameters. 
-Create or edit the DWORD value „BasicAuthLevel“ (Windows Vista, 7 and 8) or 
-„UseBasicAuth“ (Windows XP and Windows Server 2003) and set its value data 
-to 1 for SSL connections. Value 0 means that Basic Authentication is disabled, 
-a value of 2 allows both SSL and non-SSL connections (not recommended). 
-Then exit Registry Editor, and restart the computer.
+    Authentication in the Windows Registry: launch „regedit“ and navigate to 
+    HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WebClient\Parameters. 
+    Create or edit the DWORD value „BasicAuthLevel“ (Windows Vista, 7 and 8) or 
+    „UseBasicAuth“ (Windows XP and Windows Server 2003) and set its value data 
+    to 1 for SSL connections. Value 0 means that Basic Authentication is disabled, 
+    a value of 2 allows both SSL and non-SSL connections (not recommended). 
+    Then exit Registry Editor, and restart the computer.
 
 Mapping drives with the command line
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: Jacob Neplokh <me@jacobneplokh.com>

--
Resolves #1814

Previously most of the paragraph for the note regarding Basic Authentication was not indented, causing a formatting error. This fixes it. 