### PR TITLE
Clean up Caddy proxy example

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -123,7 +123,7 @@ or
   rewrite ^/\.well-known/carddav https://$server_name/remote.php/dav/ redirect;
   rewrite ^/\.well-known/caldav https://$server_name/remote.php/dav/ redirect;
 
-CADDY
+Caddy
 ^^^^^
 ::
 

--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -128,11 +128,10 @@ CADDY
 ::
 
     subdomain.example.com {
-            reverse_proxy /.well-known/carddav {$NEXTCLOUD_HOST:localhost}/remote.php/dav
+        rewrite /.well-known/carddav /remote.php/dav
+        rewrite /.well-known/caldav /remote.php/dav
 
-            reverse_proxy /.well-known/caldav {$NEXTCLOUD_HOST:localhost}/remote.php/dav
-
-            reverse_proxy * {$NEXTCLOUD_HOST:localhost}
+        reverse_proxy {$NEXTCLOUD_HOST:localhost}
     }
 
 


### PR DESCRIPTION
It's incorrect to use `reverse_proxy` for the dav paths because Caddy does not support paths in proxy addresses. https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#upstreams

Using a rewrite is the correct solution.

Was also pointed out here: https://github.com/nextcloud/documentation/pull/5894#issuecomment-772874944