### PR TITLE
Update path of icon images to match new file structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ _build
 *.snag
 
 # Icons files
-developer_manual/design/img
-developer_manual/design/icons.txt
+developer_manual/html_css_design/img
+developer_manual/html_css_design/icons.txt
 
 # Exclude Eclipse project
 .project

--- a/build/generateIconsDoc.php
+++ b/build/generateIconsDoc.php
@@ -38,7 +38,7 @@ if (!command_exist('svgexport')) {
 }
 
 $sourceDirectory = __DIR__ . '/server';
-$destinationDirectory = __DIR__ . '/../developer_manual/design/';
+$destinationDirectory = __DIR__ . '/../developer_manual/html_css_design/';
 
 // Init scss compiler
 $scss = new Compiler();


### PR DESCRIPTION
The location of the images has changed according to [the codes](https://github.com/nextcloud/documentation/blob/859f105da94bb8e8e5e2d0975de0d0e1e3b65336/developer_manual/html_css_design/icons.rst?plain=1#L15). This should correct the path in general to avoid wrong paths.

This does however **not** solve the problem, that the icons are not correctly generated. I will tackle this part in a separate PR.

This is part of #7646.