### PR TITLE
Fix command options formatting

### DIFF
--- a/admin_manual/configuration_files/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration_files/external_storage_configuration_gui.rst
@@ -159,6 +159,6 @@ changed remotely (files changed without going through Nextcloud), especially
 when it's very deep in the folder hierarchy of the external storage.
 
 You might need to setup a cron job that runs ``sudo -u www-data php occ files:scan --all``
-(or replace "--all" with the user name, see also :doc:`../configuration_server/occ_command`)
+(or replace ``--all`` with the user name, see also :doc:`../configuration_server/occ_command`)
 to trigger a rescan of the user's files periodically (for example every 15 minutes), which includes
 the mounted external storage.

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -1846,7 +1846,7 @@ the passed keys and certificates are readable by the PHP process. In addition
 PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT might need to be set to false, if the
 database servers certificates CN does not match with the hostname used to connect.
 The standard behavior here is different from the MySQL/MariaDB CLI client, which
-does not verify the server cert except --ssl-verify-server-cert is passed manually.
+does not verify the server cert except ``--ssl-verify-server-cert`` is passed manually.
 
 ::
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -689,9 +689,9 @@ the scan::
 
 Verbosity levels of ``-vv`` or ``-vvv`` are automatically reset to ``-v``
 
-Note for option --unscanned:
+Note for option ``--unscanned``:
 In general there is a background job (through cron) that will do that scan periodically.
-The --unscanned option makes it possible to trigger this from the CLI.
+The ``--unscanned`` option makes it possible to trigger this from the CLI.
 
 When using the ``--path`` option, the path must consist of following
 components::

--- a/admin_manual/configuration_user/user_auth_ldap_cleanup.rst
+++ b/admin_manual/configuration_user/user_auth_ldap_cleanup.rst
@@ -66,9 +66,8 @@ This example shows what the table of users marked as ``deleted`` looks like::
 
 Following flags can be specified additionally:
 
-*--short-date*: formats the dates for ``Last login`` and ``Detected on`` in a short Y-m-d format (e.g. 2019-01-14)
-
-*--json--*: instead of a table, the output is json-encoded. This makes it easy to process the data programmatically.
+* ``--short-date``: formats the dates for ``Last login`` and ``Detected on`` in a short Y-m-d format (e.g. 2019-01-14)
+* ``--json``: instead of a table, the output is json-encoded. This makes it easy to process the data programmatically.
 
 
 Then you can run ``sudo -u www-data php occ user:delete aaliyah_brown`` to delete 


### PR DESCRIPTION
Avoids double-dash being turned into a single one by rendering.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>