### PR TITLE
update the link to available language codes

### DIFF
--- a/admin_manual/configuration_server/language_configuration.rst
+++ b/admin_manual/configuration_server/language_configuration.rst
@@ -34,7 +34,7 @@ If users shall be unable to change their language, but users have different lang
 this value can be set to ``true`` instead of a language code.
 
 .. note:: Please check `Transifex language codes
-   <https://www.transifex.com/explore/languages/>`_ for the list of valid language
+   <https://explore.transifex.com/languages/>`_ for the list of valid language
    codes.
 
 Default locale


### PR DESCRIPTION
change the url of Transifex language codes from https://www.transifex.com/explore/languages/ to https://explore.transifex.com/languages/ as the previous link redirect to the home page.

Signed-off-by: 林柏臣 <daniel.pclin@gmail.com>