### PR TITLE
admin_delegation_configuration.rst: Fix spelling of 'privilege'

### DIFF
--- a/admin_manual/configuration_server/admin_delegation_configuration.rst
+++ b/admin_manual/configuration_server/admin_delegation_configuration.rst
@@ -1,21 +1,21 @@
-======================
-Admin right priviledge
-======================
+=====================
+Admin right privilege
+=====================
 
 By default only members of the admin group can access and edit the admin
 settings. It is sometimes needed to give some group of users access to a
 setting page while not giving them access to everything. For this you can
-use the *Admin right priviledge* settings.
+use the *Admin right privilege* settings.
 
 .. note::
   Not every setting pages support this features. This is due to either the
   feature not being implemented yet for the specific setting page or due
-  to possible priviledge escalations.
+  to possible privilege escalations.
 
-Configuring Admin right priviledge
-==================================
+Configuring Admin right privilege
+=================================
 
-Go to the *Admin right priviledge* Admin page, you should be presented
+Go to the *Admin right privilege* Admin page, you should be presented
 with the list of settings that support this features.
 
 .. figure:: images/admin-right.png


### PR DESCRIPTION
The correct and up-to-date spelling is 'privilege' without the 'd'.

Signed-off-by: Frieder Schrempf <frieder@fris.de>