### PR TITLE
add migration to tutorial

### DIFF
--- a/developer_manual/app_development/tutorial.rst
+++ b/developer_manual/app_development/tutorial.rst
@@ -264,11 +264,17 @@ so for example **notestutorial/lib/Migration/Version000000Date20181013124731.php
         }
     }
 
-To create the tables in the database, the :doc:`version tag <info>` in **notestutorial/appinfo/info.xml** needs to be increased:
+To create the tables in the database, run the :ref:`migration  <migration_console_command>` command::
+
+   php ./occ migrations:excute <appId> <versionNumber>
+
+   Example: sudo -u www-data php ./occ migrations:execute photos 000000Date20201002183800
+
+.. note:: to trigger the tabele creation/alteration when user updating the app, update the :doc:`version tag <info>` in **notestutorial/appinfo/info.xml** . migration will be executed when user reload page after app upgrade
 
 .. code-block:: xml
 
-    <?xml version="1.0"?>
+  <?xml version="1.0"?>
     <info>
         <id>notestutorial</id>
         <name>Notes Tutorial</name>
@@ -283,7 +289,6 @@ To create the tables in the database, the :doc:`version tag <info>` in **notestu
         </dependencies>
     </info>
 
-Reload the page to trigger the database migration.
 
 Now that the tables are created we want to map the database result to a PHP object to be able to control data. First create an :doc:`entity <storage/database>` in **notestutorial/lib/Db/Note.php**:
 

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -24,7 +24,7 @@ This mechanism is a versatile and typed approach to events in Nextcloud's php co
 Naming scheme
 `````````````
 
-The name should reflect the subject and the actions. Prefixing event classes with `Event` makes it easier to recognize their purpose.
+The name should reflect the subject and the actions. Suffixing event classes with `Event` makes it easier to recognize their purpose.
 
 For example, if a user is created, a `UserCreatedEvent` will be emitted.
 

--- a/developer_manual/basics/storage/migrations.rst
+++ b/developer_manual/basics/storage/migrations.rst
@@ -135,6 +135,8 @@ For version you should use the your app versions. So if you app is at version
 
 Don't forget to remove your `database.xml` file.
 
+.. _migration_console_command:
+
 Console commands
 ----------------
 


### PR DESCRIPTION
Signed-off-by: dassio <dassio@icloud.com>

during development, migration can be changed multiple times, using the updating version tag method to trigger migration has the following drawbacks:

1. version number has to be increased multi times when only one feature is added 
2. [wrong migration has to be deleted from the oc_migrations table manually](https://help.nextcloud.com/t/clean-migration-for-unpublished-app/89911), or the server will complain same migration already be used 

the migration command does not have that constraint, just drop the table and run `sudo -u www-data php ./occ migrations:execute photos 000000Date20201002183800` will recreate the table for you.
