### PR TITLE
Update admin webserver config recommendations for well known handlers

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -123,13 +123,10 @@ webroot of your nginx installation. In this example it is
       location ^~ /.well-known {
           # The following 6 rules are borrowed from `.htaccess`
       
-          rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
-          rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
-          rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
-          rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
-          
           location = /.well-known/carddav     { return 301 /remote.php/dav/; }
           location = /.well-known/caldav      { return 301 /remote.php/dav/; }
+          # Anything else is dynamically handled by Nextcloud
+          location ^~ /.well-known            { return 301 /index.php$uri; }
 
           try_files $uri $uri/ =404;
       }
@@ -241,13 +238,11 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
       location /.well-known {
           # The following 6 rules are borrowed from `.htaccess`
 
-          rewrite ^/\.well-known/host-meta\.json  /nextcloud/public.php?service=host-meta-json    last;
-          rewrite ^/\.well-known/host-meta        /nextcloud/public.php?service=host-meta         last;
-          rewrite ^/\.well-known/webfinger        /nextcloud/public.php?service=webfinger         last;
-          rewrite ^/\.well-known/nodeinfo         /nextcloud/public.php?service=nodeinfo          last;
-
           location = /.well-known/carddav   { return 301 /nextcloud/remote.php/dav/; }
           location = /.well-known/caldav    { return 301 /nextcloud/remote.php/dav/; }
+
+          # Anything else is dynamically handled by Nextcloud
+          location ^~ /.well-known          { return 301 /nextcloud/index.php$uri; }
 
           try_files $uri $uri/ =404;
       }

--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -244,19 +244,12 @@ URLs:
 
 | ``https://example.com/.well-known/carddav``
 | ``https://example.com/.well-known/caldav``
-| ``https://example.com/.well-known/webfinger``
 |
 
 Those need to be redirecting your clients to the correct endpoints. If Nextcloud
-is running at the document root of your Web server the correct URL is:
-
-``https://example.com/remote.php/dav`` for CardDAV and CalDAV and
-``https://example.com/public.php?service=webfinger``
-
-and if running in a subfolder like ``nextcloud``:
-
-``https://example.com/nextcloud/remote.php/dav``
-``https://example.com/nextcloud/public.php?service=webfinger``
+is running at the document root of your Web server the correct URL is 
+``https://example.com/remote.php/dav`` for CardDAV and CalDAV and if running in a
+subfolder like ``nextcloud``, then ``https://example.com/nextcloud/remote.php/dav``.
 
 For the first case the :file:`.htaccess` file shipped with Nextcloud should do
 this work for you when you're running Apache. You need to make sure that your
@@ -271,9 +264,6 @@ document root of your Web server and add the following lines::
 
     <IfModule mod_rewrite.c>
       RewriteEngine on
-      RewriteRule ^\.well-known/host-meta /nextcloud/public.php?service=host-meta [QSA,L]
-      RewriteRule ^\.well-known/host-meta\.json /nextcloud/public.php?service=host-meta-json [QSA,L]
-      RewriteRule ^\.well-known/webfinger /nextcloud/public.php?service=webfinger [QSA,L]
       RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
       RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav [R=301,L]
     </IfModule>


### PR DESCRIPTION
For https://github.com/nextcloud/server/pull/24702.

Basically well known has to go to Nextcloud, except for the hard-coded DAV routes.

I tested with nginx, both nextcloud hosted in the root as well as as sub directory. Ideally we'd have nginx answer to `./well-known` directly without the index.php prefix but I'm not able to change our default config for this. My previous hand-crafted nginx config allowed this.

@daita please review and test

- [x] Requires https://github.com/nextcloud/server/pull/24702