### PR TITLE
add newline in reverse proxy docs

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -120,6 +120,7 @@ NGINX
 or
 
 ::
+
   rewrite ^/\.well-known/carddav https://$server_name/remote.php/dav/ redirect;
   rewrite ^/\.well-known/caldav https://$server_name/remote.php/dav/ redirect;
 


### PR DESCRIPTION
The nginx-part of the reverse proxy documentation was missing a newline after a ``::``, causing code not to be formatted as code-block.
A very minor change but it improves readability.