### PR TITLE
Add Nextcloud 26 upgrade docs for app devs

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_26.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_26.rst
@@ -1,0 +1,39 @@
+=======================
+Upgrade to Nextcloud 26
+=======================
+
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/34692>`__. See the original ticket for links to the pull requests and tickets.
+
+General
+-------
+
+info.xml
+^^^^^^^^
+
+Make sure your ``appinfo/info.xml`` allows for Nextcloud 26.
+
+.. code-block:: xml
+
+	<dependencies>
+	  <nextcloud min-version="23" max-version="26" />
+	</dependencies>
+
+Front-end changes
+-----------------
+
+tbd
+
+Back-end changes
+----------------
+
+tbd
+
+Changed APIs
+^^^^^^^^^^^^
+
+tbd
+
+Removed APIs
+^^^^^^^^^^^^
+
+tbd


### PR DESCRIPTION
Continuation of https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.html