### PR TITLE
Update sync_ios.rst

### DIFF
--- a/user_manual/pim/sync_ios.rst
+++ b/user_manual/pim/sync_ios.rst
@@ -11,7 +11,8 @@ Calendar
 #. Select Add Account.
 #. Select Other as account type.
 #. Select Add CalDAV account.
-#. For server, type the domain name of your server i.e. ``example.com``.
+#. For server, type the domain name of your server i.e. ``example.com/remote.php/dav/principals/users/USERNAME/``.
+#. iOS adds https:// in front of your domain automatically. In this case delete https:// again. 
 #. Enter your user name and password.
 #. Select Next.
 
@@ -30,7 +31,8 @@ Contacts
 #. Select Add Account.
 #. Select Other as account type.
 #. Select Add CardDAV account.
-#. For server, type the domain name of your server i.e. ``example.com``.
+#. For server, type the domain name of your server i.e. ``example.com/remote.php/dav/principals/users/USERNAME/``.
+#. iOS adds https:// in front of your domain automatically. In this case delete https:// again. 
 #. Enter your user name and password.
 #. Select Next.
 


### PR DESCRIPTION
just providing the name of the domain wont let you in on an iphone. It will give errors like "SSL not possible, would you like to try without SSL?" (It always gives this error for some reason, even if you provide it with an nonsense URL it can't even resolve.)