### PR TITLE
[stable21] Fix legacy routes like ajax.php on nginx

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -141,6 +141,9 @@ webroot of your nginx installation. In this example it is
       # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
       # to the URI, resulting in a HTTP 500 error response.
       location ~ \.php(?:$|/) {
+          # Required for legacy support
+          rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+
           fastcgi_split_path_info ^(.+?\.php)(/.*)$;
           set $path_info $fastcgi_path_info;
           
@@ -305,6 +308,9 @@ The configuration differs from the "Nextcloud in webroot" configuration above in
           # then Nginx will encounter an infinite rewriting loop when it prepends
           # `/nextcloud/index.php` to the URI, resulting in a HTTP 500 error response.
           location ~ \.php(?:$|/) {
+              # Required for legacy support
+              rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /nextcloud/index.php$request_uri;
+
               fastcgi_split_path_info ^(.+?\.php)(/.*)$;
               set $path_info $fastcgi_path_info;
               


### PR DESCRIPTION
manual backport of https://github.com/nextcloud/documentation/pull/7141

For 22 we extracted the config to separate files, hence the automated backport failed.