### PR TITLE
Change merge retry timeout to 60sec

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -21,4 +21,4 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: ""
           MERGE_RETRIES: 10
-          MERGE_RETRY_SLEEP: 30000
+          MERGE_RETRY_SLEEP: 60000


### PR DESCRIPTION
Sometimes automated pull requests from transifex are not merged (e.g. https://github.com/nextcloud/documentation/pull/5206 or https://github.com/nextcloud/documentation/pull/5205). 
It seems the build needs some time and the action retries to soon. 