### PR TITLE
Update example_centos.rst

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -76,28 +76,13 @@ Next install the PHP modules needed for this install. Remember, because this is 
     dnf install -y php php-gd php-mbstring php-intl php-pecl-apcu\
          php-mysqlnd php-opcache php-json php-zip
 
-
-Manually building redis/imagick (optional)
+Installing optional modules redis/imagick
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
-    dnf install -y php-pear gcc curl-devel php-devel zlib-devel pcre-devel make
+    dnf install -y php-redis php-imagick
     
-    pecl install redis
-
-    dnf config-manager --set-enabled PowerTools
-
-    dnf install -y ImageMagick ImageMagick-devel
-    
-    pecl install imagick
-
-After installing the extensions make sure to load the extensions in your php.ini file with:
-
-::
-
-    extension=redis.so
-    extension=imagick.so
 
 Database
 --------


### PR DESCRIPTION
Not sure why the needed to be built manually? But a fresh install with remi 7.4 gives `php-pecl-imagick-3.4.4-10.el8.remi.7.4` and `php-pecl-redis5-5.3.1-1.el8.remi.7.4` respectively.