### PR TITLE
Update nginx sample configs with .well-kown webfinger and nodeinfo

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -112,6 +112,9 @@ server {
     location ^~ /.well-known {
         # The rules in this block are an adaptation of the rules
         # in `.htaccess` that concern `/.well-known`.
+        
+        location = /.well-known/webfinger { return 301 /index.php/.well-known/webfinger; }
+        location = /.well-known/nodeinfo { return 301 /index.php/.well-known/nodeinfo; }
 
         location = /.well-known/carddav { return 301 /remote.php/dav/; }
         location = /.well-known/caldav  { return 301 /remote.php/dav/; }

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -57,6 +57,9 @@ server {
         # The rules in this block are an adaptation of the rules
         # in the Nextcloud `.htaccess` that concern `/.well-known`.
 
+        location = /.well-known/webfinger { return 301 /nextcloud/index.php/.well-known/webfinger; }
+        location = /.well-known/nodeinfo { return 301 /nextcloud/index.php/.well-known/nodeinfo; }
+
         location = /.well-known/carddav { return 301 /nextcloud/remote.php/dav/; }
         location = /.well-known/caldav  { return 301 /nextcloud/remote.php/dav/; }
 


### PR DESCRIPTION
Noticed these redirects were missing from the nginx docs, only present in the apache ones.