### PR TITLE
nginx: fix autoloading for some builtins apps

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -174,7 +174,7 @@ webroot of your nginx installation. In this example it is
       }
       
       location / {
-          try_files $uri $uri/ /index.php$request_uri;
+          try_files  $uri/ /index.php$request_uri;
       }
   }
 


### PR DESCRIPTION
In https://github.com/nextcloud/documentation/commit/6b40a23ab928a9b84d777377f9bc7dc2f75b15f1#diff-e6fc0cd0bc2157559d74ab9196ea4209f9205a94865839d0f7b32b9810365c78 
the way nginx access files was changed. This broke some apps like user_ldap, where ajax function are called from the directory directly. They need to be executed through the top-level index.php, or otherwise they will find their dependencies. Maybe this should be reverted back to `rewrite ^ /index.php;`? cc @jivanpal 