### PR TITLE
Create build artifacts in Github Actions

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -17,6 +17,11 @@ jobs:
         docs-folder: "user_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Upload static documentation
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: User manual.zip
+        path: "user_manual/_build/html"
   user_manual-en:
     runs-on: ubuntu-latest
     steps:
@@ -35,6 +40,11 @@ jobs:
         docs-folder: "developer_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Upload static documentation
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: Developer manual.zip
+        path: "developer_manual/_build/html/com"
   admin_manual:
     runs-on: ubuntu-latest
     steps:
@@ -44,3 +54,8 @@ jobs:
         docs-folder: "admin_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Upload static documentation
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: Administration manual.zip
+        path: "admin_manual/_build/html/com"

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -17,11 +17,14 @@ jobs:
         docs-folder: "user_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Pack  the results in local tar file
+      shell: bash
+      run: tar czf /tmp/documentation.tar.gz -C user_manual/_build/html .
     - name: Upload static documentation
       uses: actions/upload-artifact@v2.2.4
       with:
         name: User manual.zip
-        path: "user_manual/_build/html"
+        path: "/tmp/documentation.tar.gz"
   user_manual-en:
     runs-on: ubuntu-latest
     steps:
@@ -40,11 +43,14 @@ jobs:
         docs-folder: "developer_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Pack the results in local tar file
+      shell: bash
+      run: tar czf /tmp/documentation.tar.gz -C developer_manual/_build/html/com .
     - name: Upload static documentation
       uses: actions/upload-artifact@v2.2.4
       with:
         name: Developer manual.zip
-        path: "developer_manual/_build/html/com"
+        path: "/tmp/documentation.tar.gz"
   admin_manual:
     runs-on: ubuntu-latest
     steps:
@@ -54,8 +60,11 @@ jobs:
         docs-folder: "admin_manual/"
         pre-build-command: pip install -r requirements.txt
         build-command: make html
+    - name: Pack the results in local tar file
+      shell: bash
+      run: tar czf /tmp/documentation.tar.gz -C admin_manual/_build/html/com .
     - name: Upload static documentation
       uses: actions/upload-artifact@v2.2.4
       with:
         name: Administration manual.zip
-        path: "admin_manual/_build/html/com"
+        path: "/tmp/documentation.tar.gz"


### PR DESCRIPTION
This PR will allow the user/developer to download a preview of the documentation from the GitHub action as an artifact. This is a precompiled set of HTML pages (plus assets) as generated for deployment. This is mainly for convenience. 

This is part of #7646 to debug the process.