### PR TITLE
Fix upgrade info about the dbal type vs types class

### DIFF
--- a/developer_manual/app_publishing_maintenance/upgrade-guide.rst
+++ b/developer_manual/app_publishing_maintenance/upgrade-guide.rst
@@ -46,9 +46,9 @@ Some (minor) breaking changes were inevitable. Here's the summary
 * ``$queryBuilder->execute()->errorInfo()`` was removed from Doctrine
 * ``$queryBuilder->execute()->setFetchMode()`` was removed from Doctrine
 * ``$connection->prepare()->execute()`` previously returned ``false`` under some error conditions, it now always gives you an ``IResult`` or throws an exception
-* ``\Doctrine\DBAL\Types\Type`` was removed, which some apps used for column type constants in apps. Use ``\Doctrine\DBAL\Types\Types::*`` or inline the values.
+* ``\Doctrine\DBAL\Types\Type::*`` type constants were moved, which some apps used for column type constants in apps. Use ``\Doctrine\DBAL\Types\Types::*`` or inline the values.
 
-The details of this change can also be seen in the `pull request on Github <https://github.com/nextcloud/server/pull/24948>`__.
+The details of this change can also be seen in the `pull request on Github <https://github.com/nextcloud/server/pull/24948>`__ and in the upstream `dbal 3.0.xx upgrade document <https://github.com/doctrine/dbal/blob/3.0.x/UPGRADE.md>`__.
 
 ``guzzlehttp/guzzle``
 =====================

--- a/developer_manual/basics/storage/migrations.rst
+++ b/developer_manual/basics/storage/migrations.rst
@@ -75,9 +75,9 @@ With this step the new column gets created:
 
 		      $table = $schema->getTable('twofactor_backupcodes');
 
-		      $table->addColumn('user_id', Type::STRING, [
+		      $table->addColumn('user_id', Types::STRING, [
 		              'notnull' => true,
-			            'length' => 64,
+		              'length' => 64,
 		      ]);
 
 		      return $schema;


### PR DESCRIPTION
The class wasn't removed, only the constants are gone.