### PR TITLE
Add link to desktop client 3.1 documentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,28 +284,28 @@
 								<h1>Nextcloud Desktop Client<a class="headerlink" href="#desktop" title="Permalink to this headline">¶</a></h1>
 								<p>Once you have a Nextcloud Server running, you can connect to it with various <a class="reference external" href="https://nextcloud.com/install/#install-clients">clients like our mobile and desktop client.</a>
 								Find documentation for the desktop client below.</p>
+								<div class="section" id="desktop-31">
+									<h2>Desktop 3.1<a class="headerlink" href="#desktop-31" title="Permalink to this headline">¶</a></h2>
+									<p>This documents the <em>latest</em> version of the Nextcloud desktop client.</p>
+									<ul class="simple">
+										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.1">Manual</a>
+									</ul>
+								</div>
 								<div class="section" id="desktop-30">
 									<h2>Desktop 3.0<a class="headerlink" href="#desktop-30" title="Permalink to this headline">¶</a></h2>
-									<p>This documents the <em>latest</em> version of the Nextcloud desktop client.</p>
+									<p>This documents the <em>previous</em> version of the Nextcloud desktop client.</p>
 									<ul class="simple">
 										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.0">Manual</a>
 									</ul>
 								</div>
 								<div class="section" id="desktop-26">
 									<h2>Desktop 2.6<a class="headerlink" href="#desktop-26" title="Permalink to this headline">¶</a></h2>
-									<p>This documents the <em>previous</em> version of the Nextcloud desktop client.</p>
+									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
 									<ul class="simple">
 										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/2.6">Manual</a>
 									</ul>
 								</div>
-								<div class="section" id="desktop-25">
-									<h2>Desktop 2.5<a class="headerlink" href="#desktop-25" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/2.5">Manual</a>
-									</ul>
-								</div>
-                                                        </div>
+							</div>
 						
 							<div class="section" id="nextcloud-older">
 								<h1>Older Nextcloud server releases<a class="headerlink" href="#nextcloud-older" title="Permalink to this headline">¶</a></h1>


### PR DESCRIPTION
Remove link to older version 2.5 since most people are using at least 2.6.

Signed-off-by: Camila <hello@camila.codes>