### PR TITLE
fix nginx well-known redirects when behind another reverse proxy

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -91,6 +91,8 @@ server {
     # `location ~ /(\.|autotest|...)` which would otherwise handle requests
     # for `/.well-known`.
     location ^~ /.well-known {
+        absolute_redirect off;
+
         # The rules in this block are an adaptation of the rules
         # in `.htaccess` that concern `/.well-known`.
 

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -42,6 +42,8 @@ server {
     }
 
     location ^~ /.well-known {
+        absolute_redirect off;
+
         # The rules in this block are an adaptation of the rules
         # in the Nextcloud `.htaccess` that concern `/.well-known`.
 


### PR DESCRIPTION
if nginx is behind another reverse proxy that handles the ssl termination it currently returns the wrong (non-https) redirect for well-known urls.

This change causes the redirect urls to only contain the path