### PR TITLE
Update reverse_proxy_configuration.rst to remove typo in Traefik config example.

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -76,7 +76,7 @@ Using docker tags:
 
   traefik.frontend.redirect.permanent: 'true'
   traefik.frontend.redirect.regex: https://(.*)/.well-known/(card|cal)dav
-  traefik.frontend.redirect.replacement: https://$$1/remote.php/dav/
+  traefik.frontend.redirect.replacement: https://$1/remote.php/dav/
 
 Using traefik.toml:
 ::


### PR DESCRIPTION
Tiny update, but there was a typo that would prevent redirection from occurring properly for Traefik.