### PR TITLE
Build the icons in GitHub workflow

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -22,9 +22,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Get the date
+      id: get-date
+      shell: bash
+      run: >
+        echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
+    - name: Preparation of icon generation
+      shell: bash
+      run: make icons-docs-prepare
+    - name: Download cached icons
+      uses: actions/cache@v2.1.7
+      id: cached-icons
+      with:
+        path: |
+          developer_manual/html_css_design/img
+          developer_manual/html_css_design/icons.txt
+        key: "icons-\
+          ${{ steps.get-date.outputs.date }}-\
+          ${{ hashFiles('Makefile', 'build/icon-builder/**', 'build/composer.json', 'build/generateIconsDoc.php', 'build/server/core/img/**') }}"
     - name: Build the icons
       shell: bash
       run: make icons-docs-docker
+      if: steps.cached-icons.outputs.cache-hit != 'true'
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "developer_manual/"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Build the icons
+      shell: bash
+      run: make icons-docs-docker
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "developer_manual/"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -39,7 +39,12 @@ jobs:
           developer_manual/html_css_design/icons.txt
         key: "icons-\
           ${{ steps.get-date.outputs.date }}-\
-          ${{ hashFiles('Makefile', 'build/icon-builder/**', 'build/composer.json', 'build/generateIconsDoc.php', 'build/server/core/img/**') }}"
+          ${{ hashFiles(\
+            'Makefile', \
+            '.github/workflows/sphinxbuild.yml', \
+            'build/icon-builder/**', 'build/composer.json', 'build/generateIconsDoc.php', \
+            'build/server/core/img/**'\
+          ) }}"
     - name: Build the icons
       shell: bash
       run: make icons-docs-docker

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ICON_BUILDER_DOCKER_NAME=icon-docs-builder
+
 all: html pdf
 
 html: admin-manual-html user-manual-html developer-manual-html
@@ -31,8 +33,12 @@ icons-docs: clean-icons-docs
 	cd build && composer install && composer update
 	cd build && php generateIconsDoc.php
 
+icons-docs-docker:
+	docker build -t $(ICON_BUILDER_DOCKER_NAME) build/icon-builder
+	docker run --rm -i -v $(shell pwd):/work $(ICON_BUILDER_DOCKER_NAME)
+
 clean: clean-icons-docs
 	rm -r admin_manual/_build developer_manual/_build user_manual/_build user_manual_de_/_build
 
 clean-icons-docs:
-	rm -rf developer_manual/design/img/
+	rm -rf developer_manual/html_css_design/img/

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,13 @@ user-manual-pdf:
 	cd user_manual && make latexpdf
 	@echo "User manual build finished; PDF is updated"
 
-icons-docs: clean-icons-docs
+icons-docs: icons-docs-prepare
+	$(MAKE) icons-doc-run
+
+icons-docs-prepare: clean-icons-docs
 	cd build && sh get-server-sources.sh $(DRONE_BRANCH)
+
+icons-docs-run:
 	cd build && composer install && composer update
 	cd build && php generateIconsDoc.php
 

--- a/build/icon-builder/Dockerfile
+++ b/build/icon-builder/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:7
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        npm git sudo \
+        libnss3 libxss1 libasound2 libx11-xcb1 libxcb-dri3-0 libxcomposite1 \
+        libxcursor1 libxdamage1 libxi6 libxtst6 libatk1.0-0 libatk-bridge2.0-0 \
+        libcups2 libxrandr2 libdrm2 libgbm1 libpangocairo-1.0-0 libgtk-3-0 && \
+    apt-get clean && \
+    npm install -g svgexport
+
+# Install composer
+RUN curl https://raw.githubusercontent.com/composer/getcomposer.org/main/web/installer -qL | php -- --quiet && \
+    mv composer.phar /usr/local/bin/composer
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/build/icon-builder/Dockerfile
+++ b/build/icon-builder/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     npm install -g svgexport
 
 # Install composer
-RUN curl https://raw.githubusercontent.com/composer/getcomposer.org/main/web/installer -qL | php -- --quiet && \
+RUN curl -qsSfL https://raw.githubusercontent.com/composer/getcomposer.org/main/web/installer | php -- --quiet && \
     mv composer.phar /usr/local/bin/composer
 
 COPY entrypoint.sh /entrypoint.sh

--- a/build/icon-builder/entrypoint.sh
+++ b/build/icon-builder/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+uid=$(stat -c '%u' /work)
+gid=$(stat -c '%g' /work)
+
+groupadd -g $gid worker
+useradd -u $uid -m -g worker worker
+
+cd /work
+
+sudo -u worker make icons-docs
+

--- a/build/icon-builder/entrypoint.sh
+++ b/build/icon-builder/entrypoint.sh
@@ -8,5 +8,5 @@ useradd -u $uid -m -g worker worker
 
 cd /work
 
-sudo -u worker make icons-docs
+sudo -u worker make icons-docs-run
 


### PR DESCRIPTION
The icons are currently not built at all. Thus, a local deployment cannot show these. In the official documentation, the icons are not either. As the exact deployment structure is not known, this PR just adds the functionality to build the images within the GitHub action but not publish it anywhere.

If required, I can extend this to store the generated images within the repo or do other things if required. Please tell me so if this was the case.

This is the second part of #7829 and part of #7646.