### PR TITLE
Added dedicated build step to build only the English version.

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -17,6 +17,15 @@ jobs:
         docs-folder: "user_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+  user_manual-en:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "user_manual/"
+        pre-build-command: pip install -r requirements.txt
+        build-command: make html-lang-en
   developer_manual:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This should allow us to always see the errors in the original files, even if translations rise more errors than allowed.

Currently, a GitHub workflow can only add 10 annotations per step. When the different languages have individual issues/errors, the basic error in the underlying English original text might get missed. This is critical as all translations will inherit syntax from that files.

By adding a dedicated English build, there are 10 annotations for the English build reserved.

This is part of #7646