### PR TITLE
Give devs a hint that it's their last chance ditch database.xml

### DIFF
--- a/developer_manual/app_publishing_maintenance/upgrade-guide.rst
+++ b/developer_manual/app_publishing_maintenance/upgrade-guide.rst
@@ -19,6 +19,11 @@ App code checker deprecation
 
 The app code checker (``occ app:check-code myapp``) is obsolete due to :ref:`static analysis<app-static-analysis>`. For Nextcloud 21 it will act as NOOP, meaning that you can still call the command but it will never fail. This allows you to still use it on CI if you test against 21, 20 and older releases. But prepare the switch to static analysis if you haven't already. Please also note that the app code checker hadn't received many updates recently, hence the number of issues it can detect is low.
 
+Last version with database.xml support and migration
+****************************************************
+
+Nextcloud 21 is the last major release that supports an app's ``appinfo/database.xml`` to :ref:`define the database schema<database-xml>`. This is your last change to :ref:`automatically convert this deprecated file into the new migration classes<migrate-database-xml>`.
+
 Upgrading to Nextcloud 20
 -------------------------
 

--- a/developer_manual/basics/storage/migrations.rst
+++ b/developer_manual/basics/storage/migrations.rst
@@ -118,6 +118,8 @@ With this the old column gets removed.
           return $schema;
   }
 
+.. _migrate-database-xml:
+
 Migrate from database.xml
 -------------------------
 

--- a/developer_manual/basics/storage/schema.rst
+++ b/developer_manual/basics/storage/schema.rst
@@ -1,3 +1,5 @@
+.. _database-xml:
+
 ============================
 Database schema (deprecated)
 ============================


### PR DESCRIPTION
It looks like 22 will drop the database.xml support alltogether, so
let's motivate devs for the mgiration if they haven't done already.

Then we can fully drop the database.xml docs in 22.

For https://github.com/nextcloud/server/pull/21641

---

Rendered

![Bildschirmfoto von 2020-12-14 10-25-47](https://user-images.githubusercontent.com/1374172/102063953-fa912f00-3df6-11eb-8b08-7518a53d061a.png)
