### PR TITLE
Reorder nginx config sample

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -17,6 +17,9 @@ server {
     listen [::]:443 ssl http2;
     server_name cloud.example.com;
 
+    # Path to the root of your installation
+    root /var/www/nextcloud;
+
     # Use Mozilla's guidelines for SSL/TLS settings
     # https://mozilla.github.io/server-side-tls/ssl-config-generator/
     ssl_certificate     /etc/ssl/nginx/cloud.example.com.crt;
@@ -58,9 +61,6 @@ server {
 
     # Remove X-Powered-By, which is an information leak
     fastcgi_hide_header X-Powered-By;
-
-    # Path to the root of your installation
-    root /var/www/nextcloud;
 
     # Specify how to handle directories -- specifying `/index.php$request_uri`
     # here as the fallback means that Nginx always exhibits the desired behaviour

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -19,6 +19,9 @@ server {
     listen [::]:443 ssl http2;
     server_name cloud.example.com;
 
+    # Path to the root of the domain
+    root /var/www;
+
     # Use Mozilla's guidelines for SSL/TLS settings
     # https://mozilla.github.io/server-side-tls/ssl-config-generator/
     ssl_certificate     /etc/ssl/nginx/cloud.example.com.crt;
@@ -31,9 +34,6 @@ server {
     # in all major browsers and getting removed from this list
     # could take several months.
     #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-
-    # Path to the root of the domain
-    root /var/www;
 
     location = /robots.txt {
         allow all;


### PR DESCRIPTION
Move the `root` directive more to the top. That way all the fields that need to be changed are in one place.