### PR TITLE
Make the example command syntactically correct

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -149,7 +149,7 @@ Adjust chunk size on Nextcloud side
 
 For upload performance improvements in environments with high upload bandwidth, the server's upload chunk size may be adjusted::
 
- sudo -u www-data php occ config:app:set files max_chunk_size --value 20MB
+ sudo -u www-data php occ config:app:set files max_chunk_size --value 20971520
 
 Put in a value in bytes (in this example, 20MB). Set ``--value 0`` for no chunking at all.
 

--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -149,9 +149,9 @@ Adjust chunk size on Nextcloud side
 
 For upload performance improvements in environments with high upload bandwidth, the server's upload chunk size may be adjusted::
 
- sudo -u www-data php occ config:app:set files max_chunk_size
+ sudo -u www-data php occ config:app:set files max_chunk_size --value 20MB
 
-Put in a value in bytes or set ``--value 0`` for no chunking at all.
+Put in a value in bytes (in this example, 20MB). Set ``--value 0`` for no chunking at all.
 
 Default is 10485760 (10 MiB).
 


### PR DESCRIPTION
The example instruction should be complete, so including all the necessary tokens for a valid execution of the command.