### PR TITLE
Fix wrong Folder path, USERNAME clarification

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -84,7 +84,7 @@ Accessing files with KDE and Dolphin file manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To access your Nextcloud files using the Dolphin file manager in KDE, use
-the ``webdav://`` protocol::
+the ``webdav://`` protocol (replace ``USERNAME`` with your username)::
 
     webdav://example.com/nextcloud/remote.php/dav/files/USERNAME/
 
@@ -106,7 +106,7 @@ You can create a permanent link to your Nextcloud server:
 
    * Server: The Nextcloud domain name, for example **example.com** (without
      **http://** before or directories afterwards).
-   * Folder -- Enter the path ``nextcloud/remote.php/dav/files/USERNAME/``.
+   * Folder -- Enter the path (replace ``USERNAME`` with your username) ``remote.php/dav/files/USERNAME/``.
 #. (Optional) Check the "Create icon" checkbox for a bookmark to appear in the
    Places column.
 #. (Optional) Provide any special settings or an SSL certificate in the "Port &


### PR DESCRIPTION
Path doesn't work with `nextcloud` as a prefix, need to be removed.
Clarified that USERNAME must be replaced.