### PR TITLE
Removed double information

### DIFF
--- a/user_manual/pim/sync_android.rst
+++ b/user_manual/pim/sync_android.rst
@@ -48,7 +48,7 @@ With the Nextcloud mobile app
 Without the Nextcloud mobile app
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you don't want to install the Nextcloud mobile app, the following
-steps are required after installing DAVx⁵
+steps are required:
 
 1. Install `DAVx⁵ (formerly known as DAVDroid) <https://www.davx5.com/download/>`_ on your Android device, 
    `from Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.davdroid>`_ or 


### PR DESCRIPTION
'after installing DAVx⁵' is redundant, since it's the 1st point of the following numbered table. 

Added colon before list starts.

Reported at Transifex.

Signed-off-by: rakekniven <2069590+rakekniven@users.noreply.github.com>