### PR TITLE
Remove link to android doc

### DIFF
--- a/user_manual/index.rst
+++ b/user_manual/index.rst
@@ -16,13 +16,10 @@ You can share one or more files and folders on your computer, and synchronize
 them with your Nextcloud server. Place files in your local shared directories,
 and those files are immediately synchronized to the server and to other devices
 using the Nextcloud Desktop Sync Client, Android app, or iOS app. To
-learn more about the Nextcloud desktop and mobile clients, please refer to
-their respective manuals:
+learn more about the Nextcloud desktop, please refer to:
 
 * `Nextcloud Desktop Client`_
-* `Nextcloud Android App`_
 
 .. _`Nextcloud Desktop Client`: https://docs.nextcloud.com/desktop/latest/
-.. _`Nextcloud Android App`: https://docs.nextcloud.com/android/
 
 `Help translate <https://www.transifex.com/nextcloud/nextcloud-user-documentation/>`_.


### PR DESCRIPTION
Remove link to non-existant android documentation, ref: https://github.com/nextcloud/documentation/issues/1583

Signed-off-by: Joachim Boerner <tflidd@aspekte.net>