### PR TITLE
Remove meaningless note regarding "testEcho" from tutorial

### DIFF
--- a/developer_manual/app_development/tutorial.rst
+++ b/developer_manual/app_development/tutorial.rst
@@ -857,8 +857,6 @@ If `PHPUnit in version 8 is installed <https://phpunit.de/>`_ we can run the tes
 
     phpunit
 
-.. note:: You need to adjust the **notestutorial/tests/Unit/Controller/PageControllerTest** file to get the tests passing: remove the **testEcho** method since that method is no longer present in your **PageController** and do not test the user id parameters since they are not passed anymore
-
 Integration tests
 -----------------
 


### PR DESCRIPTION
"testEcho" method isn't mentioned anywhere else in the tutorial and it
is not present in the app-tutorial git repository either.

Executing `git log -S testEcho` in both repositories doesn't show the
string in any other place, so remove the note.

Signed-off-by: Helen Koike <helen@koikeco.de>