### PR TITLE
Fix PHP's rewrite rule in NGINX subdir.conf.sample

### DIFF
--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -115,7 +115,7 @@ server {
         # `/nextcloud/index.php` to the URI, resulting in a HTTP 500 error response.
         location ~ \.php(?:$|/) {
             # Required for legacy support
-            rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /nextcloud/index.php$request_uri;
+            rewrite ^/nextcloud/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /nextcloud/index.php$request_uri;
 
             fastcgi_split_path_info ^(.+?\.php)(/.*)$;
             set $path_info $fastcgi_path_info;


### PR DESCRIPTION
This was introduced by #7141 and should also be backported to stable20, stable21 and stable22.