### PR TITLE
Remove "host to resolve" from the list of valid options for `trusted_proxies`

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -21,7 +21,6 @@ Set the :file:`trusted_proxies` parameter as an array of:
 * IPv4 addresses, 
 * IPv4 ranges in CIDR notation
 * IPv6 addresses
-* host to resolve
 
 to define the servers Nextcloud should trust as proxies. This parameter
 provides protection against client spoofing, and you should secure those


### PR DESCRIPTION
There is no code to actually support that as far as I can tell