### PR TITLE
remove global browser caching

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -100,9 +100,6 @@ webroot of your nginx installation. In this example it is
       # always provides the desired behaviour.
       index index.php index.html /index.php$request_uri;
       
-      # Default Cache-Control policy
-      expires 1m;
-      
       # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
       location = / {
           if ( $http_user_agent ~ ^DavClnt ) {
@@ -287,9 +284,6 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           # `try_files $uri $uri/ /nextcloud/index.php$request_uri`
           # always provides the desired behaviour.
           index index.php index.html /nextcloud/index.php$request_uri;
-          
-          # Default Cache-Control policy
-          expires 1m;
 
           # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
           location = /nextcloud {


### PR DESCRIPTION
API calls for the frontend get stuck in the browser cache and the Apache `.htaccess` also doesn't contain anything similar.
Fixes #5472