### PR TITLE
Explain how to add several IDelegatedSettings in the key "settings"

### DIFF
--- a/developer_manual/basics/setting.rst
+++ b/developer_manual/basics/setting.rst
@@ -162,3 +162,20 @@ setting with annotations.
          ...
     }
 
+
+If you have several classes that implement `IDelegatedSettings` for a function. You must add them in the key "settings" and they must seperate with semi-colons.
+
+.. code-block:: php
+
+    <?php
+    class NotesSettingsController extends Controller {
+        /**
+         * Save settings
+         * @PasswordConfirmationRequired
+         * @AuthorizedAdminSetting(settings=OCA\NotesTutorial\Settings\NotesAdmin;OCA\NotesTutorial\Settings\NotesSubAdmin)
+         */
+         public function saveSettings($mySetting) {
+             ....
+         }
+         ...
+    }


### PR DESCRIPTION
In this documentation, there is no explanation on how to add several IDelegatedSettings' classes for a function.

For example :

```php
    <?php
    class NotesSettingsController extends Controller {
        /**
         * Save settings
         * @PasswordConfirmationRequired
         * @AuthorizedAdminSetting(settings=OCA\NotesTutorial\Settings\NotesAdmin;OCA\NotesTutorial\Settings\NotesSubAdmin)
         */
         public function saveSettings($mySetting) {
             // code
         }
    }
```