### PR TITLE
Update broken link to client manual

### DIFF
--- a/user_manual/files/desktop_mobile_sync.rst
+++ b/user_manual/files/desktop_mobile_sync.rst
@@ -16,7 +16,7 @@ have your latest files with you wherever you are.
 
 Its usage is documented separately in the `Nextcloud Desktop Client Manual`_.
 
-.. _`Nextcloud Desktop Client Manual`: https://docs.nextcloud.com/desktop/2.6
+.. _`Nextcloud Desktop Client Manual`: https://docs.nextcloud.com/desktop/3.5
 .. _`Nextcloud Sync Client`: https://nextcloud.com/install/#install-clients
 
 Mobile clients


### PR DESCRIPTION
Update of `desktop_mobile_sync.rst`: The current desktop client docs link of v.2.6 leads to a "File not found.". An update to v.3.5 fixes that.