### PR TITLE
Fix dev manual inconsistencies

### DIFF
--- a/developer_manual/basics/index.rst
+++ b/developer_manual/basics/index.rst
@@ -15,3 +15,4 @@ Basic concepts
    backgroundjobs
    logging
    storage/index
+   testing

--- a/developer_manual/basics/request_lifecycle.rst
+++ b/developer_manual/basics/request_lifecycle.rst
@@ -2,12 +2,6 @@
 Request lifecycle
 =================
 
-.. toctree::
-   :maxdepth: 1
-
-   container
-   api
-
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>, Morris Jobke <hey@morrisjobke.de>
 
 A typical HTTP request consists of the following:

--- a/developer_manual/core/index.rst
+++ b/developer_manual/core/index.rst
@@ -9,7 +9,6 @@ Please make sure you have set up a :ref:`devenv`.
 .. toctree::
    :maxdepth: 2
 
-   translation
    unit-testing
    externalapi
    ../how_to/index

--- a/developer_manual/getting_started/index.rst
+++ b/developer_manual/getting_started/index.rst
@@ -7,3 +7,4 @@ Getting started
 
    devenv
    codingguidelines
+   debugging

--- a/developer_manual/prologue/bugtracker/triaging.rst
+++ b/developer_manual/prologue/bugtracker/triaging.rst
@@ -67,7 +67,7 @@ Much content from https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging
 
 The goal of triaging is to have only useful bug reports for the developers. And you don't have to know much to be able to judge at least some bug reports to be less than useful. There are duplications, incomplete reports and so on. Here is the work flow for each bug:
 
-.. figure:: ../images/triageworkflow.png
+.. figure:: ../../images/triageworkflow.png
    :scale: 50
 
 Let's go over each step.

--- a/developer_manual/prologue/index.rst
+++ b/developer_manual/prologue/index.rst
@@ -10,4 +10,3 @@ Prologue
    bugtracker/index
    development_process
    security
-   performance


### PR DESCRIPTION
* Add missing debugging page
* Remove dead request lifecycle sub pages TOC
* Remove dead link to core translations page
* Revive link to basics debugging page
* Fix triage workflow image path
* Remove dead link to performance page

Those were all shown in red during the build. Once resolved I'll see if we can make them errors and let CI error out whenever this happens again.