### PR TITLE
Added note on apc.enable_cli for system Cron based configs

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -90,6 +90,8 @@ Which returns::
 
 .. note:: On some systems it might be required to call **php-cli** instead of **php**.
 
+.. note:: For some configurations, it might be neccessary to append ``--define apc.enable_cli=1`` to the cron command. Please refer to :doc:`the caching configuration page section APCu<./caching_configuration>`.
+
 .. note:: Please refer to the crontab man page for the exact command syntax.
 
 .. _easyCron: https://www.easycron.com/

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -90,7 +90,7 @@ Which returns::
 
 .. note:: On some systems it might be required to call **php-cli** instead of **php**.
 
-.. note:: For some configurations, it might be neccessary to append ``--define apc.enable_cli=1`` to the cron command. Please refer to :doc:`the caching configuration page section APCu<./caching_configuration>`.
+.. note:: For some configurations, it might be neccessary to append ``--define apc.enable_cli=1`` to the cron command. Please refer to :doc:`./caching_configuration` (section APCu).
 
 .. note:: Please refer to the crontab man page for the exact command syntax.
 


### PR DESCRIPTION
Closes #7051.

This adds a note about the parameter `--define apc.enable_cli=1` that might be necessary for some newer instances. For more information, please refer to the linked issue #7000.