### PR TITLE
admin: add note about json and openssl being included since php8

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -40,10 +40,10 @@ Required:
 * PHP module filter (only on Mageia and FreeBSD)
 * PHP module GD
 * PHP module hash (only on FreeBSD)
-* PHP module JSON
+* PHP module JSON (included with PHP >= 8.0)
 * PHP module libxml (Linux package libxml2 must be >=2.7.0)
 * PHP module mbstring
-* PHP module openssl
+* PHP module openssl (included with PHP >= 8.0)
 * PHP module posix
 * PHP module session
 * PHP module SimpleXML


### PR DESCRIPTION
Hi,
as @Hell-o-Admin pointed out in #7121, the PHP modules ``json`` and ``openssl`` are now included since PHP8.0 and thus do not have to be installed manually anymore.
I have verified this on FreeBSD 12 and Arch Linux as shown [here](https://forums.cpanel.net/threads/can-not-find-some-of-te-php7-3-extensions-like-json-and-openssl.665241/): ``php -i | grep -E -i '(json|openssl)'``

How to verify:

- have an OS with PHP8.0 support
- install PHP8.0 without any additional modules
- run command above
- OpenSSL support and JSON support should show "enabled"

To prevent confusion while doing a manual install, i'd suggest adding a note in the installation instructions.

closes #7121