### PR TITLE
Remove outdated warning about encryption for S3 as primary storage

### DIFF
--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -27,9 +27,6 @@ Because of this primary object stores usually perform better than when using the
 object store as external storage but it restricts being able to access the files from
 outside of Nextcloud.
 
-.. warning:: Using an object store as primary storage will mean you are `unable to use
-	Nextcloud's server-side encryption functionality <https://github.com/nextcloud/server/issues/22077>`_.
-
 -------------
 Configuration
 -------------


### PR DESCRIPTION
The mentioned issue https://github.com/nextcloud/server/issues/22077 is closed and resolved in 24.0.2 onwards.