### PR TITLE
Document primary object storage breaking SSE

### DIFF
--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -27,6 +27,9 @@ Because of this primary object stores usually perform better than when using the
 object store as external storage but it restricts being able to access the files from
 outside of Nextcloud.
 
+.. warning:: Using an object store as primary storage will mean you are `unable to use
+	Nextcloud's server-side encryption functionality <https://github.com/nextcloud/server/issues/22077>`_.
+
 -------------
 Configuration
 -------------


### PR DESCRIPTION
Server-side encryption breaking when using object storage as a primary storage backend is significant, and people should be aware of it when reading documentation rather than running into the issue after having already set up Nextcloud.

All this does is document the existence of issue https://github.com/nextcloud/server/issues/22077.