### PR TITLE
Use --data-binary opton when shoing chunked upload with curl

### DIFF
--- a/developer_manual/client_apis/WebDAV/chunking.rst
+++ b/developer_manual/client_apis/WebDAV/chunking.rst
@@ -44,8 +44,8 @@ sorting always works.
 Where ``XXXXXXXXXXXXXXX`` is the start byte of the chunk (with leading zeros) and
 ``YYYYYYYYYYYYYYY`` is the end byte of the chunk with leading zeros.
 
-``curl -X PUT -u roeland:pass https://server/remote.php/dav/uploads/roeland/myapp-e1663913-4423-4efe-a9cd-26e7beeca3c0/000000000000000-000000010485759 -d @chunk1``
-``curl -X PUT -u roeland:pass https://server/remote.php/dav/uploads/roeland/myapp-e1663913-4423-4efe-a9cd-26e7beeca3c0/000000010485760-000000015728640 -d @chunk2``
+``curl -X PUT -u roeland:pass https://server/remote.php/dav/uploads/roeland/myapp-e1663913-4423-4efe-a9cd-26e7beeca3c0/000000000000000-000000010485759 --data-binary @chunk1``
+``curl -X PUT -u roeland:pass https://server/remote.php/dav/uploads/roeland/myapp-e1663913-4423-4efe-a9cd-26e7beeca3c0/000000010485760-000000015728640 --data-binary @chunk2``
 
 This will upload 2 chunks of a file. The first chunk is 10MB in size and the second
 chunk is 5MB in size.


### PR DESCRIPTION
Otherwise the upload of the individual chunks might fail when using random binary data, e.g. with:

```
dd if=/dev/urandom of=500M.dd bs=1M count=500
curl -k -X PUT -u admin:admin https://nextcloud/remote.php/dav/uploads/admin/upload-1234/500M.dd -d @500M.dd -v
```