### PR TITLE
Do not suppress include_once errors for the composer autoloader

### DIFF
--- a/developer_manual/app_development/bootstrap.rst
+++ b/developer_manual/app_development/bootstrap.rst
@@ -64,7 +64,7 @@ The class **must** extend ``OCP\AppFramework\App`` and may optionally implement 
             // ... registration logic goes here ...
 
             // Register the composer autoloader for packages shipped by this app, if applicable
-            @include_once __DIR__ . '/../../vendor/autoload.php'
+            include_once __DIR__ . '/../../vendor/autoload.php'
 
             $context->registerEventListener(
                 BeforeUserDeletedEvent::class,


### PR DESCRIPTION
If this really causes an error then it shall throw. The server will log it.

Ref https://github.com/nextcloud/server/pull/23125#pullrequestreview-527259691