### PR TITLE
ocs-api-overview: Talk about user using singular they

### DIFF
--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -25,7 +25,7 @@ User metadata
 
 Since: 11.0.2, 12.0.0
 
-This request returns the available metadata of a user. Admin users can see the information of all users, while a default user only can access it's own metadata.
+This request returns the available metadata of a user. Admin users can see the information of all users, while a default user only can access their own metadata.
 
 .. code::
 


### PR DESCRIPTION
The word "it's" should be "its", but I think "their" is nicer because we're talking about a group of humans.

Signed-off-by: Christian Paul <info@jaller.de>