### PR TITLE
Add note about when to enable SSL

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -164,6 +164,8 @@ In case of UTF8MB4 you will also find::
 SSL for MySQL Database
 ^^^^^^^^^^^^^^^^^^^^^^
 
+Enabling SSL is only necessary if your database does not reside on the same server as your Nextcloud instance.
+If you do not connect over localhost and need to allow remote connections then you should enable SSL.
 This just covers the SSL database configuration on the Nextcloud server. First you need to configure your database server accordingly.
 
 ::


### PR DESCRIPTION
As the manual currently reads it sounds like you should always enable SSL for your database. Added note explaining that is is only necessary when you connect remotely.
Since the default install for MariaDB or MySQL only allows communication on localhost through a unix socket, this will not need to be configured for most installs.