### PR TITLE
Remove traces of migrations:generate-from-schema

### DIFF
--- a/developer_manual/app_development/tutorial.rst
+++ b/developer_manual/app_development/tutorial.rst
@@ -278,6 +278,8 @@ To create the tables in the database, run the :ref:`migration  <migration_consol
 
 .. note:: to trigger the table creation/alteration when user updating the app, update the :doc:`version tag <info>` in **notestutorial/appinfo/info.xml** . migration will be executed when user reload page after app upgrade
 
+.. note:: to be able to access the occ migrations commands, please enable the debug flag in config.php
+
 .. code-block:: xml
 
   <?xml version="1.0"?>

--- a/developer_manual/app_publishing_maintenance/upgrade-guide.rst
+++ b/developer_manual/app_publishing_maintenance/upgrade-guide.rst
@@ -79,11 +79,6 @@ The original `PSR-0` standard was deprecated in 2014 and therefore the support f
 .. _`PSR-0`: https://www.php-fig.org/psr/psr-0/
 .. _`PSR-4`: https://www.php-fig.org/psr/psr-4/
 
-Last version with database.xml support and migration
-****************************************************
-
-Nextcloud 21 is the last major release that supports an app's ``appinfo/database.xml`` to :ref:`define the database schema<database-xml>`. This is your last change to :ref:`automatically convert this deprecated file into the new migration classes<migrate-database-xml>`.
-
 Replaced well-known handler API
 *******************************
 

--- a/developer_manual/basics/storage/migrations.rst
+++ b/developer_manual/basics/storage/migrations.rst
@@ -118,32 +118,13 @@ With this the old column gets removed.
           return $schema;
   }
 
-.. _migrate-database-xml:
-
-Migrate from database.xml
--------------------------
-
-To migrate your app from a `database.xml` file to migrations run:
-
-.. code-block:: bash
-
-   php ./occ migrations:generate-from-schema <app_id> <version>
-
-This will create a new file under `lib/Migration` that results in the
-same database table(s) as your database.xml file.
-
-For version you should use your app versions. So if you app is at version
-1.2.3 use 010203.
-
-Don't forget to remove your `database.xml` file.
-
 .. _migration_console_command:
 
 Console commands
 ----------------
 
 There are some console commands, which should help developers to create or deal
-with migrations, which are sometimes only available if you are running your
+with migrations, which are only available if you are running your
 Nextcloud in debug mode:
 
 * `migrations:execute`: Executes a single migration version manually.
@@ -156,6 +137,5 @@ Nextcloud in debug mode:
   in another branch. Since you can’t change this retroactive, we recommend to
   leave enough space in between and therefore map the numbers to 3 digits:
   `1.0.x => 1000`, `2.34.x => 2034`, etc.
-* `migrations:generate-from-schema`: Create a migration from the old `database.xml`.
 * `migrations:migrate`: Execute a migration to a specified or the latest available version.
 * `migrations:status`: View the status of a set of migrations.


### PR DESCRIPTION
Remove traces of occ migrations:generate-from-schema which was removed
in NC 22.

Also adjust text that specifies that now ALL migrations:* commands are only
available in debug mode.
