### PR TITLE
Include note on App Password

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -50,6 +50,14 @@ Distributed Authoring and Versioning (WebDAV) is a Hypertext Transfer Protocol
 servers. With WebDAV you can access your Nextcloud shares on Linux, macOS and
 Windows in the same way as any remote network share, and stay synchronized.
 
+App Passwords
+--------------------
+
+Nextcloud supports generating unquie application password seprate from your user login. 
+If you are using a 3rd party authenication provider you will need to generate an application password for WebDAV.
+In Nextcloud’s web GUI, go to the user preferences, go to Security. Generate an App password.
+
+
 Accessing files using Linux
 ---------------------------
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -53,7 +53,7 @@ Windows in the same way as any remote network share, and stay synchronized.
 App Passwords
 --------------------
 
-Nextcloud supports generating unquie application password seprate from your user login. 
+Nextcloud supports generating unquie application password separate from your user login. 
 If you are using a 3rd party authenication provider you will need to generate an application password for WebDAV.
 In Nextcloud’s web GUI, go to the user preferences, go to Security. Generate an App password.
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -51,7 +51,7 @@ servers. With WebDAV you can access your Nextcloud shares on Linux, macOS and
 Windows in the same way as any remote network share, and stay synchronized.
 
 App Passwords
---------------------
+-------------
 
 Nextcloud supports generating unquie application password separate from your user login. 
 If you are using a 3rd party authenication provider you will need to generate an application password for WebDAV.


### PR DESCRIPTION
App Passwords are needed when using a third party login provider or MFA/2FA.