### PR TITLE
Update general_troubleshooting.rst with correct CalDAV/CardDAV redirection

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -274,8 +274,8 @@ document root of your Web server and add the following lines::
       RewriteRule ^\.well-known/host-meta /nextcloud/public.php?service=host-meta [QSA,L]
       RewriteRule ^\.well-known/host-meta\.json /nextcloud/public.php?service=host-meta-json [QSA,L]
       RewriteRule ^\.well-known/webfinger /nextcloud/public.php?service=webfinger [QSA,L]
-      RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav/ [R=301,L]
-      RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav/ [R=301,L]
+      RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
+      RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav [R=301,L]
     </IfModule>
 
 Make sure to change /nextcloud to the actual subfolder your Nextcloud instance is running in.


### PR DESCRIPTION
I had setup CalDAV and CardDAV rewrite rules as suggested with trailing slash, which was always mentioned as missing under  Security & setup warnings. I removed the trailing slashes and voila it still works and the warning under Security & Setup is finally gone for good. 