### PR TITLE
Update section on `config_is_read_only` to reflect its changed meaning

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -950,11 +950,11 @@ Defaults to ``true``
 
 In certain environments it is desired to have a read-only configuration file.
 
-When this switch is set to ``true`` Nextcloud will not verify whether the
-configuration is writable. However, it will not be possible to configure
-all options via the Web interface. Furthermore, when updating Nextcloud
-it is required to make the configuration file writable again for the update
-process.
+When this switch is set to ``true``, writing to the configuration file will
+be prevented. Therefore, it will not be possible to configure all options via
+the Web interface. Furthermore, when updating Nextcloud it is required to make
+the configuration file writable again for the update process and to set this
+switch to ``false``.
 
 Defaults to ``false``
 


### PR DESCRIPTION
This depends on https://github.com/nextcloud/server/pull/30130.

Signed-off-by: Jonas Meurer <jonas@freesources.org>