### PR TITLE
fix warnings on webfinger/nodeinfo on OpenBSD

### DIFF
--- a/admin_manual/installation/example_openbsd.rst
+++ b/admin_manual/installation/example_openbsd.rst
@@ -88,7 +88,11 @@ Create a virtualhost in ``/etc/httpd.conf`` and add the following content to it:
 	  }
 
 	  location "/.well-known/webfinger" {
-		  block return 301 "https://$SERVER_NAME/nextcloud/public.php?service=webfinger"
+		  block return 301 "https://$SERVER_NAME/nextcloud/index.php/$DOCUMENT_URI"
+	  }
+
+	  location "/.well-known/nodeinfo" {
+		  block return 301 "https://$SERVER_NAME/nextcloud/index.php/$DOCUMENT_URI"
 	  }
 
 	  location match "/nextcloud/oc[ms]%-provider/*" {


### PR DESCRIPTION
As to the latest package of NextCloud on OpenBSD, this commit mitigates warnings on webfinger and nodeinfo.

Note:
In order to follow the current official Nginx configuration strictly, it may be necessary to include consideration on `/.well-known/acme-challenge` and `/.well-known/pki-validation` , although it had nothing to do with my usage:
https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html?highlight=nginx

![Screenshot_2021-08-26_12-48-04](https://user-images.githubusercontent.com/19984221/130897515-7764ce4e-7671-47f9-a018-6bb867313bf3.png)