### PR TITLE
Document calendar embed parameters

### DIFF
--- a/user_manual/pim/calendar.rst
+++ b/user_manual/pim/calendar.rst
@@ -90,7 +90,14 @@ Calendars can be published through a public link to make them viewable (read-onl
 There's also an « embedding code » that provides an HTML iframe to embed your calendar into public pages.
 
 Multiple calendars can be shared together by adding their unique tokens to the end of an embed link. Individual tokens can be found at the end of each calendar's public link. The full address will look like
-``https://cloud.example.com/index.php/apps/calendar/embed/token1-token2-token3``
+``https://cloud.example.com/index.php/apps/calendar/embed/<token1>-<token2>-<token3>``
+
+To change the default view or date of an embedded calendar, you need to provide an url that look like ``https://cloud.example.com/index.php/apps/calendar/embed/<token>/<view>/<date>``.
+In this url you need to replace the following variables:
+
+- ``<token>`` with the calendar's token.
+- ``<view>`` with one of ``month``, ``week``, ``day``, ``listMonth``, ``listWeek``, ``listDay``. The default view is ``month`` and the normally used list is ``listMonth``.
+- ``<date>`` with ``now`` or any date with the following format ``<year>-<month>-<day>`` (e.g. ``2019-12-28``).
 
 On the public page, users are able to get the subscription link for the calendar and download the whole calendar directly.
 


### PR DESCRIPTION
This describe additional parameters in order to embed a calendar using  iframes.

Closes https://github.com/nextcloud/calendar/issues/2938