### PR TITLE
Corrected unintended text emphasis

### DIFF
--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -219,7 +219,7 @@ An example curl command would be:
      curl -i -u master -X GET -H "OCS-APIRequest: true" 'https://my.nextcloud/ocs/v2.php/core/autocomplete/get?search=JOANNE%40EMAIL.ISP&itemType=%20&itemId=%20&shareTypes[]=8&limit=2'
 
 That would look for JOANNE@EMAIL.ISP as guest user. Maximum 2 results to be returned for a regular user, the shareTypes array would carry only "0".
-`itemType` and itemId are left (set to a white space), essentially they are to give context about the use case, so sorters can do their work (like who 
+``itemType`` and ``itemId`` are left (set to a white space), essentially they are to give context about the use case, so sorters can do their work (like who 
 commented last). It can be an option for filtering on a later stage but you can also leave them out as per the below example.
 
 .. code::

--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -218,9 +218,9 @@ An example curl command would be:
 
      curl -i -u master -X GET -H "OCS-APIRequest: true" 'https://my.nextcloud/ocs/v2.php/core/autocomplete/get?search=JOANNE%40EMAIL.ISP&itemType=%20&itemId=%20&shareTypes[]=8&limit=2'
 
-That would look for JOANNE@EMAIL.ISP as guest user. Maximum 2 results to be returned
- for a regular user, the shareTypes array would carry only "0"
-. itemType and itemId are left (set to a white space), essentially they are to give context about the use case, so sorters can do their work (like who commented last). It  can be an option for filtering on a later stage but you can also leave them out:
+That would look for JOANNE@EMAIL.ISP as guest user. Maximum 2 results to be returned for a regular user, the shareTypes array would carry only "0".
+`itemType` and itemId are left (set to a white space), essentially they are to give context about the use case, so sorters can do their work (like who 
+commented last). It can be an option for filtering on a later stage but you can also leave them out as per the below example.
 
 .. code::
 


### PR DESCRIPTION
The docs at https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html#auto-complete-and-user-search are rendered with unintended emphasis as per the below screenshot.

![Screenshot from 2020-09-12 22-15-05](https://user-images.githubusercontent.com/7005614/93003308-34c40980-f546-11ea-925e-12c63f2cebce.png)

This PR is supposed to fix that.