### PR TITLE
Remove some errors in the build process

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -17,7 +17,6 @@ jobs:
         docs-folder: "user_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
   developer_manual:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +26,6 @@ jobs:
         docs-folder: "developer_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
   admin_manual:
     runs-on: ubuntu-latest
     steps:
@@ -37,4 +35,3 @@ jobs:
         docs-folder: "admin_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -35,9 +35,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Get the date
+      id: get-date
+      shell: bash
+      run: >
+        echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
+    - name: Preparation of icon generation
+      shell: bash
+      run: make icons-docs-prepare
+    - name: Download cached icons
+      uses: actions/cache@v2.1.7
+      id: cached-icons
+      with:
+        path: |
+          developer_manual/html_css_design/img
+          developer_manual/html_css_design/icons.txt
+        key: "icons-\
+          ${{ steps.get-date.outputs.date }}-\
+          ${{ hashFiles('Makefile', 'build/icon-builder/**', 'build/composer.json', 'build/generateIconsDoc.php', 'build/server/core/img/**') }}"
     - name: Build the icons
       shell: bash
       run: make icons-docs-docker
+      if: steps.cached-icons.outputs.cache-hit != 'true'
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "developer_manual/"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -17,6 +17,11 @@ jobs:
         docs-folder: "user_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Upload static documentation
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: User manual.zip
+        path: "user_manual/_build/html"
   user_manual-en:
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +43,11 @@ jobs:
         docs-folder: "developer_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Upload static documentation
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: Developer manual.zip
+        path: "developer_manual/_build/html/com"
   admin_manual:
     runs-on: ubuntu-latest
     steps:
@@ -47,3 +57,8 @@ jobs:
         docs-folder: "admin_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Upload static documentation
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: Administration manual.zip
+        path: "admin_manual/_build/html/com"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -17,11 +17,14 @@ jobs:
         docs-folder: "user_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Pack  the results in local tar file
+      shell: bash
+      run: tar czf /tmp/documentation.tar.gz -C user_manual/_build/html .
     - name: Upload static documentation
       uses: actions/upload-artifact@v2.2.4
       with:
         name: User manual.zip
-        path: "user_manual/_build/html"
+        path: "/tmp/documentation.tar.gz"
   user_manual-en:
     runs-on: ubuntu-latest
     steps:
@@ -62,11 +65,14 @@ jobs:
         docs-folder: "developer_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Pack the results in local tar file
+      shell: bash
+      run: tar czf /tmp/documentation.tar.gz -C developer_manual/_build/html/com .
     - name: Upload static documentation
       uses: actions/upload-artifact@v2.2.4
       with:
         name: Developer manual.zip
-        path: "developer_manual/_build/html/com"
+        path: "/tmp/documentation.tar.gz"
   admin_manual:
     runs-on: ubuntu-latest
     steps:
@@ -76,8 +82,11 @@ jobs:
         docs-folder: "admin_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Pack the results in local tar file
+      shell: bash
+      run: tar czf /tmp/documentation.tar.gz -C admin_manual/_build/html/com .
     - name: Upload static documentation
       uses: actions/upload-artifact@v2.2.4
       with:
         name: Administration manual.zip
-        path: "admin_manual/_build/html/com"
+        path: "/tmp/documentation.tar.gz"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -55,7 +55,12 @@ jobs:
           developer_manual/html_css_design/icons.txt
         key: "icons-\
           ${{ steps.get-date.outputs.date }}-\
-          ${{ hashFiles('Makefile', 'build/icon-builder/**', 'build/composer.json', 'build/generateIconsDoc.php', 'build/server/core/img/**') }}"
+          ${{ hashFiles(\
+            'Makefile', \
+            '.github/workflows/sphinxbuild.yml', \
+            'build/icon-builder/**', 'build/composer.json', 'build/generateIconsDoc.php', \
+            'build/server/core/img/**'\
+          ) }}"
     - name: Build the icons
       shell: bash
       run: make icons-docs-docker

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -30,6 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Build the icons
+      shell: bash
+      run: make icons-docs-docker
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "developer_manual/"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -17,6 +17,15 @@ jobs:
         docs-folder: "user_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+  user_manual-en:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "user_manual/"
+        pre-build-command: pip install -r requirements.txt
+        build-command: make html-lang-en
   developer_manual:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ _build
 *.snag
 
 # Icons files
-developer_manual/design/img
-developer_manual/design/icons.txt
+developer_manual/html_css_design/img
+developer_manual/html_css_design/icons.txt
 
 # Exclude Eclipse project
 .project

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ICON_BUILDER_DOCKER_NAME=icon-docs-builder
+
 all: html pdf
 
 html: admin-manual-html user-manual-html developer-manual-html
@@ -31,8 +33,12 @@ icons-docs: clean-icons-docs
 	cd build && composer install && composer update
 	cd build && php generateIconsDoc.php
 
+icons-docs-docker:
+	docker build -t $(ICON_BUILDER_DOCKER_NAME) build/icon-builder
+	docker run --rm -i -v $(shell pwd):/work $(ICON_BUILDER_DOCKER_NAME)
+
 clean: clean-icons-docs
 	rm -r admin_manual/_build developer_manual/_build user_manual/_build user_manual_de_/_build
 
 clean-icons-docs:
-	rm -rf developer_manual/design/img/
+	rm -rf developer_manual/html_css_design/img/

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,13 @@ user-manual-pdf:
 	cd user_manual && make latexpdf
 	@echo "User manual build finished; PDF is updated"
 
-icons-docs: clean-icons-docs
+icons-docs: icons-docs-prepare
+	$(MAKE) icons-doc-run
+
+icons-docs-prepare: clean-icons-docs
 	cd build && sh get-server-sources.sh $(DRONE_BRANCH)
+
+icons-docs-run:
 	cd build && composer install && composer update
 	cd build && php generateIconsDoc.php
 

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -1638,6 +1638,8 @@ use the occ command ``preview:repair``. For now this will only migrate
 previews that were generated before Nextcloud 19 in the flat
 ``appdata_INSTANCEID/previews/FILEID`` folder structure.
 
+.. _configPHP_Sharing:
+
 Sharing
 -------
 

--- a/admin_manual/maintenance/migrating.rst
+++ b/admin_manual/maintenance/migrating.rst
@@ -61,8 +61,8 @@ the new location. It is also assumed that the authentication method
 	
 #.  Check the config.php file of the **ORIGINAL** system to see if it has
     the ``data-fingerprint`` set to a non-empty value. If this is the case, make
-	sure to also run the ``maintenance:data-fingerprint`` command on the **NEW**
-	system, similarly to how it is required when performing a backup restoration (See :doc:`restore` for details).
+    sure to also run the ``maintenance:data-fingerprint`` command on the **NEW**
+    system, similarly to how it is required when performing a backup restoration (See :doc:`restore` for details).
 
 
 #.  While still having Nextcloud in maintenance mode (confirm!) and **BEFORE**

--- a/build/generateIconsDoc.php
+++ b/build/generateIconsDoc.php
@@ -38,7 +38,7 @@ if (!command_exist('svgexport')) {
 }
 
 $sourceDirectory = __DIR__ . '/server';
-$destinationDirectory = __DIR__ . '/../developer_manual/design/';
+$destinationDirectory = __DIR__ . '/../developer_manual/html_css_design/';
 
 // Init scss compiler
 $scss = new Compiler();

--- a/build/icon-builder/Dockerfile
+++ b/build/icon-builder/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:7
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        npm git sudo \
+        libnss3 libxss1 libasound2 libx11-xcb1 libxcb-dri3-0 libxcomposite1 \
+        libxcursor1 libxdamage1 libxi6 libxtst6 libatk1.0-0 libatk-bridge2.0-0 \
+        libcups2 libxrandr2 libdrm2 libgbm1 libpangocairo-1.0-0 libgtk-3-0 && \
+    apt-get clean && \
+    npm install -g svgexport
+
+# Install composer
+RUN curl https://raw.githubusercontent.com/composer/getcomposer.org/main/web/installer -qL | php -- --quiet && \
+    mv composer.phar /usr/local/bin/composer
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/build/icon-builder/entrypoint.sh
+++ b/build/icon-builder/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+uid=$(stat -c '%u' /work)
+gid=$(stat -c '%g' /work)
+
+groupadd -g $gid worker
+useradd -u $uid -m -g worker worker
+
+cd /work
+
+sudo -u worker make icons-docs
+

--- a/build/icon-builder/entrypoint.sh
+++ b/build/icon-builder/entrypoint.sh
@@ -8,5 +8,5 @@ useradd -u $uid -m -g worker worker
 
 cd /work
 
-sudo -u worker make icons-docs
+sudo -u worker make icons-docs-run
 

--- a/developer_manual/app_development/bootstrap.rst
+++ b/developer_manual/app_development/bootstrap.rst
@@ -102,7 +102,7 @@ Nextcloud 20 and later
 Nextcloud 20 is the first release with the interface ``\OCP\AppFramework\Bootstrap\IBootstrap``. This interface can be
 implemented by your app's ``Application`` class to signal that it wants to act on the bootstrapping stages. The major difference
 between this and the old process is that the boostrapping is not performed in sequence, but apps register and boot
-interleaved. This should ensure that an app that ``boot``s can rely on all other apps' registration to be finished.
+interleaved. This should ensure that an app that ``boot``\s can rely on all other apps' registration to be finished.
 
 The overall process is as follows:
 

--- a/developer_manual/basics/front-end/l10n.rst
+++ b/developer_manual/basics/front-end/l10n.rst
@@ -209,7 +209,7 @@ As a small help, the file in question as well as the line of code is written in 
 
 **Android Strings**
 
-.. code-block:: Android
+.. code-block:: xml
 
     <!-- TRANSLATORS List of deck boards -->
     <string name="simple_boards">Boards</string>

--- a/developer_manual/basics/front-end/templates.rst
+++ b/developer_manual/basics/front-end/templates.rst
@@ -13,9 +13,9 @@ can be accessed through::
     $_['key']
 
 
-.. note:: To prevent XSS the following PHP **functions for printing are forbidden: echo, print() and <?=**. Instead use the **p()** function for printing your values. Should you require unescaped printing, **double check for XSS** and use: :php:func:`print_unescaped`.
+.. note:: To prevent XSS the following PHP **functions for printing are forbidden: echo, print() and <?=**. Instead use the **p()** function for printing your values. Should you require unescaped printing, **double check for XSS** and use: :php:func:`print_unescaped()`.
 
-Printing values is done by using the **p()** function, printing HTML is done by using **print_unescaped()**
+Printing values is done by using the :php:func:`p()` function, printing HTML is done by using :php:func:`print_unescaped()`.
 
 :file:`templates/main.php`
 
@@ -26,7 +26,6 @@ Printing values is done by using the **p()** function, printing HTML is done by 
   <?php
   }
 
-  
 Including templates
 -------------------
 

--- a/developer_manual/client_apis/OCS/ocs-status-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-status-api.rst
@@ -31,9 +31,12 @@ Set your own status
 * Endpoint: ``/status``
 * Data:
 
-    field | type | Description | Allowed values
-    ------|------|-------------|---------------|
-    ``statusType`` | string | New status for the authenticated user | ``online``, ``away``, ``dnd``, ``invisible``, ``offline`` | 
++---------------+--------+---------------------------------------+-----------------------------------------------------------+
+| field         | type   | Description                           | Allowed values                                            |
++---------------+--------+---------------------------------------+-----------------------------------------------------------+
+|``statusType`` | string | New status for the authenticated user | ``online``, ``away``, ``dnd``, ``invisible``, ``offline`` |
++---------------+--------+---------------------------------------+-----------------------------------------------------------+
+
 
 * Response:
     - Status code:
@@ -48,10 +51,12 @@ Set a custom message (predefined)
 * Endpoint: ``/message/predefined``
 * Data:
 
-    field | type | Description 
-    ------|------|------------
-    ``messageId`` | string | Message-Id of the predefined message
-    ``clearAt``   | int    | Unix Timestamp representing the time to clear the status
++---------------+--------+----------------------------------------------------------+
+| field         | type   | Description                                              |
++---------------+--------+----------------------------------------------------------+
+| ``messageId`` | string | Message-Id of the predefined message                     |
+| ``clearAt``   | int    | Unix Timestamp representing the time to clear the status |
++---------------+--------+----------------------------------------------------------+
 
 * Response:
     - Status code:
@@ -67,11 +72,13 @@ Set a custom message (user-defined)
 * Endpoint: ``/message/custom``
 * Data:
 
-    field | type | Description 
-    ------|------|------------
-    ``statusIcon`` | string/null | The icon picked by the user (must be an emoji, at most one)
-    ``message``    | string      | The custom message picked by the user
-    ``clearAt``    | int         | Unix Timestamp representing the time to clear the status
++----------------+-------------+-------------------------------------------------------------+
+| field          | type        | Description                                                 |
++----------------+-------------+-------------------------------------------------------------+
+| ``statusIcon`` | string/null | The icon picked by the user (must be an emoji, at most one) |
+| ``message``    | string      | The custom message picked by the user                       |
+| ``clearAt``    | int         | Unix Timestamp representing the time to clear the status    |
++----------------+-------------+-------------------------------------------------------------+
 
 * Response:
     - Status code:
@@ -118,10 +125,12 @@ Fetch a list of all set user-statuses
 * Endpoint: ``/``
 * Data:
 
-    field | type | Description 
-    ------|------|------------
-    ``limit``  | int | Limit for pagination
-    ``offset`` | int | Offset for pagination
++------------+------+-----------------------+
+| field      | type | Description           |
++------------+------+-----------------------+
+| ``limit``  | int  | Limit for pagination  |
+| ``offset`` | int  | Offset for pagination |
++------------+------+-----------------------+
 
 * Response:
     - Status code:

--- a/developer_manual/client_apis/WebDAV/comments.rst
+++ b/developer_manual/client_apis/WebDAV/comments.rst
@@ -33,62 +33,61 @@ For a list of properties, see:
 Examples
 ********
 
-REPORT request:
+REPORT request::
 
-```
-curl -u user:pwd -i --data-binary "@report.xml" -X REPORT -H "Content-Type: text/xml" http://test.nextcloud.bla/master/remote.php/dav/comments/files/2156
-```
+  curl -u user:pwd -i --data-binary "@report.xml" -X REPORT -H "Content-Type: text/xml" http://test.nextcloud.bla/master/remote.php/dav/comments/files/2156
 
 report.xml your receive:
 
-```
-<?xml version="1.0" encoding="utf-8" ?>
-<D:report xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
-  <oc:limit>5</oc:limit>
-  <oc:offset>0</oc:offset>
-  <oc:datetime>2016-01-18 22:10:30</oc:datetime>
-</D:report>
-```
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <D:report xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns" >
+      <oc:limit>5</oc:limit>
+      <oc:offset>0</oc:offset>
+      <oc:datetime>2016-01-18 22:10:30</oc:datetime>
+    </D:report>
+
 
 Example Output (without headers):
 
-```
-<?xml version="1.0"?>
-<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns">
- <d:response>
-  <oc:comment>
-   <oc:id>3</oc:id>
-   <oc:parentId>0</oc:parentId>
-   <oc:topmostParentId>0</oc:topmostParentId>
-   <oc:childrenCount>0</oc:childrenCount>
-   <oc:message>first</oc:message>
-   <oc:verb>comment</oc:verb>
-   <oc:actorType>users</oc:actorType>
-   <oc:actorId>master</oc:actorId>
-   <oc:objectType>files</oc:objectType>
-   <oc:objectId>2156</oc:objectId>
-   <oc:creationDateTime>2016-01-18 22:01:16</oc:creationDateTime>
-   <oc:latestChildDateTime>2016-01-20 14:01:24</oc:latestChildDateTime>
-  </oc:comment>
- </d:response>
- <d:response>
-  <oc:comment>
-   <oc:id>2</oc:id>
-   <oc:parentId>0</oc:parentId>
-   <oc:topmostParentId>0</oc:topmostParentId>
-   <oc:childrenCount>0</oc:childrenCount>
-   <oc:message>first</oc:message>
-   <oc:verb>comment</oc:verb>
-   <oc:actorType>users</oc:actorType>
-   <oc:actorId>master</oc:actorId>
-   <oc:objectType>files</oc:objectType>
-   <oc:objectId>2156</oc:objectId>
-   <oc:creationDateTime>2016-01-18 22:01:12</oc:creationDateTime>
-   <oc:latestChildDateTime>2016-01-20 14:01:24</oc:latestChildDateTime>
-  </oc:comment>
- </d:response>
-</d:multistatus>
-```
+.. code-block:: xml
+
+  <?xml version="1.0"?>
+  <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns">
+   <d:response>
+    <oc:comment>
+     <oc:id>3</oc:id>
+     <oc:parentId>0</oc:parentId>
+     <oc:topmostParentId>0</oc:topmostParentId>
+     <oc:childrenCount>0</oc:childrenCount>
+     <oc:message>first</oc:message>
+     <oc:verb>comment</oc:verb>
+     <oc:actorType>users</oc:actorType>
+     <oc:actorId>master</oc:actorId>
+     <oc:objectType>files</oc:objectType>
+     <oc:objectId>2156</oc:objectId>
+     <oc:creationDateTime>2016-01-18 22:01:16</oc:creationDateTime>
+     <oc:latestChildDateTime>2016-01-20 14:01:24</oc:latestChildDateTime>
+    </oc:comment>
+   </d:response>
+   <d:response>
+    <oc:comment>
+     <oc:id>2</oc:id>
+     <oc:parentId>0</oc:parentId>
+     <oc:topmostParentId>0</oc:topmostParentId>
+     <oc:childrenCount>0</oc:childrenCount>
+     <oc:message>first</oc:message>
+     <oc:verb>comment</oc:verb>
+     <oc:actorType>users</oc:actorType>
+     <oc:actorId>master</oc:actorId>
+     <oc:objectType>files</oc:objectType>
+     <oc:objectId>2156</oc:objectId>
+     <oc:creationDateTime>2016-01-18 22:01:12</oc:creationDateTime>
+     <oc:latestChildDateTime>2016-01-20 14:01:24</oc:latestChildDateTime>
+    </oc:comment>
+   </d:response>
+  </d:multistatus>
 
 If you want a real life example of use, the announcement center has comments implemented.
 See the comments related files in `https://github.com/nextcloud/announcementcenter/tree/master/js`

--- a/developer_manual/conf.py
+++ b/developer_manual/conf.py
@@ -29,7 +29,7 @@ from conf import *
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions += ['sphinx.ext.todo', 'rst2pdf.pdfbuilder', 'sphinx.ext.intersphinx']
+extensions += ['sphinx.ext.todo', 'rst2pdf.pdfbuilder', 'sphinx.ext.intersphinx', 'sphinxcontrib.phpdomain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['../_shared_assets/templates']

--- a/developer_manual/design/introduction.rst
+++ b/developer_manual/design/introduction.rst
@@ -1,7 +1,5 @@
 ..  _navigation:
 
-..  _newbutton:
-
 ============
 Introduction
 ============

--- a/developer_manual/design/layoutcomponents.rst
+++ b/developer_manual/design/layoutcomponents.rst
@@ -3,8 +3,6 @@ Layout components
 
 All Nextcloud apps are built using individual reusable components for consistency and efficiency. Currently, these components are written in Vue and can be found at the `nextcloud-vue repository on Github <https://github.com/nextcloud/nextcloud-vue/>`_ with the documentation available at `the Nextcloud Vue components style guide <https://nextcloud-vue-components.netlify.app/>`_.
 
-.. _Navigation:
-
 Navigation
 ----------
 

--- a/developer_manual/how_to/index.rst
+++ b/developer_manual/how_to/index.rst
@@ -169,7 +169,7 @@ Test with Nextcloud
 WebAuthn without SSL
 --------------------
 
-`Chrome has the option to test WebAuthn with a fake device.<https://developer.chrome.com/docs/devtools/webauthn/>`_ Browsers support WebAuthn on HTTPS protected sites and localhost domains. Unfortunately this is not supported by the used PHP library where the check for HTTPS needs to be commented for testing on non-HTTPS localhost development environments.
+`Chrome has the option to test WebAuthn with a fake device <https://developer.chrome.com/docs/devtools/webauthn/>`__. Browsers support WebAuthn on HTTPS protected sites and localhost domains. Unfortunately this is not supported by the used PHP library where the check for HTTPS needs to be commented for testing on non-HTTPS localhost development environments.
 
 ::
 

--- a/developer_manual/html_css_design/content.rst
+++ b/developer_manual/html_css_design/content.rst
@@ -1,6 +1,5 @@
 .. sectionauthor:: John Molakvoæ <skjnldsv@protonmail.com>
 .. codeauthor:: John Molakvoæ <skjnldsv@protonmail.com>
-..  _content:
 
 ============
 Main content

--- a/developer_manual/html_css_design/list.rst
+++ b/developer_manual/html_css_design/list.rst
@@ -1,6 +1,5 @@
 .. sectionauthor:: John Molakvoæ <skjnldsv@protonmail.com>
 .. codeauthor:: John Molakvoæ <skjnldsv@protonmail.com>
-..  _list:
 
 =============
 Content list

--- a/developer_manual/html_css_design/navigation.rst
+++ b/developer_manual/html_css_design/navigation.rst
@@ -1,8 +1,5 @@
 .. sectionauthor:: John Molakvoæ <skjnldsv@protonmail.com>
 .. codeauthor:: John Molakvoæ <skjnldsv@protonmail.com>
-..  _navigation:
-
-..  _newbutton:
 
 ===============
 Introduction
@@ -463,8 +460,6 @@ Various information
 
 * You can add the ``icon-loading-small`` class to any ``li`` element to set it in a `loading` state.
 * Every element as a ``min-height`` of 44px as that is the minimum recommended touch target. It also helps with clickability and separation on desktop environments.
-
-..  _settings:
 
 =========
 Settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 rst2pdf
 pillow
 sphinx-rtd-theme
+sphinxcontrib-phpdomain

--- a/user_manual/files/sharing.rst
+++ b/user_manual/files/sharing.rst
@@ -12,7 +12,7 @@ Nextcloud users can share files and folders. Possible targets are:
 * users or groups on federated Nextcloud servers
 
 .. note:: Some options may not be available due to administrative configuration.
-   See :doc:`administrator documentation <file_sharing_configuration>` for details.
+   See `administrator documentation <https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/file_sharing_configuration.html>`__ for details.
 
 
 Public link shares

--- a/user_manual/groupware/sync_android.rst
+++ b/user_manual/groupware/sync_android.rst
@@ -5,8 +5,8 @@ Synchronizing with Android
 Files and notifications
 -----------------------
 
-1. Install the Nextcloud Android client `from Google Play Store <https://play.google.com/store/apps/details?id=com.nextcloud.client>`_ or 
-   `from F-Droid <https://f-droid.org/packages/com.nextcloud.client/>`_.
+1. Install the Nextcloud Android client `from Google Play Store <https://play.google.com/store/apps/details?id=com.nextcloud.client>`__ or 
+   `from F-Droid <https://f-droid.org/packages/com.nextcloud.client/>`__.
 2. Start the app. There are two ways of setting it up:
 
    *Either*: enter
@@ -26,8 +26,8 @@ With the Nextcloud mobile app
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1. Install `DAVx⁵ (formerly known as DAVDroid) <https://www.davx5.com/download/>`_ on your Android device, 
-   `from Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.davdroid>`_ or 
-   `from F-Droid <https://f-droid.org/packages/at.bitfire.davdroid/>`_.
+   `from Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.davdroid>`__ or 
+   `from F-Droid <https://f-droid.org/packages/at.bitfire.davdroid/>`__.
 2. In the Nextcloud mobile, go
    to **Settings**/**More**, tap on "**Sync calendars & contacts**".
 3. Now, DAVx⁵ will open Nextcloud's Webflow login window, where you
@@ -39,8 +39,8 @@ With the Nextcloud mobile app
    order to finish setup, you have to manually launch DAVx⁵ again.
 6. Tap on the icon for the account DAVx⁵ has just created, when requested grant DAVx⁵ access
    to your calendars and contacts. Optionally install OpenTasks 
-   (`Google Play Store <https://play.google.com/store/apps/details?id=org.dmfs.tasks>`_ or
-   `F-Droid <https://f-droid.org/en/packages/org.dmfs.tasks/>`_)
+   (`Google Play Store <https://play.google.com/store/apps/details?id=org.dmfs.tasks>`__ or
+   `F-Droid <https://f-droid.org/packages/org.dmfs.tasks/>`__)
    and grant DAVx⁵ access to your tasks, too.
 7. When you tap the icon for the account DAVx⁵ has set up, it will
    discover the available address books and calendars. Choose which
@@ -53,10 +53,10 @@ If you do not want to install the Nextcloud mobile app, the following
 steps are required:
 
 1. Install `DAVx⁵ (formerly known as DAVDroid) <https://www.davx5.com/download/>`_ on your Android device, 
-   `from Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.davdroid>`_ or 
-   `from F-Droid <https://f-droid.org/packages/at.bitfire.davdroid/>`_.
-2. Optionally install OpenTasks (`Google Play Store <https://play.google.com/store/apps/details?id=org.dmfs.tasks>`_ or
-   `F-Droid <https://f-droid.org/en/packages/org.dmfs.tasks/>`_).
+   `from Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.davdroid>`__ or 
+   `from F-Droid <https://f-droid.org/packages/at.bitfire.davdroid/>`__.
+2. Optionally install `OpenTasks (`Google Play Store` <https://play.google.com/store/apps/details?id=org.dmfs.tasks>`__ or
+   `F-Droid <https://f-droid.org/packages/org.dmfs.tasks/>`__).
 3. Create a new account ("+" button).
 4. Select **Connection with URL and username**.
    **Base URL:** URL of your Nextcloud instance (e.g. ``https://sub.example.com/remote.php/dav``) and 
@@ -73,4 +73,4 @@ steps are required:
    account using the Nextcloud mobile app, this all should be aready the case.
 
 
-.. tip:: DAVx⁵ lists the calendar subscriptions made through the Nextcloud Calendar app, but you need to install the `ICSx⁵ (formerly known as ICSDroid) <https://icsx5.bitfire.at/>`_ app on your Android device, `from the Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.icsdroid>`_ or `from F-Droid <https://f-droid.org/packages/at.bitfire.icsdroid/>`_ to sync them.
+.. tip:: DAVx⁵ lists the calendar subscriptions made through the Nextcloud Calendar app, but you need to install the `ICSx⁵ (formerly known as ICSDroid) <https://icsx5.bitfire.at/>`__ app on your Android device, `from the Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.icsdroid>`__ or `from F-Droid <https://f-droid.org/packages/at.bitfire.icsdroid/>`__ to sync them.

--- a/user_manual/talk/talk_basics.rst
+++ b/user_manual/talk/talk_basics.rst
@@ -75,7 +75,7 @@ In the ``...`` menu you can also choose to reply privately. This will open a one
 Here you can also create a direct link to the message or mark it unread so you will scroll back there next time you enter the chat. When it is a file, you can view the file in Files.
 
 Managing a conversation
----------------
+-----------------------
 
 You are always moderator in your new conversation. In the participant list on the right you can elevate other participants to moderators using the ``...`` menu to the right of their user name, or remove them from the conversation. 
 

--- a/user_manual/webinterface.rst
+++ b/user_manual/webinterface.rst
@@ -15,14 +15,23 @@ For the best experience with the Nextcloud web interface, we recommend that you 
 latest and supported version of a browser from this list:
 
 .. No need to translate
+
 * Microsoft **Internet Explorer**
+
 .. No need to translate
+
 * Microsoft **Edge**
+
 .. No need to translate
+
 * Mozilla **Firefox**
+
 .. No need to translate
+
 * Google **Chrome**/Chromium
+
 .. No need to translate
+
 * Apple **Safari**
 
 .. note:: If you want to use Nextcloud Talk you need to run Mozilla **Firefox** 52+


### PR DESCRIPTION
This is a first step to reduce the number of build errors/warnings and thereby GitHub annotations (#7637).

It should remove any syntactical error in the existing code. However, the translations of the user documentation are handled in transifex. Thus, the annotations introduced by bad translations are not recovered/tackled.