### PR TITLE
Add rewrites for nodeinfo and webfinger services.

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -263,6 +263,8 @@ document root of your Web server and add the following lines::
       RewriteEngine on
       RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
       RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav [R=301,L]
+      RewriteRule ^\.well-known/webfinger /nextcloud/index.php/.well-known/webfinger [R=301,L]
+      RewriteRule ^\.well-known/nodeinfo /nextcloud/index.php/.well-known/nodeinfo [R=301,L]
     </IfModule>
 
 Make sure to change /nextcloud to the actual subfolder your Nextcloud instance is running in.


### PR DESCRIPTION
Add Apache rewrite rules for webfinger and nodeinfo in case NC is installed in a subdirectory. This fixes #6157.

Rebased #7129  on master

Fix #7129 
Fix #6157 