### PR TITLE
Add (composer) dependency management docs

### DIFF
--- a/developer_manual/app_development/dependency_management.rst
+++ b/developer_manual/app_development/dependency_management.rst
@@ -1,0 +1,18 @@
+.. _Dependencymanagement:
+
+=====================
+Dependency management
+=====================
+
+It's possible to build a Nextcloud app with existing software packages.
+
+
+Back-end
+--------
+
+You can add 3rd party packages with `Composer`_. Composer will download the specified packages to a directory of your choise, typically to ``/vendor``. In order to benefit from Composer's autoloader, you'll want to add a ``require_once`` to the ``register`` method of your ``Application`` class in the :ref:`bootstrapping<Bootstrapping>` code of your app.
+
+.. note:: Be careful with which packages you add to an app. Php can not load two version of the same class twice, hence there can be conflicts between Nextcloud Server and an app or between two or more apps if they ship the same library. So try to keep the number of libraries to a minimum.
+
+
+.. _Composer: https://getcomposer.org/

--- a/developer_manual/app_development/dependency_management.rst
+++ b/developer_manual/app_development/dependency_management.rst
@@ -6,11 +6,12 @@ Dependency management
 
 It's possible to build a Nextcloud app with existing software packages.
 
+.. _app-composer:
 
-Back-end
+Composer
 --------
 
-You can add 3rd party packages with `Composer`_. Composer will download the specified packages to a directory of your choise, typically to ``/vendor``. In order to benefit from Composer's autoloader, you'll want to add a ``require_once`` to the ``register`` method of your ``Application`` class in the :ref:`bootstrapping<Bootstrapping>` code of your app.
+You can add 3rd party php packages with `Composer`_. Composer will download the specified packages to a directory of your choise, typically to ``/vendor``. In order to benefit from Composer's autoloader, you'll want to add a ``require_once`` to the ``register`` method of your ``Application`` class in the :ref:`bootstrapping<Bootstrapping>` code of your app.
 
 .. note:: Be careful with which packages you add to an app. Php can not load two version of the same class twice, hence there can be conflicts between Nextcloud Server and an app or between two or more apps if they ship the same library. So try to keep the number of libraries to a minimum.
 

--- a/developer_manual/app_development/index.rst
+++ b/developer_manual/app_development/index.rst
@@ -10,4 +10,4 @@ App development
    bootstrap
    info
    init
-   logging
+   dependency_management

--- a/developer_manual/digging_deeper/classloader.rst
+++ b/developer_manual/digging_deeper/classloader.rst
@@ -5,7 +5,7 @@ Classloader
 ===========
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
 
-The classloader is provided by Nextcloud and loads all your classes automatically. The only thing left to include by yourself are 3rdparty libraries. Those should be loaded in :file:`lib/AppInfo/Application.php`.
+The classloader is provided by Nextcloud and loads all your classes automatically. See :ref:`the composer section<app-composer>` if you want to include and autoload 3rd party libraries.
 
 PSR-4 autoloading
 -----------------


### PR DESCRIPTION
Related to the discussion at https://github.com/nextcloud/server/pull/23125. It's not uncommon to have composer in an app, so let's document what app devs have to be careful about.