### PR TITLE
Add php APCu hint to command line based updater

### DIFF
--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -160,6 +160,11 @@ Using the command line based updater
 The command line based updater works in the exact same way the web based
 updater works. The steps and checks are the very same.
 
+.. warning:: APCu is disabled by default on CLI which could cause issues with nextcloud's
+   command line based updater. Please make sure you set the ``apc.enable_cli`` to ``1`` on your ``php.ini``
+   config file or append ``--define apc.enable_cli=1`` to the command line based updater call
+   (like ``sudo -u www-data php --define apc.enable_cli=1 /var/www/nextcloud/updater/updater.phar``).
+
 The steps are basically the same as for the web based updater:
 
 1.  You should see a notification at the top of any Nextcloud page when there is


### PR DESCRIPTION
With respect to https://github.com/nextcloud/server/issues/27781 we should add a hint regarding the PHP CLI parameters for APCu like we did in  https://github.com/nextcloud/documentation/commit/c5fa1b6859edfc20477719cf77488a797719e7c3#diff-48dc187eeb03371b5ad6886b33043bf060884809c1d51a3568c5d29e40e3bf13 and https://github.com/nextcloud/documentation/commit/38a0a33e4edc3b7bc18f05ecf190eaf010dea1f4#diff-48dc187eeb03371b5ad6886b33043bf060884809c1d51a3568c5d29e40e3bf13 for the cronjob.