### PR TITLE
Extend legacy encryption scan docs

### DIFF
--- a/admin_manual/configuration_files/encryption_migration.rst
+++ b/admin_manual/configuration_files/encryption_migration.rst
@@ -5,8 +5,7 @@ Encryption migration
 Encryption format
 -----------------
 
-Nextcloud still supports the legacy encryption scheme used for server side encryption.
-However it is recommended to check if you have to still support this scheme.
+Nextcloud still supports the legacy encryption scheme used for server side encryption where the encrypted files did not contain header information. This may still be used for installations that still have encrypted files from <= ownCloud 6. Files will be updated to the new encryption format once they are written again. However it is recommended to check if you have to still support this scheme.
 
 Starting with version 20 for new installations the legacy encryption will be off by default.
 However if you are upgrading there is a migration path to check if you can disable legacy encryption.


### PR DESCRIPTION
Make the documentation about the legacy encryption format and scanning a bit clearer

For reference, the encryption header fallback was added in https://github.com/owncloud/core/pull/15860