### PR TITLE
Dev settings docs: implement interface, not extend

### DIFF
--- a/developer_manual/basics/setting.rst
+++ b/developer_manual/basics/setting.rst
@@ -19,7 +19,7 @@ In our case we will create an admin section class in **<myapp>/lib/Sections/Note
     use OCP\IURLGenerator;
     use OCP\Settings\IIconSection;
 
-    class NotesAdmin extends IIconSection {
+    class NotesAdmin implements IIconSection {
         private IL10N $l;
         private IURLGenerator $urlGenerator;
 
@@ -59,7 +59,7 @@ in *<myapp>/lib/Settings/NotesAdmin.php**.
     use OCP\IL10N;
     use OCP\Settings\ISettings;
 
-    class NotesAdmin extends ISettings {
+    class NotesAdmin implements ISettings {
         private IL10N $l;
         private IConfig $config;
 
@@ -125,7 +125,7 @@ and implement two additional methods.
     use OCP\IL10N;
     use OCP\Settings\IDelegatedSettings;
 
-    class NotesAdmin extends IDelegatedSettings {
+    class NotesAdmin implements IDelegatedSettings {
 
         ...
 


### PR DESCRIPTION
Tiny PR for a tiny typo in the docs.

Interfaces should use the `implements` keywords and not the `extends` keyword.

Signed-off-by: Kalle Fagerberg <kalle.f8@proton.me>