### PR TITLE
Example centos walkthrough, add working secure apache config

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -21,8 +21,26 @@ Apache
 ::
 
     dnf install -y httpd
+    
+Create a virtualhost in ``/etc/httpd/conf.d/nextcloud.conf`` and add the following content to it:
 
-See :ref:`apache_configuration_label` for details.
+::
+
+  <VirtualHost *:80>
+    DocumentRoot /var/www/html/nextcloud/
+    ServerName  your.server.com
+
+    <Directory /var/www/html/nextcloud/>
+      Require all granted
+      AllowOverride All
+      Options FollowSymLinks MultiViews
+
+      <IfModule mod_dav.c>
+        Dav off
+      </IfModule>
+
+    </Directory>
+  </VirtualHost>
 
 Make sure the apache web service is enabled and started::
 

--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -41,6 +41,9 @@ Create a virtualhost in ``/etc/httpd/conf.d/nextcloud.conf`` and add the followi
 
     </Directory>
   </VirtualHost>
+  
+  
+See :ref:`apache_configuration_label` for further details.
 
 Make sure the apache web service is enabled and started::
 


### PR DESCRIPTION
It would be really helpful if the example of a CentOS Configuration Walkthrough would directly contain a working and secure apache configuration.
Just the Reference to the detailed apache config is not adequate and too easy to overlook and users will end up with an unsecure and broken config. This could lead to the usual htaccess not working questions.

So here is my proposal :)