### PR TITLE
Adapted Webfinger and Nodeinfo for Nginx

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -97,6 +97,8 @@ server {
 
         location = /.well-known/carddav { return 301 /remote.php/dav/; }
         location = /.well-known/caldav  { return 301 /remote.php/dav/; }
+        location = /.well-known/webfinger { return 301 /index.php/.well-known/webfinger/; }
+        location = /.well-known/nodeinfo { return 301 index.php/.well-known/nodeinfo/; }
 
         location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
         location /.well-known/pki-validation    { try_files $uri $uri/ =404; }


### PR DESCRIPTION
I guess they were missing?! Another thing is that without them all checks are being passed - while adding them, it can results in more security and setup warnings!