### PR TITLE
adding token lifetime for loginflow v2

### DIFF
--- a/developer_manual/client_apis/LoginFlow/index.rst
+++ b/developer_manual/client_apis/LoginFlow/index.rst
@@ -143,6 +143,7 @@ The program should directly start polling the poll endpoint:
 
         curl -X POST https://cloud.example.com/login/v2/poll -d "token=mQUYQdffOSAMJYtm8pVpkOsVqXt5hglnuSpO5EMbgJMNEPFGaiDe8OUjvrJ2WcYcBSLgqynu9jaPFvZHMl83ybMvp6aDIDARjTFIBpRWod6p32fL9LIpIStvc6k8Wrs1"
 
+The token will be valid for 20 minutes.
 This will return a 404 until authentication is done. Once a 200 is returned it is another json object.
 
 .. code-block:: json


### PR DESCRIPTION
The token lifetime never made it into the developer manual even though relevant.

- As described in the push request for login flow V2 [nextcloud/server#14161](https://github.com/nextcloud/server/pull/14161), the token lifetime is 20 mins.
- In the source code: https://github.com/nextcloud/server/blob/master/core/Db/LoginFlowV2Mapper.php#L34

Signed-off-by: Knoxell <85034894+knoxell@users.noreply.github.com>