### PR TITLE
Fix various client API docs issues

### DIFF
--- a/developer_manual/client_apis/OCS/index.rst
+++ b/developer_manual/client_apis/OCS/index.rst
@@ -9,4 +9,4 @@ OCS API
    ocs-api-overview
    ocs-share-api
    ocs-sharee-api
-
+   ocs-status-api

--- a/developer_manual/client_apis/WebDAV/comments.rst
+++ b/developer_manual/client_apis/WebDAV/comments.rst
@@ -1,9 +1,12 @@
-## Comments
+########
+Comments
+########
 
 Comments have a PHP API within OCP and also via WebDAV. Basic documentation below.
 
 
-### Endpoint
+Endpoint
+^^^^^^^^
 
 The Comments resource has an endpoint:
 
@@ -27,7 +30,8 @@ The `CommentID` endpoint accepts:
 For a list of properties, see:
 `https://github.com/nextcloud/server/blob/master/apps/dav/lib/Comments/CommentNode.php#L108`
 
-### Examples of usage
+Examples
+********
 
 REPORT request:
 

--- a/developer_manual/client_apis/WebDAV/index.rst
+++ b/developer_manual/client_apis/WebDAV/index.rst
@@ -5,6 +5,7 @@ Webdav
 ======
 
 .. toctree::
+    :maxdepth: 2
 
     basic
     search

--- a/developer_manual/client_apis/activity-api.rst
+++ b/developer_manual/client_apis/activity-api.rst
@@ -1,1 +1,5 @@
-Find the documentation in the Activities repo here: `https://github.com/nextcloud/activity/blob/master/docs/endpoint-v2.md`
+============
+Activity API
+============
+
+Find the documentation in the `Activity app repo <https://github.com/nextcloud/activity/blob/master/docs/endpoint-v2.md>`__.

--- a/developer_manual/client_apis/index.rst
+++ b/developer_manual/client_apis/index.rst
@@ -12,7 +12,7 @@ Clients and Client APIs
     OCS/index
     LoginFlow/index
     RemoteWipe/index
-    ocs-share-api
-    ocs-sharee-api
+    OCS/ocs-share-api
+    OCS/ocs-sharee-api
     activity-api
     


### PR DESCRIPTION
* Add missing OCS status API page 
* Give the comments page a title, so it get included in TOCs
* Limit WebDAV TOC depth like on other pages
* Give the Activity API page a title so it shows in the TOC
* Fix inclusion of share and sharee OCS API pages