### PR TITLE
Added info about webfinger and nodeinfo

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -257,6 +257,7 @@ Web server is using this file. Additionally, you need the mod_rewrite Apache
 module installed to process these redirects. When running Nginx please refer to
 :doc:`../installation/nginx`.
 
+Additionally  you may also need to create redirects for webfinger and nodeinfo.
 
 If your Nextcloud instance is installed in a subfolder called ``nextcloud`` and
 you're running Apache create or edit the :file:`.htaccess` file within the
@@ -266,7 +267,18 @@ document root of your Web server and add the following lines::
       RewriteEngine on
       RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
       RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav [R=301,L]
+      RewriteRule ^.well-known/webfinger /nextcloud/index.php/.well-known/webfinger [R=301,L]
+      RewriteRule ^.well-known/nodeinfo /nextcloud/index.php/.well-known/nodeinfo [R=301,L]
     </IfModule>
+    
+.. note:: These redirects can also be added directly in your server configuration; you can even use the redirect directive, which is often easier than using mod_rewrite. 
+
+Alternatively, the following should also work::
+
+    Redirect 301 /.well-known/carddav /nextcloud/remote.php/dav
+    Redirect 301 /.well-known/caldav /nextcloud/remote.php/dav
+    Redirect 301 /.well-known/webfinger /nextcloud/index.php/.well-known/webfinger
+    Redirect 301 /.well-known/nodeinfo /nextcloud/index.php/.well-known/nodeinfo
 
 Make sure to change /nextcloud to the actual subfolder your Nextcloud instance is running in.
 


### PR DESCRIPTION
I am not sure what exactly webfinger and nodeinfo is, but at least these redirects seem to fix the:

Your web server is not properly set up to resolve “/.well-known/webfinger”...
Your web server is not properly set up to resolve “/.well-known/nodeinfo”...

Errors that many users seem to get when running Nextcloud in a subfolder.