### PR TITLE
Fix 26 upgrade docs missing from TOC

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
@@ -9,6 +9,7 @@ These sub pages will cover the most important changes in Nextcloud, as well as s
 .. toctree::
    :maxdepth: 1
 
+   upgrade_to_26.rst
    upgrade_to_25.rst
    upgrade_to_24.rst
    upgrade_to_23.rst


### PR DESCRIPTION
Leftover from https://github.com/nextcloud/documentation/pull/9246