### PR TITLE
Adds links to end of ubuntu 20.04 example

### DIFF
--- a/admin_manual/installation/example_ubuntu.rst
+++ b/admin_manual/installation/example_ubuntu.rst
@@ -80,3 +80,8 @@ Now download the archive of the latest Nextcloud version:
 
 On other HTTP servers it is recommended to install Nextcloud outside of the
 document root.
+
+Next steps
+----------
+
+After installing the prerequisites and extracting the nextcloud directory, you should follow the instructions for Apache configuration at :ref:`apache_configuration_label`. Once Apache is installed, you can optionally follow the :doc:`source_installation` guide from :ref:`pretty_urls_label` until :ref:`other_HTTP_servers_label`


### PR DESCRIPTION
The current documentation ends abruptly when only reading the "example
installation on ubuntu 20.04" document. This PR adds some links for the
next (potential) steps.