### PR TITLE
add example for type annotation

### DIFF
--- a/developer_manual/app_development/tutorial.rst
+++ b/developer_manual/app_development/tutorial.rst
@@ -302,6 +302,10 @@ Now that the tables are created we want to map the database result to a PHP obje
         protected $title;
         protected $content;
         protected $userId;
+        
+        public function __construct() {
+            $this->addType('id','integer');
+        }
 
         public function jsonSerialize() {
             return [


### PR DESCRIPTION
for Entity to database column mapping, Type is really important as described [here](https://docs.nextcloud.com/server/latest/developer_manual/basics/storage/database.html). 

adding the type annotation will help people who are following the tutorial but not only using string for a database column