### PR TITLE
Update recommend MariaDB versions

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -22,7 +22,7 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - openSUSE Leap 42.1+                                                 |
 |                  | - CentOS Stream                                                       |
 +------------------+-----------------------------------------------------------------------+
-| Database         | - **MySQL 8.0+ or MariaDB 10.2/10.3/10.4/10.5** (recommended)         |
+| Database         | - **MySQL 8.0+ or MariaDB 10.3/10.4/10.5/10.6** (recommended)         |
 |                  | - Oracle Database 11g (*only as part of an enterprise subscription*)  |
 |                  | - PostgreSQL 10/11/12/13                                              |
 |                  | - SQLite (*only recommended for testing and minimal-instances*)       |


### PR DESCRIPTION
- 10.2 is EOL and therefore no longer recommend
- 10.6 is current LTS and supported since https://github.com/nextcloud/server/pull/30129