### PR TITLE
Remove IE 11 as supported browser

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -81,7 +81,6 @@ Web browser
 For the best experience with the Nextcloud web interface, we recommend that you use the latest and supported version
 of a browser from this list, or one based on those:
 
-- Microsoft **Internet Explorer 11** (latest version)
 - Microsoft **Edge**
 - Mozilla **Firefox**
 - Google **Chrome**/Chromium


### PR DESCRIPTION
We no longer support IE11 since Nextcloud 22. :tada: 

https://github.com/nextcloud/documentation/blob/f6557b02b9e70664a6f05b6a0dae78d229b3641c/developer_manual/app_publishing_maintenance/upgrade-guide.rst#L42-L45