### PR TITLE
Corrected described side of control placement

### DIFF
--- a/user_manual/groupware/sync_gnome.rst
+++ b/user_manual/groupware/sync_gnome.rst
@@ -23,7 +23,7 @@ This can be done by following these steps:
 .. image:: ../images/goa-add-nextcloud-account.png
    
 4. In the next window, select which resources GNOME should access and
-   press the cross in the top left to close:
+   press the cross in the top right to close:
    
 .. image:: ../images/goa-nextcloud-select.png
 


### PR DESCRIPTION
As screenshot below this sentence in document suggests, cross symbol for closing is actually on top right side of dialog window...

Signed-off-by: p-bo <pavel.borecki@gmail.com>