### PR TITLE
Add link to new phpdoc build

### DIFF
--- a/developer_manual/digging_deeper/api.rst
+++ b/developer_manual/digging_deeper/api.rst
@@ -1,25 +1,9 @@
-.. only:: html
-
-    API documentation
-    =================
+API reference
+=============
 
 
-    PHP public API
-    --------------
-    .. toctree::
-        :maxdepth: 1
+PHP public API
+--------------
 
-        /OCP namespace <api/OCP/index>
-
-
-    PHP class reference
-    -------------------
-
-    Please note that only APIs in \OCP namespace are considered to be public. The
-    following documentation is just for reference:
-
-    .. toctree::
-        :maxdepth: 1
-
-        / namespace <api/index>
-        /OC namespace <api/OC/index>
+The public API is contained in the OCP namespace. See the `OCP API reference
+<https://nextcloud-server.netlify.app/>`_ for further details.


### PR DESCRIPTION
Fixes https://github.com/nextcloud/documentation/issues/1782

Needs backports once the stable server branch docs are deployed as well.