### PR TITLE
Update example_ubuntu.rst

### DIFF
--- a/admin_manual/installation/example_ubuntu.rst
+++ b/admin_manual/installation/example_ubuntu.rst
@@ -8,9 +8,9 @@ installation, using Apache and MariaDB, by issuing the following commands in a
 terminal::
 
     sudo apt update
-    sudo apt install apache2 mariadb-server libapache2-mod-php7.4
-    sudo apt install php7.4-gd php7.4-mysql php7.4-curl php7.4-mbstring php7.4-intl
-    sudo apt install php7.4-gmp php7.4-bcmath php-imagick php7.4-xml php7.4-zip
+    sudo apt install apache2 mariadb-server libapache2-mod-php
+    sudo apt install php-gd php-mysql php-curl php-mbstring php-intl
+    sudo apt install php-gmp php-bcmath php-imagick php-xml php-zip
 
 * This installs the packages for the Nextcloud core system. 
   If you are planning on running additional apps, keep in mind that they might require additional
@@ -22,8 +22,7 @@ when you login for the first time.
 
 To start the MySQL command line mode use the following command and press the enter key when prompted for a password::
 
-  sudo /etc/init.d/mysql start
-  sudo mysql -uroot -p
+  sudo mysql
 
 Then a **MariaDB [root]>** prompt will appear. Now enter the following lines, replacing username and password with appropriate values, and confirm them with the enter key:
 


### PR DESCRIPTION
Php package shouldn't be installed with their version number.
The root user of mysql / mariadb is authenticated by unix account, not password.