### PR TITLE
sync_android.rst: With Nextcloud app: Specify the contact-grouping method that the user needs to choose

### DIFF
--- a/user_manual/pim/sync_android.rst
+++ b/user_manual/pim/sync_android.rst
@@ -32,12 +32,15 @@ With the Nextcloud mobile app
    to **Settings** / **More**, tap on "**Sync calendars & contacts**".
 3. Now, DAVx⁵ will open Nextcloud's Webflow login window, where you
    will have to enter your credentials and grant access.
-4. After this, DAVx⁵ will close and the Nextcloud app reappears. In
+4. DAVx⁵ will open and ask you to create an account. Set the account
+   name to one of your choosing, and set **Contact Group Method** to
+   **Groups are per-contact categories**.
+5. After this, DAVx⁵ will close and the Nextcloud app reappears. In
    order to finish setup, you have to manually launch DAVx⁵ again.
-5. Tap on the icon for the account DAVx⁵ has just created, when requested grant DAVx⁵ access
+6. Tap on the icon for the account DAVx⁵ has just created, when requested grant DAVx⁵ access
    to your calendars and contacts. Optionally install `OpenTasks <https://play.google.com/store/apps/details?id=org.dmfs.tasks>`_  and
    grant DAVx⁵ access to your tasks, too.
-6. When you tap the icon for the account DAVx⁵ has set up, it will
+7. When you tap the icon for the account DAVx⁵ has set up, it will
    discover the available address books and calendars. Choose which
    ones you want to synchronize and finish.
 


### PR DESCRIPTION
User must specify "Groups are per-contact categories" even when using the Nextcloud app flow. This behaviour is seen with the following platform:

- Android 9.0 (Samsung One UI 1.0)
- Nextcloud for Android, version 3.13.1
- DAVx⁵ for Android, version 3.3.2-ose, installed via F-Droid

If this is not the case on other platforms, perhaps mention that the new step (4) may happen automatically?