### PR TITLE
Clarify the Version “disable” option disables the app

### DIFF
--- a/admin_manual/configuration_files/file_versioning.rst
+++ b/admin_manual/configuration_files/file_versioning.rst
@@ -40,4 +40,4 @@ Additional options are:
     Keep versions for at least D1 days and delete when they exceed D2 days.
 
 * ``disabled``  
-    Disable Versions; no files will be deleted.
+    Disable the Versions app; no old file versions will be deleted.


### PR DESCRIPTION
Signed-off-by: Jacob Neplokh <me@jacobneplokh.com>

--
Resolves #2151
@MorrisJobke 

This clarifies "disabled" means you are disabling the Versions *app*, so there will be no automatic file deletion of old file versions. 