### PR TITLE
Disable proxy buffering (download big files)

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -85,7 +85,7 @@ webroot of your nginx installation. In this example it is
       # Remove X-Powered-By, which is an information leak
       fastcgi_hide_header X-Powered-By;
       
-      # Disable buffering (and thus ignoring oxy_max_temp_file_size),
+      # Disable buffering (and thus ignoring proxy_max_temp_file_size),
       # allowing to download larger files without issues.
       proxy_buffering off;
       
@@ -285,7 +285,7 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           # Remove X-Powered-By, which is an information leak
           fastcgi_hide_header X-Powered-By;
           
-          # Disable buffering (and thus ignoring oxy_max_temp_file_size),
+          # Disable buffering (and thus ignoring proxy_max_temp_file_size),
           # allowing to download larger files without issues.
           proxy_buffering off;
 

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -85,6 +85,10 @@ webroot of your nginx installation. In this example it is
       # Remove X-Powered-By, which is an information leak
       fastcgi_hide_header X-Powered-By;
       
+      # Disable buffering (and thus ignoring oxy_max_temp_file_size),
+      # allowing to download larger files without issues.
+      proxy_buffering off;
+      
       # Path to the root of your installation
       root /var/www/nextcloud;
       
@@ -281,6 +285,10 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           # Remove X-Powered-By, which is an information leak
           fastcgi_hide_header X-Powered-By;
           
+          # Disable buffering (and thus ignoring oxy_max_temp_file_size),
+          # allowing to download larger files without issues.
+          proxy_buffering off;
+
           # Specify how to handle directories -- specifying `/nextcloud/index.php$request_uri`
           # here as the fallback means that Nginx always exhibits the desired behaviour
           # when a client requests a path that corresponds to a directory that exists


### PR DESCRIPTION
Disable proxy buffering with Nginx reverse proxy, in order to download large files without issues.  As stated here:

https://docs.nextcloud.com/server/stable/admin_manual/configuration_files/big_file_upload_configuration.html?highlight=big%20files

Currently added to the server context, any feedback is welcome if you think it needs only be added to a certain location context instead.

Regards,
Melroy