### PR TITLE
Add section about activities in external storages

### DIFF
--- a/admin_manual/configuration_server/activity_configuration.rst
+++ b/admin_manual/configuration_server/activity_configuration.rst
@@ -50,6 +50,15 @@ like in normal shares when set to ``true``.
     2. Users that had access to a groupfolder, share or external storage can see activities in their stream and emails that happen after they are removed until they login again
     3. Users that are newly added to a groupfolder, share or external storage can not see activities in their stream nor emails that happen after they are added until they login again
 
+.. _label-activities-externalstorages:
+
+Activities in external storages
+-------------------------------
+
+When external storages have been configured in a way that multiple users have access to it,
+you can use the config flag ``activity_use_cached_mountpoints`` that makes activities
+with external storages work like in normal shares when set to ``true``.
+
 Better scheduling of activity emails
 ------------------------------------
 

--- a/admin_manual/configuration_server/activity_configuration.rst
+++ b/admin_manual/configuration_server/activity_configuration.rst
@@ -34,12 +34,12 @@ you to clean-up older activities from the database.
 
 .. _label-activities-groupfolders:
 
-Activities in groupfolders
---------------------------
+Activities in groupfolders or external storages
+-----------------------------------------------
 
-By default activities in groupfolders are only generated for the current user.
-This is due to the logic of groupfolders. There is a config flag
-``activity_use_cached_mountpoints`` that makes activities in groupfolders work
+By default activities in groupfolders or external storages are only generated for the current user.
+This is due to the logic of groupfolders and external storages. There is a config flag
+``activity_use_cached_mountpoints`` that makes activities in groupfolders and external storages work
 like in normal shares when set to ``true``.
 
 .. warning::
@@ -49,15 +49,6 @@ like in normal shares when set to ``true``.
     1. If "Advanced Permissions" (ACLs) are enabled in a groupfolder, the activities don't respect the permissions and therefore all users see all activities, even for files and directories they don't have access to. **This potentially leaks sensitive information!** See `this issue <https://github.com/nextcloud/groupfolders/issues/1057>`_ for more information.
     2. Users that had access to a groupfolder, share or external storage can see activities in their stream and emails that happen after they are removed until they login again
     3. Users that are newly added to a groupfolder, share or external storage can not see activities in their stream nor emails that happen after they are added until they login again
-
-.. _label-activities-externalstorages:
-
-Activities in external storages
--------------------------------
-
-When external storages have been configured in a way that multiple users have access to it,
-you can use the config flag ``activity_use_cached_mountpoints`` that makes activities
-with external storages work like in normal shares when set to ``true``.
 
 Better scheduling of activity emails
 ------------------------------------


### PR DESCRIPTION
This got mentioned to me by @nickvergessen and I've tested this locally on 23.0.2 with a globally mounted external storage (with an empty "available for").
