### PR TITLE
Add information about possible reason for broken passwords

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -1789,7 +1789,14 @@ of your php version. Then set the setting to true.
 Nextcloud uses the Argon2 algorithm (with PHP >= 7.2) to create hashes by its
 own and exposes its configuration options as following. More information can
 be found at: https://www.php.net/manual/en/function.password-hash.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+.. note::
+    In some case it can happens what when updating from PHP 7.2 to later
+    versions of PHP, that old passwords don't anymore. This might be caused
+    by the fact that the new PHP version doesn't provide the Argon2 algorithm
+    anymore. On PHP 7.4, you will need to install php-sodium instead.
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 
 ::


### PR DESCRIPTION
This commit adds some additional information about one of the reasons why
passwords might be broken after updating to PHP 7.4. This principally targets
centos/rhel but that might also happen on other systems.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>