### PR TITLE
docs(email_configuration): SMTPS is not outdated

### DIFF
--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -168,7 +168,7 @@ the following two variants:
 SSL
 ^^^
 
-A secure connection will be initiated using the outdated SMTPS protocol
+A secure connection will be initiated using the SMTPS protocol
 which uses the port 465/tcp:
 
 ::
@@ -331,18 +331,20 @@ listening on localhost port 25.
 
 * 143/tcp/udp is unencrypted imap4
 
-* 465/tcp is encrypted ssmtp
+* 465/tcp is encrypted submissions
+
+* 587/tcp is opportunistically-encrypted submission
 
 * 993/tcp/udp is encrypted imaps
 
 * 995/tcp/udp is encrypted pop3s
 
 
-**Question**: How can I determine if the SMTP server supports the outdated SMTPS
+**Question**: How can I determine if the SMTP server supports the SMTPS
 protocol?
 
 **Answer**: A good indication that the SMTP server supports the SMTPS protocol
-is that it is listening on port **465**.
+is that it is listening on the `submissions` port **465**.
 
 **Question**: How can I determine what authorization and encryption protocols
 the mail server supports?


### PR DESCRIPTION
The documentation previously stated that the SMTPS protocol is outdated, while this isn't true. The "port 465 situation" is often misunderstood because its usage has changed over the years, and this caused confusion, with old documents saying one thing, newer ones saying another one, and updated ones a different thing again. Wikipedia has a short, good explanation about the situation: https://en.wikipedia.org/wiki/SMTPS

In short, as of 2018, thanks to [RFC8314](https://datatracker.ietf.org/doc/html/rfc8314#section-3.3), port 465 should be used similarly to port 587 (i.e. for _submission_ of emails), with the difference that instead of using STARTTLS for _maybe_ securing the communication with TLS, port 465 uses implicit TLS encryption, similarly to HTTPS (hence the name `submissions`, where `s` stands for secure).

As an example, you take a quick look at the output of `grep 465 /etc/services` on your Linux/BSD system.

Please note that I'm not an email expert, just a curious guy that runs his own email server :)