### PR TITLE
Remove nonexistent event

### DIFF
--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -576,11 +576,6 @@ Emitted when a new user has been created on the back-end.
 
 Emitted before a user is logged out.
 
-``\OCP\User\Events\CreateUserEvent``
-************************************
-
-*Available in Nextcloud 18 and later.*
-
 ``\OCP\User\Events\PostLoginEvent``
 ***********************************
 


### PR DESCRIPTION
There is no string `CreateUserEvent` in the entire nextcloud-server code.