### PR TITLE
Remove iconv from required PHP modules

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -40,7 +40,6 @@ Required:
 * PHP module filter (only on Mageia and FreeBSD)
 * PHP module GD
 * PHP module hash (only on FreeBSD)
-* PHP module iconv
 * PHP module JSON
 * PHP module libxml (Linux package libxml2 must be >=2.7.0)
 * PHP module mbstring


### PR DESCRIPTION
The usage of iconv has been removed in: https://github.com/nextcloud/server/pull/29470

The dependency has been removed in: https://github.com/nextcloud/server/pull/29958