### PR TITLE
Fix description of "Enforce expiration date" parameter

### DIFF
--- a/admin_manual/configuration_files/file_sharing_configuration.rst
+++ b/admin_manual/configuration_files/file_sharing_configuration.rst
@@ -15,7 +15,12 @@ Configure your sharing policy on your Admin page in the Sharing section.
 * Check ``Set default expiration date for shares`` to set a default expiration date
   on local user and group shares.
 * Check ``Enforce expiration date`` to always enforce the configured expiration date
-  on local user and group shares. Users will not be able to adjust or remove the expiration date.
+  on local user and group shares. Users will not be able to set the expiration date further
+  in the future than the enforced expiration date, although they will be able to set a more
+  recent date. Also note that they will also be able to update the expiration date again at
+  a later point; as the expiration date is based on the current date and not on the share
+  creation date the user will be able to extend the expiration date again whenever a
+  previous expiration date is close to be reached.
 * Check ``Allow users to share via link`` to enable creating public shares for  
   people who are not Nextcloud users via hyperlink.
 * Check ``Allow public uploads`` to allow anyone to upload files to public shares.
@@ -26,7 +31,12 @@ Configure your sharing policy on your Admin page in the Sharing section.
 * Check ``Set default expiration date for link shares`` to set a default expiration date on 
   public shares.
 * Check ``Enforce expiration date`` to always enforce the configured expiration date
-  on public shares. Users will not be able to adjust or remove the expiration date.
+  on public shares. Users will not be able to set the expiration date further
+  in the future than the enforced expiration date, although they will be able to set a more
+  recent date. Also note that they will also be able to update the expiration date again at
+  a later point; as the expiration date is based on the current date and not on the share
+  creation date the user will be able to extend the expiration date again whenever a
+  previous expiration date is close to be reached.
 * Check ``Allow resharing`` to enable users to re-share files shared with them.
 * Check ``Allow sharing with groups`` to enable users to share with groups.
 * Check ``Restrict users to only share with users in their groups`` to confine 

--- a/admin_manual/configuration_files/file_sharing_configuration.rst
+++ b/admin_manual/configuration_files/file_sharing_configuration.rst
@@ -15,12 +15,16 @@ Configure your sharing policy on your Admin page in the Sharing section.
 * Check ``Set default expiration date for shares`` to set a default expiration date
   on local user and group shares.
 * Check ``Enforce expiration date`` to always enforce the configured expiration date
-  on local user and group shares. Users will not be able to set the expiration date further
-  in the future than the enforced expiration date, although they will be able to set a more
-  recent date. Also note that they will also be able to update the expiration date again at
-  a later point; as the expiration date is based on the current date and not on the share
-  creation date the user will be able to extend the expiration date again whenever a
-  previous expiration date is close to be reached.
+  on local user and group shares.
+
+    .. note:: Users will not be able to set the expiration date further
+        in the future than the enforced expiration date, although they 
+        will be able to set a more recent date.
+        Also note that users will be able to update the expiration date again at
+        a later point. The expiration date is based on the current date and not on the share
+        creation date. The user will be able to extend the expiration date again whenever a
+        previous expiration date is close to be reached.
+
 * Check ``Allow users to share via link`` to enable creating public shares for  
   people who are not Nextcloud users via hyperlink.
 * Check ``Allow public uploads`` to allow anyone to upload files to public shares.
@@ -31,12 +35,16 @@ Configure your sharing policy on your Admin page in the Sharing section.
 * Check ``Set default expiration date for link shares`` to set a default expiration date on 
   public shares.
 * Check ``Enforce expiration date`` to always enforce the configured expiration date
-  on public shares. Users will not be able to set the expiration date further
-  in the future than the enforced expiration date, although they will be able to set a more
-  recent date. Also note that they will also be able to update the expiration date again at
-  a later point; as the expiration date is based on the current date and not on the share
-  creation date the user will be able to extend the expiration date again whenever a
-  previous expiration date is close to be reached.
+  on public shares. 
+
+    .. note:: Users will not be able to set the expiration date further
+        in the future than the enforced expiration date, although they 
+        will be able to set a more recent date.
+        Also note that users will be able to update the expiration date again at
+        a later point. The expiration date is based on the current date and not on the share
+        creation date. The user will be able to extend the expiration date again whenever a
+        previous expiration date is close to be reached.
+
 * Check ``Allow resharing`` to enable users to re-share files shared with them.
 * Check ``Allow sharing with groups`` to enable users to share with groups.
 * Check ``Restrict users to only share with users in their groups`` to confine 


### PR DESCRIPTION
The `Enforce expiration date` parameter [enforces that the expiration date will not be set further in the future](https://github.com/nextcloud/server/blob/de7026f6e4662ff42e0a3c12021a3cee25c5d91f/lib/private/Share20/Manager.php#L494-L507), but [it does not prevent users from setting a more recent date](https://github.com/nextcloud/documentation/blob/5146a352e197ef59b8d232f3f5956b73d1a3c451/admin_manual/configuration_files/file_sharing_configuration.rst#distinguish-between-max-expiration-date-and-default-expiration-date), or from updating the expiration date again at a later point.

Wording and styling improvements are welcome, I do not like too much how I wrote it :-P