### PR TITLE
Ensure that nginx config sample allow downloading big file

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -134,6 +134,8 @@ server {
 
         fastcgi_intercept_errors on;
         fastcgi_request_buffering off;
+
+        fastcgi_max_temp_file_size 0;
     }
 
     location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite)$ {

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -133,6 +133,8 @@ server {
 
             fastcgi_intercept_errors on;
             fastcgi_request_buffering off;
+
+            fastcgi_max_temp_file_size 0;
         }
 
         location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite)$ {


### PR DESCRIPTION
"fastcgi_max_temp_file_size 0;" makes it possible to download file
bigger than 1GB. See https://help.nextcloud.com/t/synchronization-impossible-on-files-larger-than-1gb/66323/2
