### PR TITLE
📝 Include instructions on how to configure the server with Env Variables

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -12,6 +12,13 @@ is usually not necessary to edit ``config/config.php``.
    Only manually add configuration parameters to ``config/config.php`` if you need to
    use a special value for a parameter. **Do not copy everything from**
    ``config/config.sample.php`` **. Only enter the parameters you wish to modify!**
+   
+   
+Environment Variables configuration
+------------------------
+
+If a config isn't present in ``config/config.php``, Nextcloud will attempt to get the configuration from the Environment by prepending ``NC_`` before it. For example, if you want to configure the ``default_phone_region`` configuration, you would have to start your application with ``NC_default_phone_region=BR``
+   
 
 Multiple config.php file
 ------------------------


### PR DESCRIPTION
This commit adds to the docs instructions on how to configure a Nextcloud instance to use Environment configuration when values aren't present in config.php.

This should close https://github.com/nextcloud/docker/issues/1544 and https://github.com/nextcloud/docker/issues/1465
It should also render https://github.com/nextcloud/docker/pull/1795 unnecessary.

Signed-off-by: Leonardo Colman <dev@leonardo.colman.com.br>