### PR TITLE
Add information that the app is enabled in OCS Apps API result

### DIFF
--- a/admin_manual/configuration_user/instruction_set_for_apps.rst
+++ b/admin_manual/configuration_user/instruction_set_for_apps.rst
@@ -94,6 +94,7 @@ XML output
       <author>Robin Appelman</author>
       <require>4.9</require>
       <shipped>true</shipped>
+      <active>true</active>
       <standalone></standalone>
       <default_enable></default_enable>
       <types>


### PR DESCRIPTION
Just to avoid having the check the code for this information.