### PR TITLE
Document Calendar default alarm type for admins

### DIFF
--- a/admin_manual/groupware/calendar.rst
+++ b/admin_manual/groupware/calendar.rst
@@ -45,6 +45,17 @@ You'll also need to change the sending mode from ``background-job`` to ``occ``::
 
 If you don't use this dedicated command, the reminders will just be sent as soon as possible when the background jobs run.
 
+Event alarm types
+-----------------
+
+Nextcloud allows users to set notification and email reminders for events. Admins can enforce one of the two options::
+
+ occ config:app:set calendar forceEventAlarmType --value=EMAIL
+
+Allowed values are ``EMAIL`` (email) and ``DISPLAY`` (notification).
+
+.. note:: This only enforces alarm types for events created with the Nextcloud Calendar. This setting has no influence for other connected applications.
+
 FreeBusy
 --------
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/documentation/issues/8114