### PR TITLE
Fixed local redis socket configuration

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -104,7 +104,7 @@ If you want to connect to Redis configured to listen on an Unix socket (which is
 recommended if Redis is running on the same system as Nextcloud) use this example
 ``config.php`` configuration::
 
-  'memcache.local' => '\OC\Memcache\APCu',
+  'memcache.local' => '\OC\Memcache\Redis',
   'memcache.distributed' => '\OC\Memcache\Redis',
   'redis' => [
        'host'     => '/var/run/redis/redis.sock',


### PR DESCRIPTION
Fixed a fail in the configuration for local redis socket.
The Configuration above worked for me (Debian 10, Nextcloud 19, php 7.3)