### PR TITLE
Add nginx documentation about setting for fix warning of webfinger and nodeinfo.

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -96,6 +96,8 @@ server {
 
         location = /.well-known/carddav { return 301 /remote.php/dav/; }
         location = /.well-known/caldav  { return 301 /remote.php/dav/; }
+        location = /.well-known/webfinger   { return 301 /index.php$uri; }
+        location = /.well-known/nodeinfo    { return 301 /index.php$uri; }
 
         location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
         location /.well-known/pki-validation    { try_files $uri $uri/ =404; }

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -47,6 +47,8 @@ server {
 
         location = /.well-known/carddav { return 301 /nextcloud/remote.php/dav/; }
         location = /.well-known/caldav  { return 301 /nextcloud/remote.php/dav/; }
+        location = /.well-known/webfinger   { return 301 /nextcloud/index.php$uri; }
+        location = /.well-known/nodeinfo    { return 301 /nextcloud/index.php$uri; }
 
         location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
         location /.well-known/pki-validation    { try_files $uri $uri/ =404; }


### PR DESCRIPTION
This fixes nextcloud#6157.

Add a description of the settings to be added to nginx's nextcloud.conf to turn off the following warnings in nginx.

Your web server is not properly set up to resolve “/.well-known/webfinger”
Your web server is not properly set up to resolve “/.well-known/nodeinfo”
