### PR TITLE
Usage of env settings in package.json

### DIFF
--- a/developer_manual/digging_deeper/npm.rst
+++ b/developer_manual/digging_deeper/npm.rst
@@ -27,7 +27,7 @@ For apps that use webpack, this might look like this:
   {
     "name": "myapp",
     "scripts": {
-      "build": "NODE_ENV=production webpack --progress --hide-modules --config webpack.prod.js"
+      "build": "webpack --node-env production --progress --hide-modules --config webpack.prod.js"
     },
     "devDependencies": {
       "webpack": "^4.26.1",
@@ -53,9 +53,9 @@ This command should be added to ``package.json`` as ``dev``  and ``watch`` scrip
   {
     "name": "myapp",
     "scripts": {
-      "build": "NODE_ENV=production webpack --progress --hide-modules --config webpack.prod.js",
-      "dev": "NODE_ENV=development webpack --progress --config webpack.dev.js",
-      "watch": "NODE_ENV=development webpack --progress --watch --config webpack.dev.js"
+      "build": "webpack --node-env production --progress --hide-modules --config webpack.prod.js",
+      "dev": "webpack --node-env development --progress --config webpack.dev.js",
+      "watch": "webpack --node-env development --progress --watch --config webpack.dev.js"
     },
     "devDependencies": {
       "webpack": "^4.26.1",

--- a/developer_manual/digging_deeper/npm.rst
+++ b/developer_manual/digging_deeper/npm.rst
@@ -30,8 +30,8 @@ For apps that use webpack, this might look like this:
       "build": "webpack --node-env production --progress --hide-modules --config webpack.prod.js"
     },
     "devDependencies": {
-      "webpack": "^4.26.1",
-      "webpack-cli": "^3.1.2",
+      "webpack": "^5.65.0",
+      "webpack-cli": "^4.9.1",
     }
   }
 
@@ -58,8 +58,8 @@ This command should be added to ``package.json`` as ``dev``  and ``watch`` scrip
       "watch": "webpack --node-env development --progress --watch --config webpack.dev.js"
     },
     "devDependencies": {
-      "webpack": "^4.26.1",
-      "webpack-cli": "^3.1.2",
+      "webpack": "^5.65.0",
+      "webpack-cli": "^4.9.1",
     }
   }
 


### PR DESCRIPTION
Change documentation referring the usage of webpack to get it more platform independent
* use `--node-env` switch instead of `NODE_ENV=`
* update examples to lates `webpack` and `webpack-cli` versions

Connected to 
* https://github.com/nextcloud/calendar/pull/3859
* https://github.com/nextcloud/app-tutorial/pull/362
* https://github.com/nextcloud/webpack-vue-config/pull/268