### PR TITLE
Add rewrites for nodeinfo and webfinger services.

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -266,6 +266,8 @@ document root of your Web server and add the following lines::
       RewriteEngine on
       RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
       RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav [R=301,L]
+      RewriteRule ^\.well-known/webfinger /nextcloud/index.php/.well-known/webfinger [R=301,L]
+      RewriteRule ^\.well-known/nodeinfo /nextcloud/index.php/.well-known/nodeinfo [R=301,L]
     </IfModule>
 
 Make sure to change /nextcloud to the actual subfolder your Nextcloud instance is running in.


### PR DESCRIPTION
This PR fixes #6157 and adds Apache rewrite rules in the [NC docs](https://docs.nextcloud.com/server/21/admin_manual/issues/general_troubleshooting.html#service-discovery) for webfinger and nodeinfo.

The problem: Starting with NC21, in the system and security check complains about missing redirects, but the documentation behind the links is incomplete:

> Your web server is not properly set up to resolve "/.well-known/webfinger". Further information can be found in the [documentation](https://docs.nextcloud.com/server/21/go.php?to=admin-setup-well-known-URL).
> Your web server is not properly set up to resolve "/.well-known/nodeinfo". Further information can be found in the [documentation](https://docs.nextcloud.com/server/21/go.php?to=admin-setup-well-known-URL).

