### PR TITLE
Disable xss header and add CSP header

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -69,13 +69,13 @@ server {
     client_body_buffer_size 512k;
 
     # HTTP response headers borrowed from Nextcloud `.htaccess`
-    add_header Referrer-Policy                      "no-referrer"   always;
-    add_header X-Content-Type-Options               "nosniff"       always;
-    add_header X-Download-Options                   "noopen"        always;
-    add_header X-Frame-Options                      "SAMEORIGIN"    always;
-    add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-    add_header X-Robots-Tag                         "none"          always;
-    add_header X-XSS-Protection                     "0"             always;
+    add_header Referrer-Policy                      "no-referrer"             always;
+    add_header X-Content-Type-Options               "nosniff"                 always;
+    add_header X-Download-Options                   "noopen"                  always;
+    add_header Content-Security-Policy              "default-src 'self'"      always;
+    add_header X-Permitted-Cross-Domain-Policies    "none"                    always;
+    add_header X-Robots-Tag                         "none"                    always;
+    add_header X-XSS-Protection                     "0"                       always;
 
     # Remove X-Powered-By, which is an information leak
     fastcgi_hide_header X-Powered-By;

--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -75,7 +75,7 @@ server {
     add_header X-Frame-Options                      "SAMEORIGIN"    always;
     add_header X-Permitted-Cross-Domain-Policies    "none"          always;
     add_header X-Robots-Tag                         "none"          always;
-    add_header X-XSS-Protection                     "1; mode=block" always;
+    add_header X-XSS-Protection                     "0"             always;
 
     # Remove X-Powered-By, which is an information leak
     fastcgi_hide_header X-Powered-By;

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -92,13 +92,13 @@ server {
         client_body_buffer_size 512k;
 
         # HTTP response headers borrowed from Nextcloud `.htaccess`
-        add_header Referrer-Policy                      "no-referrer"   always;
-        add_header X-Content-Type-Options               "nosniff"       always;
-        add_header X-Download-Options                   "noopen"        always;
-        add_header X-Frame-Options                      "SAMEORIGIN"    always;
-        add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-        add_header X-Robots-Tag                         "none"          always;
-        add_header X-XSS-Protection                     "1; mode=block" always;
+        add_header Referrer-Policy                      "no-referrer"             always;
+        add_header X-Content-Type-Options               "nosniff"                 always;
+        add_header X-Download-Options                   "noopen"                  always;
+        add_header Content-Security-Policy              "default-src 'self'"      always;
+        add_header X-Permitted-Cross-Domain-Policies    "none"                    always;
+        add_header X-Robots-Tag                         "none"                    always;
+        add_header X-XSS-Protection                     "0"                       always;
 
         # Remove X-Powered-By, which is an information leak
         fastcgi_hide_header X-Powered-By;


### PR DESCRIPTION
By now, no modern browser supports the `XSS-Protection` header anymore - and with good reason. It actually has known security vulnerabilities. Instead, it is recommended to disable it and use CSP instead. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

Hence, this patch disables the XSS header and enables CSP instead. The CSP part was copied from an earlier PR (#1714), which was closed because of an incompatible browser matrix. That issue does not exist anymore. Is it possible to merge these changes?