### PR TITLE
Add `_netdev` to fstab

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -161,7 +161,7 @@ automatically every time you log in to your Linux computer.
 7. Add the mount information to ``/etc/fstab``::
 
     https://example.com/nextcloud/remote.php/dav/files/USERNAME/ /home/<linux_username>/nextcloud
-    davfs user,rw,auto 0 0
+    davfs user,rw,auto,_netdev 0 0
 
 
 8. Then test that it mounts and authenticates by running the following


### PR DESCRIPTION
Hi,

if the parameter `auto` is used and the mount is done before the network is up, the system is not reachable via ssh.

With `_netdev` systemd will wait for the network before mounting.

Greetings