### PR TITLE
Update iOS requirements

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -74,13 +74,13 @@ of our mobile apps.
 Files App
 ^^^^^^^^^
 
-- **iOS** 11.x+
+- **iOS** 12.1+
 - **Android** 6.0+
 
 Talk App
 ^^^^^^^^
 
-- **iOS** 10.0+
+- **iOS** 12.0+
 - **Android** 5.0+
 - **Nextcloud Server** 14.0+
 - **Nextcloud Talk** 4.0+


### PR DESCRIPTION
Latest version of Nextcloud Talk iOS requires atleast iOS 12 (see https://github.com/nextcloud/talk-ios/pull/736)
Latest version of Nextcloud Files iOS requires atleast iOS 12.1 (see https://github.com/nextcloud/ios/blob/e2e52363b045d31542c49c5e12bf517362b69df2/Nextcloud.xcodeproj/project.pbxproj#L3026)