### PR TITLE
Update access_control.rst

### DIFF
--- a/admin_manual/file_workflows/access_control.rst
+++ b/admin_manual/file_workflows/access_control.rst
@@ -22,7 +22,7 @@ If access to a file has been denied for a user, the user can not:
 Examples
 --------
 After installing the File Access Control app as described in :doc:`../apps_management`
-navigate to the configuration and locate the File Access Control settings.
+navigate to the configuration and locate the settings for the Flow application.
 
     .. figure:: images/files_access_control_sample_rules.png
        :alt: Sample rules to block on user group, time and IP base.


### PR DESCRIPTION
After the installation of the app, the user must move to the Flow app to define a new access control flow. The current explanation makes the user think that there is a dedicated settings section for Files Access Control, but there isnt't