### PR TITLE
Add hint about "fileinfo" module being required for theming

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -60,7 +60,7 @@ Database connectors (pick the one for your database:)
 
 *Recommended* packages:
 
-* PHP module fileinfo (highly recommended, enhances file analysis performance)
+* PHP module fileinfo (highly recommended, enhances file analysis performance; required to set custom theming images or if PHP module imagick with SVG support is installed)
 * PHP module bz2 (recommended, required for extraction of apps)
 * PHP module intl (increases language translation performance and fixes sorting
   of non-ASCII characters)


### PR DESCRIPTION
The Theming app requires the `mime_content_type` function, which [is part of the `fileinfo` module](https://www.php.net/manual/en/ref.fileinfo.php), to [identify the mime type of the custom images](https://github.com/nextcloud/server/blob/3d0b5c1ff9725b9babb8c92d0549613b64b6296e/apps/theming/lib/ImageManager.php#L229). Currently if `mime_content_type` is not available the Theming UI does not show any error, but that is fixed in https://github.com/nextcloud/server/pull/33332

Moreover, [if the `imagick` module is installed and it has support for SVG files](https://github.com/nextcloud/server/blob/3d0b5c1ff9725b9babb8c92d0549613b64b6296e/apps/theming/lib/ImageManager.php#L311-L315) a rasterized counterpart [will be generated for the SVG app icons](https://github.com/nextcloud/server/blob/master/apps/theming/lib/Controller/IconController.php#L162). In this case [`mime_content_type` is used to identify the mime type of the original icon](https://github.com/nextcloud/server/blob/af61ac6a7afca423a33e91f509d58a907981e8bd/apps/theming/lib/IconBuilder.php#L138). If testing this by adding or removing the extension once Nextcloud has been already set up [beware of the cached value](https://github.com/nextcloud/server/blob/3d0b5c1ff9725b9babb8c92d0549613b64b6296e/apps/theming/lib/ImageManager.php#L306-L309).

I tried to replace the usages of `mime_content_type` in the Theming app with the [IMimeTypeDetector implementation](https://github.com/nextcloud/server/blob/6be7aa112f6174c1406cfef5449836124a7f6f50/lib/private/Files/Type/Detection.php), which tries in more ways than just `mime_content_type`. Unfortunately it does not work, as [the secure mime type](https://github.com/nextcloud/server/blob/6be7aa112f6174c1406cfef5449836124a7f6f50/lib/private/Files/Type/Detection.php#L243) for `SVG+XML` files is [`text/plain` rather than `image/svg+xml`](https://github.com/nextcloud/server/blob/0d2e05a0b57723b9f3dddc3ef2ad59c1844d7697/resources/config/mimetypemapping.dist.json#L177), and thus are not properly handled by the Theming app.