### PR TITLE
Removed fixed ROW_FORMAT for MariaDB 10.6

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -1767,7 +1767,6 @@ innodb_file_per_table=ON
 Tables will be created with
  * character set: utf8mb4
  * collation:     utf8mb4_bin
- * row_format:    compressed
 
 See:
 https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html


### PR DESCRIPTION
As statet in https://mariadb.com/kb/en/innodb-compressed-row-format/, the ROW_FORMAT = compressed is made read-only in MariaDB 10.6 and will mostly be removed in MariaDB 10.7. 
I made a pull request in nextcloud/server#30101 for removing the default fixed ROW_FORMAT in code and pulling this to the docs.
