### PR TITLE
Deprecate the app code checker

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -193,7 +193,6 @@ The ``app`` commands list, enable, and disable apps::
 
  app
   app:install      install selected app
-  app:check-code   check code to be compliant
   app:disable      disable an app
   app:enable       enable an app
   app:getpath      get an absolute path to the app directory
@@ -223,27 +222,6 @@ Disable an app::
 
  sudo -u www-data php occ app:disable files_external
  files_external disabled   
-   
-``app:check-code`` has multiple checks: it checks if an app uses Nextcloud's 
-public API (``OCP``) or private API (``OC_``), and it also checks for deprecated 
-methods and the validity of the ``info.xml`` file. By default all checks are 
-enabled. The Activity app is an example of a correctly-formatted app::
-
- sudo -u www-data php occ app:check-code notifications
- App is compliant - awesome job!
-
-If your app has issues, you'll see output like this::
-
- sudo -u www-data php occ app:check-code foo_app
- Analysing /var/www/nextcloud/apps/files/foo_app.php
- 4 errors
-    line   45: OCP\Response - Static method of deprecated class must not be 
-    called
-    line   46: OCP\Response - Static method of deprecated class must not be 
-    called
-    line   47: OCP\Response - Static method of deprecated class must not be 
-    called
-    line   49: OC_Util - Static method of private class must not be called
 
 You can get the full filepath to an app::
     
@@ -1305,7 +1283,6 @@ Then choose your ``occ`` options. This lists your available options::
   list                  Lists commands
   status                show some status information
   app
-  app:check-code        check code to be compliant
   l10n
   l10n:createjs         Create javascript translation files for a given app
   maintenance

--- a/developer_manual/app_publishing_maintenance/publishing.rst
+++ b/developer_manual/app_publishing_maintenance/publishing.rst
@@ -18,14 +18,6 @@ Getting an app approved
 -----------------------
 You can find documentation on getting apps in our app store `here. <https://nextcloudappstore.readthedocs.io/en/latest/developer.html#publishing-apps-on-the-app-store>`_
 
-Using the code checker
-^^^^^^^^^^^^^^^^^^^^^^
-Before getting the app in the app store, it is best to check your app code with the code checker, and fix the issues found by the code checker.
-
-.. code-block:: bash
-
-  ./occ app:check-code <app_name>
-  
 Losing a rating
 ^^^^^^^^^^^^^^^
 Apps can lose their rating when:

--- a/developer_manual/app_publishing_maintenance/upgrade-guide.rst
+++ b/developer_manual/app_publishing_maintenance/upgrade-guide.rst
@@ -6,6 +6,19 @@ Once you've created and published the first version of your app, you will want t
 
 This document will cover the most important changes in Nextcloud, as well as some guides on how to upgrade existing apps.
 
+Upgrading to Nextcloud 21
+-------------------------
+
+.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/23210>`__. See the original ticket for links to the pull requests and tickets.
+
+General
+^^^^^^^
+
+App code checker deprecation
+****************************
+
+The app code checker (``occ app:check-code myapp``) is obsolute due to :ref:`static analysis<app-static-analysis>`. For Nextcloud 21 it will act as NOOP, meaning that you can still call the command but it will never fail. This allows you to still use it on CI if you test against 21, 20 and older releases. But prepare the switch to static analysis if you haven't already. Please also note that the app code checker hadn't received many updates recently, hence the number of issues it can detect is low.
+
 Upgrading to Nextcloud 20
 -------------------------
 

--- a/developer_manual/digging_deeper/continuous_integration.rst
+++ b/developer_manual/digging_deeper/continuous_integration.rst
@@ -64,6 +64,7 @@ A lint of all php source files can find syntax errors that could crash the appli
       - name: Lint
         run: composer run lint
 
+.. _app-static-analysis:
 
 Static analysis
 ---------------


### PR DESCRIPTION
* Remove from app publishing guide
* Add to app upgrade guide
* Drop from admin manual (kind of inappropriate anyway)

Rendered:

![Bildschirmfoto von 2020-12-03 10-49-33](https://user-images.githubusercontent.com/1374172/100993106-46b9b500-3555-11eb-92bc-ad732e473a37.png)
