### PR TITLE
Adds automation to build catalog templates.

### DIFF
--- a/.github/workflows/generate_catalog_templates.yml
+++ b/.github/workflows/generate_catalog_templates.yml
@@ -1,0 +1,19 @@
+name: L10n
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  user_manual:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "user_manual/"
+        pre-build-command: pip install -r requirements.txt
+        build-command: make gettext
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Adds Or Updates catalog templates (POT files fetched automatically by transifex)

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,14 @@ If using the command line and your name and email are configured, you can use
 In both settings be sure that your email address matches that in your Github profile,
 which if you have privacy enabled will be github.username@users.noreply.github.com
 
+
+Translations
+------------
+
+[Help translate the documentation](https://www.transifex.com/indiehosters/nextcloud-user-documentation/dashboard/).
+
+For developers that want to ease the translation process, please read [this documentation](https://docs.transifex.com/integrations/sphinx-doc).
+
 Building
 --------
 

--- a/user_manual/Makefile
+++ b/user_manual/Makefile
@@ -147,9 +147,9 @@ info:
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
 gettext:
-	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) locale/source
 	@echo
-	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+	@echo "Build finished. The message catalogs are in ./locale/source."
 
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes


### PR DESCRIPTION
This is the necessary first step to then automate transifex fetch/push with this yml:

```
filters:
- filter_type: dir
  file_format: PO
  source_language: en
  source_file_dir: user_manual/locale/source
  # path expression to translation files, must contain <lang> placeholder
  translation_files_expression: 'user_manual/locale/<lang>/LC_MESSAGES'
```

Once the PR is merged, the github action should populate the folder `user_manual/locale/source` with a new commit.
Then we can configure transifex to fetch and push.

Translated strings should appear in `user_manual/locale/<lang>/LC_MESSAGES`

This PR superseeds #1824 I'll still need to make another PR to automatically build all the translated docs, but I need the files locally, hence this first PR :)