### PR TITLE
Allow to serve static WebAssembly and TensorFlow Lite files

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -41,7 +41,7 @@ server {
     gzip_comp_level 4;
     gzip_min_length 256;
     gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/wasm application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
     # Pagespeed is not supported by Nextcloud, so if your server is built
     # with the `ngx_pagespeed` module, uncomment this line to disable it.
@@ -136,10 +136,14 @@ server {
         fastcgi_request_buffering off;
     }
 
-    location ~ \.(?:css|js|svg|gif|png|jpg|ico)$ {
+    location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite)$ {
         try_files $uri /index.php$request_uri;
         expires 6M;         # Cache-Control policy borrowed from `.htaccess`
         access_log off;     # Optional: Don't log access to assets
+
+        location ~ \.wasm$ {
+            default_type application/wasm;
+        }
     }
 
     location ~ \.woff2?$ {

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -68,7 +68,7 @@ server {
         gzip_comp_level 4;
         gzip_min_length 256;
         gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-        gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+        gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/wasm application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
         # Pagespeed is not supported by Nextcloud, so if your server is built
         # with the `ngx_pagespeed` module, uncomment this line to disable it.
@@ -135,10 +135,14 @@ server {
             fastcgi_request_buffering off;
         }
 
-        location ~ \.(?:css|js|svg|gif|png|jpg|ico)$ {
+        location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite)$ {
             try_files $uri /nextcloud/index.php$request_uri;
             expires 6M;         # Cache-Control policy borrowed from `.htaccess`
             access_log off;     # Optional: Don't log access to assets
+
+            location ~ \.wasm$ {
+                default_type application/wasm;
+            }
         }
 
         location ~ \.woff2?$ {


### PR DESCRIPTION
NGINX equivalent to https://github.com/nextcloud/server/pull/29747

[Since Talk 13](https://github.com/nextcloud/spreed/pull/6517) (and thus Nextcloud 23) WebAssembly (.wasm) and TensorFlow Lite (.tflite) files need to be loaded from the web server to provide certain features (like the background blur in the WebUI).

Those files can be treated in a similar way to other static resources, and there should not be any problem caching or compressing them. However, as compressed TensorFlow Lite files are only ~12% smaller, the compression directive depends on the MIME type and [there is no standard MIME type for TensorFlow Lite files](https://www.iana.org/assignments/media-types/media-types.xhtml), for now only WebAssembly files are compressed.

Depending on the setup _application/wasm_ may not be associated with _.wasm_ files, so the directive was added just in case, as the compression is enabled through the MIME type and, besides that, the browsers log a warning if the expected MIME type is not returned.

In any case my NGINX knowledge is almost null, so please review carefully :-)