### PR TITLE
Clarify on InnoDB file format

### DIFF
--- a/admin_manual/configuration_database/mysql_4byte_support.rst
+++ b/admin_manual/configuration_database/mysql_4byte_support.rst
@@ -9,7 +9,7 @@ Enabling MySQL 4-byte support
 In order to use Emojis (textbased smilies) on your Nextcloud server with a MySQL database, the
 installation needs to be tweaked a bit.
 
-1. Make sure your database is set to use the Barracuda InnoDB file format:
+1. Make sure your database is set to use the Barracuda InnoDB file format (this is only needed on MySQL 5.x and MariaDB < 10.3):
 
    Login to your mysql database and run::
 


### PR DESCRIPTION
In MariaDB 10.2.2 Barracuda is the default and in 10.3 it can't be changed anymore: https://mariadb.com/kb/en/innodb-file-format/

The MySQL deprecation page: https://dev.mysql.com/doc/refman/8.0/en/added-deprecated-removed.html

Thanks to @timbabcock in #5262 for highlighting this.