### PR TITLE
emphasize that debug mode is required

### DIFF
--- a/developer_manual/basics/storage/migrations.rst
+++ b/developer_manual/basics/storage/migrations.rst
@@ -125,7 +125,7 @@ Console commands
 
 There are some console commands, which should help developers to create or deal
 with migrations, which are only available if you are running your
-Nextcloud in debug mode:
+Nextcloud **in debug mode**:
 
 * `migrations:execute`: Executes a single migration version manually.
 * `migrations:generate`:


### PR DESCRIPTION
I was searching and debugging the core code to find out why all `migrations:` commands are gone. It's documented, but who reads until the end of an introduction text? :smile: