### PR TITLE
Fix documentation stable/latest intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,21 +219,33 @@
 								page for more information.</p>
 							</div>
 
-							<div class="section" id="nextcloud-21">
-								<h2>Nextcloud 21<a class="headerlink" href="#nextcloud-21" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>upcoming</em> version of Nextcloud.</p>
+							<div class="section" id="nextcloud-latest">
+								<h2>Nextcloud 22<a class="headerlink" href="#nextcloud-latest" title="Permalink to this headline">¶</a></h2>
+								<p>This documents the <em>upcoming</em> version of Nextcloud (not released).</p>
 								<ul class="simple">
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/21/user_manual/">User Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/21/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/21/admin_manual/">Administration Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/21/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/21/developer_manual/">Developer Manual</a>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/latest/user_manual/">User Manual</a>
+										(<a class="reference external" href="https://docs.nextcloud.com/server/latest/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/latest/admin_manual/">Administration Manual</a>
+										(<a class="reference external" href="https://docs.nextcloud.com/server/latest/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/latest/developer_manual/">Developer Manual</a>
+								</ul>
+							</div>
+
+							<div class="section" id="nextcloud-stable">
+								<h2>Nextcloud 21<a class="headerlink" href="#nextcloud-stable" title="Permalink to this headline">¶</a></h2>
+								<p>This documents the <em>latest stable</em> version of Nextcloud.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/stable/user_manual/">User Manual</a>
+										(<a class="reference external" href="https://docs.nextcloud.com/server/stable/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/stable/admin_manual/">Administration Manual</a>
+										(<a class="reference external" href="https://docs.nextcloud.com/server/stable/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
+									<li><a class="reference external" href="https://docs.nextcloud.com/server/stable/developer_manual/">Developer Manual</a>
 								</ul>
 							</div>
 
 							<div class="section" id="nextcloud-20">
 								<h2>Nextcloud 20<a class="headerlink" href="#nextcloud-20" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>latest</em> version of Nextcloud.</p>
+								<p>This documents the <em>previous</em> version of Nextcloud.</p>
 								<ul class="simple">
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/20/user_manual/">User Manual</a>
 										(<a class="reference external" href="https://docs.nextcloud.com/server/20/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
@@ -245,7 +257,7 @@
 
 							<div class="section" id="nextcloud-19">
 								<h2>Nextcloud 19<a class="headerlink" href="#nextcloud-19" title="Permalink to this headline">¶</a></h2>
-								<p>This documents a <em>previous</em> version of Nextcloud.</p>
+								<p>This documents the <em>last supported</em> version of Nextcloud.</p>
 								<ul class="simple">
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/19/user_manual/">User Manual</a>
 										(<a class="reference external" href="https://docs.nextcloud.com/server/19/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>


### PR DESCRIPTION
The intro was confusing compared to the urls we're using:
https://docs.nextcloud.com/server/latest/developer_manual/
https://docs.nextcloud.com/server/stable/developer_manual/

I edited that to properly reflect the diffs between latest/stable and last versions.

I also used the aliases `stable` and `latest` for the url as this is easier to change when a new release is pushed.
