### PR TITLE
Recommend latest Python in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Building
 --------
 
 1. Install `pipenv` - https://pipenv.readthedocs.io/en/latest/
-2. Create a Python environment (typically inside this repository): `pipenv --python 3.8`
+2. Create a Python environment (typically inside this repository): `pipenv --python 3.9`
 3. Change into the environment: `pipenv shell`
 4. Install the dependencies `pip install -r requirements.txt`
 5. Now you can use `make ...` to build all the stuff - for example `make html` to build the HTML flavor of all manuals


### PR DESCRIPTION
Newer = better

I use Arch, btw, and there is no 3.8 here.