### PR TITLE
Update index of Android lib

### DIFF
--- a/developer_manual/client_apis/android_library/index.rst
+++ b/developer_manual/client_apis/android_library/index.rst
@@ -21,6 +21,10 @@ setup and process of contribution is
 You might want to start with doing one or two `good first issues <https://github.com/nextcloud/android/labels/good%20first%20issue>`_
 to get into the code and note our :doc:`../general/index`.
 
+For authentication, you can use our usual login flow, and in addition (or instead
+if you are OK for users to depend on our Files app) use the great
+`Android SingeSignOn library <https://github.com/nextcloud/Android-SingleSignOn/#how-to-use-this-library>`_
+
 Nextcloud Android library
 -------------------------
 


### PR DESCRIPTION
We want to remove this link from nextcloud.com/developer as it is a bit too specific. This seems a good place to link to it instead.