### PR TITLE
typo: update formatting and correct capitalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,8 @@ developer_manual/design/icons.txt
 venv
 
 # VScode
-.vscode
+.vscode/
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/README.rst
+++ b/README.rst
@@ -50,39 +50,39 @@ from GitHub.
 Editing
 -------
 
-Contributing to the documentation requires a Github account. Make sure you are
+Contributing to the documentation requires a GitHub account. Make sure you are
 working in the correct branch for your version of Nextcloud or client apps.
 If your edits pertain to multiple manual versions, be prepared to backport as
 needed.
 
 To edit a document, you can edit the .rst files on your local system, or work
-directly on Github. The latter is only suitable for small fixes and improvements
+directly on GitHub. The latter is only suitable for small fixes and improvements
 because substantial editing efforts can better be controlled on your local PC.
 
 The best way is to install a complete Sphinx build environment and work on your
 local PC. You will be able to make your own local builds, which is the fastest
 and best way to preview for errors. Sphinx will report syntax errors, missing
-images, and formatting errors. The Github preview is not complete and misses
+images, and formatting errors. The GitHub preview is not complete and misses
 many mistakes. Create a new branch against the master or stable branch you are
-editing, make your edits, then push your new branch to Github and open a new PR.
+editing, make your edits, then push your new branch to GitHub and open a new PR.
 
-To edit on Github, fork the repository (see top-right of the screen, under
+To edit on GitHub, fork the repository (see top-right of the screen, under
 your username). You will then be able to make changes easily. Once done,
 you can create a pull request and get the changes reviewed and back into
 the official repository.
 
-When editing either on your own local PC or on Github, be sure to sign of
+When editing either on your own local PC or on GitHub, be sure to sign of
 commits, to certify adherence to the Developer Certificate of Origin,
-see https://github.com/probot/dco . Your commit messages need to have, 
+see https://github.com/probot/dco . Your commit messages need to have,
 the name and email address of the contributor.
 
   Signed-off-by: Awesome Contributor <awesome.contributor@reach.me>
-  
-If using the command line and your name and email are configured, you can use 
+
+If using the command line and your name and email are configured, you can use
 
   git commit -s -m 'Commit message'
-  
-In both settings be sure that your email address matches that in your Github profile,
+
+In both settings be sure that your email address matches that in your GitHub profile,
 which if you have privacy enabled will be github.username@users.noreply.github.com
 
 

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -430,10 +430,10 @@ You can find all the available versions `here <https://shop.hanssonit.se/product
 
 For complete instructions and downloads see:
 
-- `Nextcloud VM (Github) <https://github.com/nextcloud/vm/>`_
+- `Nextcloud VM (GitHub) <https://github.com/nextcloud/vm/>`_
 - `Nextcloud VM (T&M Hansson IT) <https://www.hanssonit.se/nextcloud-vm/>`_
 
-.. note:: You can install the VM on several different operating systems as long as you can mount OVA, VMDK, or VHD/VHDX VM in your hypervisor. If you are using KVM then you need to install the VM from the scripts on Github. You can follow the `instructions in the README <https://github.com/nextcloud/vm#build-your-own-vm-or-install-on-a-vps>`_.
+.. note:: You can install the VM on several different operating systems as long as you can mount OVA, VMDK, or VHD/VHDX VM in your hypervisor. If you are using KVM then you need to install the VM from the scripts on GitHub. You can follow the `instructions in the README <https://github.com/nextcloud/vm#build-your-own-vm-or-install-on-a-vps>`_.
 
 .. _snaps_label:
 

--- a/developer_manual/app_development/tutorial.rst
+++ b/developer_manual/app_development/tutorial.rst
@@ -12,9 +12,9 @@ Setup
 
 First the :doc:`development environment <../general/devenv>` needs to be set up. This can be done by either `downloading the zip from the website <https://nextcloud.com/install/>`_ or cloning it directly from GitHub::
 
-   git clone git@github.com:nextcloud/server.git --branch $BRANCH
-   cd server
-   git submodule update --init
+    git clone git@github.com:nextcloud/server.git --branch $BRANCH
+    cd server
+    git submodule update --init
 
 .. note:: ``$BRANCH`` is the desired Nextcloud branch (e.g. ``stable19`` for Nextcloud 19, ``master`` for the upcoming release)
 
@@ -33,11 +33,15 @@ Now open another terminal window and start the development server::
     cd nextcloud
     php -S localhost:8080
 
-*Alternative Setup*:
-Launch with podman (leaner than docker and allows you to run containers without being root):
-    podman run --name=nextcloud --replace=true -p 8080:80 -v /YOUR_FULL_PATH/apps:/var/www/html/custom_apps docker.io/nextcloud
-Launch with docker (not tested):
-    sudo docker run --name=nextcloud --replace=true -p 8080:80 -v /YOUR_FULL_PATH/apps:/var/www/html/custom_apps nextcloud
+*Alternative Setups*:
+
+Launch with podman (leaner than docker and allows you to run containers without being root)::
+
+    podman run --name=nextcloud --replace=true -p 8080:80 -v /absolute/path/to/apps:/var/www/html/custom_apps docker.io/nextcloud
+
+Launch with docker (not tested)::
+
+    sudo docker run --name=nextcloud -p 8080:80 -v /absolute/path/to/apps:/var/www/html/custom_apps nextcloud
 
 Afterwards a skeleton app can be created in the `app store <https://apps.nextcloud.com/developer/apps/generate>`_.
 
@@ -315,7 +319,7 @@ Now that the tables are created we want to map the database result to a PHP obje
         protected $title;
         protected $content;
         protected $userId;
-        
+
         public function __construct() {
             $this->addType('id','integer');
         }

--- a/developer_manual/app_publishing_maintenance/publishing.rst
+++ b/developer_manual/app_publishing_maintenance/publishing.rst
@@ -91,4 +91,4 @@ The goal of these rules is simple: help your project be more successful. We also
 How to move
 ^^^^^^^^^^^
 
-To move your repository to our Github organization, just ask any of our contributors, `especially those who are admin. <https://github.com/orgs/nextcloud/people?utf8=%E2%9C%93&query=+role%3Aowner>`_ They will be happy to help!
+To move your repository to our GitHub organization, just ask any of our contributors, `especially those who are admin. <https://github.com/orgs/nextcloud/people?utf8=%E2%9C%93&query=+role%3Aowner>`_ They will be happy to help!

--- a/developer_manual/app_publishing_maintenance/upgrade-guide.rst
+++ b/developer_manual/app_publishing_maintenance/upgrade-guide.rst
@@ -9,7 +9,7 @@ This document will cover the most important changes in Nextcloud, as well as som
 Upgrading to Nextcloud 22
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/26407>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/26407>`__. See the original ticket for links to the pull requests and tickets.
 
 General
 ^^^^^^^
@@ -19,7 +19,7 @@ Migration commands
 
 The occ commands in the ``migration:*`` namespace are now only available in :ref:`debug mode<debug-mode>`.
 
-See `the pull request on Github <https://github.com/nextcloud/server/pull/27113>`__ for more information. If you thought you needed them, feel free to ping the author or a reviewer of the PR to solve the problem correctly. Running migrations directly mostly breaks the database status and is therefore only meant for debugging faulty migrations.
+See `the pull request on GitHub <https://github.com/nextcloud/server/pull/27113>`__ for more information. If you thought you needed them, feel free to ping the author or a reviewer of the PR to solve the problem correctly. Running migrations directly mostly breaks the database status and is therefore only meant for debugging faulty migrations.
 
 Log format
 **********
@@ -32,7 +32,7 @@ Front-end changes
 Scss variable and compilation deprecation
 *****************************************
 
-Nextcloud is slowly phasing out scss variables and the compilation of app style sheets. It's recommended that apps use their own compilation (e.g. through Webpack) to transform scss and similar to plain css. The ability of Nextcloud compiling scss for apps will be removed in the future. Subscribe to `Github ticket 9940 <https://github.com/nextcloud/server/issues/9940>`__ to get updates on how to best approach this. Right now some scss variables can be replaced with css variables. Other mechanisms like the icon generation still depend on the scss compilation by Nextcloud.
+Nextcloud is slowly phasing out scss variables and the compilation of app style sheets. It's recommended that apps use their own compilation (e.g. through Webpack) to transform scss and similar to plain css. The ability of Nextcloud compiling scss for apps will be removed in the future. Subscribe to `GitHub ticket 9940 <https://github.com/nextcloud/server/issues/9940>`__ to get updates on how to best approach this. Right now some scss variables can be replaced with css variables. Other mechanisms like the icon generation still depend on the scss compilation by Nextcloud.
 
 Node.js upgrade
 ***************
@@ -105,7 +105,7 @@ Deprecated APIs
 Upgrading to Nextcloud 21
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/23210>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/23210>`__. See the original ticket for links to the pull requests and tickets.
 
 General
 ^^^^^^^
@@ -115,7 +115,7 @@ The biggest change in Nextcloud 21 is the initial support for PHP 8 and the corr
 PHP 8 support
 *************
 
-Nextcloud 21 is the first major release that is compatible with the new PHP 8.0. As a consequence, some previously working syntax can cause problems when an app is deployed with PHP newer than 7.4. The full changelog can be found `on the php.net website <https://www.php.net/ChangeLog-8.php>`__. There is also a document for all breaking changes `on Github <https://github.com/php/php-src/blob/PHP-8.0/UPGRADING#L20>`__.
+Nextcloud 21 is the first major release that is compatible with the new PHP 8.0. As a consequence, some previously working syntax can cause problems when an app is deployed with PHP newer than 7.4. The full changelog can be found `on the php.net website <https://www.php.net/ChangeLog-8.php>`__. There is also a document for all breaking changes `on GitHub <https://github.com/php/php-src/blob/PHP-8.0/UPGRADING#L20>`__.
 
 To check compatibility automatically we recommend adding or updating the :ref:`app-ci` of your app so that linters, tests and static analysis can warn you about any problems before the app is shipped to users.
 
@@ -145,7 +145,7 @@ Some (minor) breaking changes were inevitable. Here's the summary
 * ``$connection->prepare()->execute()`` previously returned ``false`` under some error conditions, it now always gives you an ``IResult`` or throws a ``\OCP\DB\Exception``.
 * ``\Doctrine\DBAL\Types\Type::*`` type constants were moved, which some apps used for column type constants in apps. Use the new ``\OCP\DB\Types::*`` as a replacement.
 
-The details of this change can also be seen in the `pull request on Github <https://github.com/nextcloud/server/pull/24948>`__ and in the upstream `dbal 3.0.xx upgrade document <https://github.com/doctrine/dbal/blob/3.0.x/UPGRADE.md>`__.
+The details of this change can also be seen in the `pull request on GitHub <https://github.com/nextcloud/server/pull/24948>`__ and in the upstream `dbal 3.0.xx upgrade document <https://github.com/doctrine/dbal/blob/3.0.x/UPGRADE.md>`__.
 
 ``guzzlehttp/guzzle``
 =====================
@@ -188,7 +188,7 @@ There was an old, unused and inofficial mechanism to hook into well-known discov
 Upgrading to Nextcloud 20
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/20953>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/20953>`__. See the original ticket for links to the pull requests and tickets.
 
 Front-end changes
 ^^^^^^^^^^^^^^^^^
@@ -413,7 +413,7 @@ Removed from public namespace
 Upgrading to Nextcloud 19
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/18479>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/18479>`__. See the original ticket for links to the pull requests and tickets.
 
 Front-end changes
 ^^^^^^^^^^^^^^^^^
@@ -504,7 +504,7 @@ Changed APIs
 Upgrading to Nextcloud 18
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/17131>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/17131>`__. See the original ticket for links to the pull requests and tickets.
 
 Front-end changes
 ^^^^^^^^^^^^^^^^^
@@ -557,7 +557,7 @@ Behavioral changes
 Upgrading to Nextcloud 17
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/15339>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/15339>`__. See the original ticket for links to the pull requests and tickets.
 
 Front-end changes
 ^^^^^^^^^^^^^^^^^
@@ -612,14 +612,14 @@ Deprecations
 Behavioral changes
 ^^^^^^^^^^^^^^^^^^
 
-* LDAP: default value for ``ldapGroupMemberAssocAttr`` changed from ``uniqueMember`` to unset. On scripted setups, it has to be set if LDAP groups should be used within Nextcloud. 
+* LDAP: default value for ``ldapGroupMemberAssocAttr`` changed from ``uniqueMember`` to unset. On scripted setups, it has to be set if LDAP groups should be used within Nextcloud.
 * Provisioning API: creating users will return the assigned user ID as dataset, as in ``['id' => $userid]``.
 
 
 Upgrading to Nextcloud 16
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/12915>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/12915>`__. See the original ticket for links to the pull requests and tickets.
 
 Front-end changes
 ^^^^^^^^^^^^^^^^^
@@ -669,7 +669,7 @@ Removed APIs
 Upgrading to Nextcloud 15
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/15339>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/15339>`__. See the original ticket for links to the pull requests and tickets.
 
 Front-end changes
 ^^^^^^^^^^^^^^^^^
@@ -712,7 +712,7 @@ Removed APIs
 Upgrading to Nextcloud 14
 -------------------------
 
-.. note:: Critical changes were collected `on Github <https://github.com/nextcloud/server/issues/7827>`__. See the original ticket for links to the pull requests and tickets.
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/7827>`__. See the original ticket for links to the pull requests and tickets.
 
 General
 ^^^^^^^
@@ -812,7 +812,7 @@ Added APIs
 Changed APIs
 ************
 
-* OCS API `getGroup` method replaced by `getGroupUsers` #8904 
+* OCS API `getGroup` method replaced by `getGroupUsers` #8904
 
 
 Internal changes

--- a/developer_manual/digging_deeper/continuous_integration.rst
+++ b/developer_manual/digging_deeper/continuous_integration.rst
@@ -116,7 +116,7 @@ Static analysis
 .. Note:: The definition supresses usages of the global and static class ``OC`` like ``\OC::$server``, which is discouraged but still found in some apps. The doctrine supression is currently necessary as the database mappers and schema abstractions leak some of the 3rd party libraries of Nextcloud that are not known to Psalm.
 
 
-You can put this process into a Github Action that is run for every pull request.
+You can put this process into a GitHub Action that is run for every pull request.
 
 .. code-block:: yaml
 

--- a/developer_manual/digging_deeper/javascript-apis.rst
+++ b/developer_manual/digging_deeper/javascript-apis.rst
@@ -17,10 +17,10 @@ Usage
 
 The idea is that apps install these packages via `npm` and bundle the code with tools like `Babel <https://babeljs.io/>`_, `Webpack <https://webpack.js.org/>`_ or `Parcel <https://parceljs.org/>`_. This ensures that an app runs the exact same code independent of the Nextcloud version and also reduces the chances of running into conflicts with other apps.
 
-For more details on the design considerations see `the discussion on Github <https://github.com/nextcloud/server/issues/15932>`_.
+For more details on the design considerations see `the discussion on GitHub <https://github.com/nextcloud/server/issues/15932>`_.
 
 
-.. note:: We highly recommend keeping packages up-to-date as they provide fixes and security patches. For apps with code hosted on Github we recommend the use of `Dependabot <https://dependabot.com/>`_.
+.. note:: We highly recommend keeping packages up-to-date as they provide fixes and security patches. For apps with code hosted on GitHub we recommend the use of `Dependabot <https://dependabot.com/>`_.
 
 
 Compatibility

--- a/developer_manual/getting_started/codingguidelines.rst
+++ b/developer_manual/getting_started/codingguidelines.rst
@@ -103,7 +103,7 @@ User interface
 PHP
 ---
 
-Starting with Nextcloud 19 there is a shared `PHP Coding Standards Fixer <https://github.com/FriendsOfPhp/PHP-CS-Fixer>`_ configuration you can use to automatically format your app's source code. For full details see the `repository on Github <https://github.com/nextcloud/coding-standard/>`_.
+Starting with Nextcloud 19 there is a shared `PHP Coding Standards Fixer <https://github.com/FriendsOfPhp/PHP-CS-Fixer>`_ configuration you can use to automatically format your app's source code. For full details see the `repository on GitHub <https://github.com/nextcloud/coding-standard/>`_.
 
 Always use::
 

--- a/developer_manual/getting_started/devenv.rst
+++ b/developer_manual/getting_started/devenv.rst
@@ -11,7 +11,7 @@ Please follow the steps on this page to set up your development environment.
 Set up Web server and database
 ------------------------------
 
-First `set up your Web server and database <https://docs.nextcloud.org/server/stable/admin_manual/installation/index.html>`_ (**Section**: Manual Installation - Prerequisites).
+First `set up your Web server and database <https://docs.nextcloud.com/server/stable/admin_manual/installation/index.html>`_ (**Section**: Manual Installation - Prerequisites).
 
 .. TODO ON RELEASE: Update version number above on release
 


### PR DESCRIPTION
I was just going through the documentation, so I could try to set up Nextcloud development through Docker.
This just makes some minor edits to improve the documentation.

### Alternate Setups
* Splits the heading from the list of setups.
* Formats them in code blocks, before they displayed invalid commands. (ie `--` became `—`)
* Removes `--replace` argument on Docker, this is not a valid argument for the `docker run` command.

### Links to nextcloud.org
There are links to nextcloud.org scattered around the documentation, I only updated one of them to nextcloud.com because the page name and content is literally the same.

There are however some dead links remaining that I haven't addressed. Someone familiar with the documentation and where resources should be linked may want to `CTRL` + `SHIFT` + `F` and check for all instances of `nextcloud.org`.

### Noun Capitalization
Github → GitHub

### .gitignore
Just ignores Visual Studio Code files from being committed to git.
