### PR TITLE
Update unified search docs

### DIFF
--- a/developer_manual/app_publishing_maintenance/upgrade-guide.rst
+++ b/developer_manual/app_publishing_maintenance/upgrade-guide.rst
@@ -40,7 +40,7 @@ jQuery was updated to v2.2. The most notable change is that ``$(document).ready(
 Search
 ******
 
-The unified search replaces the traditional search input, hence ``OCA.Search`` became a noop. For backwards compatibility, the code will not raise any errors now, but it does not have any functionality.
+The :ref:`unified search<unified-search>` replaces the traditional search input, hence ``OCA.Search`` became a noop. For backwards compatibility, the code will not raise any errors now, but it does not have any functionality.
 
 Removed globals
 ***************

--- a/developer_manual/digging_deeper/search.rst
+++ b/developer_manual/digging_deeper/search.rst
@@ -168,26 +168,9 @@ Handling search requests
 
 Search requests are processed in the ``search`` method. The ``$user`` object is the user who the result shall be generated for. ``$query`` gives context information like the **search term**, the **sort order**, the **route information**, the **size limit** of a request and the **cursor** for follow-up request of paginated results.
 
-The result is encapsulated in the ``SearchResult`` class that offers two static factory methods ``complete`` and ``paginated``. Both of these methods take an array of ``SearchResultEntry`` objects. ``SearchResultEntry`` is a static class that can be extended and used by the provider.
+The result is encapsulated in the ``SearchResult`` class that offers two static factory methods ``complete`` and ``paginated``. Both of these methods take an array of ``SearchResultEntry`` objects.
 
-.. note:: In most cases you don't have to add any methods or fields to this new result entry type so you can directly use ``SearchResultEntry``, but this API design was chosen so new optional properties can be added in the future without breaking the existing implementations in 3rd party apps.
-
-.. code-block:: php
-
-    <?php
-
-    declare(strict_types=1);
-
-    namespace OCA\MyApp\Search;
-
-    use OCP\Search\SearchResultEntry;
-
-    class MySearchResultEntry extends SearchResultEntry {}
-
-
-The above snippet shows this implementation of a result entry. Again, this class should be saved to ``lib/Search`` in the app directory.
-
-Next, you'll see a dummy provider that returns a static set of results using the result entry class from above.
+Next, you'll see a dummy provider that returns a static set of results.
 
 .. code-block:: php
 
@@ -202,6 +185,7 @@ Next, you'll see a dummy provider that returns a static set of results using the
     use OCP\IURLGenerator;
     use OCP\IUser;
     use OCP\Search\IProvider;
+    use OCP\Search\SearchResultEntry;
 
     class Provider implements IProvider {
 
@@ -238,7 +222,7 @@ Next, you'll see a dummy provider that returns a static set of results using the
             return SearchResult::complete(
                 $this->l10n->t('My app'),
                 [
-                    new MySearchResultEntry(
+                    new SearchResultEntry(
                         $this->urlGenerator->linkToRoute(
                             'myapp.Preview.getPreviewByFileId',
                             [

--- a/developer_manual/digging_deeper/search.rst
+++ b/developer_manual/digging_deeper/search.rst
@@ -1,3 +1,5 @@
+.. _unified-search:
+
 ======
 Search
 ======
@@ -394,3 +396,19 @@ For a **cursor-based pagination** a app-specific property is used to know a refe
             );
         }
     }
+
+Optional attributes
+^^^^^^^^^^^^^^^^^^^
+
+The unified search is available via OCS, which means client application like the mobile apps can use it to get access to the server search mechanism. The default properties of a search result entry might be difficult to parse and interpret in those clients, hence it's possible to add optional string attributes to each entry.
+
+.. code-block:: php
+
+    <?php
+
+    $entry = new SearchResultEntry(/* same arguments as above */);
+    $entry->addAttribute("type", "deckCard");
+    $entry->addAttribute("cardId", "1234");
+    $entry->addAttribute("boardId", "567");
+
+.. note:: This method was added in Nextcloud 21. If your app also targets Nextcloud 20 you should either not use it or add a version check to invoke the method only conditionally.


### PR DESCRIPTION
This consists of two commits

1) Fix the misleading docs about the subclass. This changed in https://github.com/nextcloud/server/pull/22103 without an update to this page.
2) Document the new API from https://github.com/nextcloud/server/pull/24474

Rendered

![Bildschirmfoto von 2020-12-04 09-09-06](https://user-images.githubusercontent.com/1374172/101139052-41ba3b80-3611-11eb-9378-c3c77e8a34b9.png)
