### PR TITLE
Fix missing 25 split

### DIFF
--- a/admin_manual/apps_management.rst
+++ b/admin_manual/apps_management.rst
@@ -23,14 +23,14 @@ To see which apps are enabled go to your Apps page.
 Those apps are supported and developed by Nextcloud GmbH directly and
 have an **Featured**-tag. See :doc:`installation/apps_supported` for a list of supported apps.
 
-.. note:: Your Nextcloud server needs to be able to communicate with 
+.. note:: Your Nextcloud server needs to be able to communicate with
           ``https://apps.nextcloud.com`` to list and download apps. Please make sure to whitelist this target in your firewall or proxy if necessary.
 
 .. note:: To get access to work-arounds, long-term-support, priority bug fixing
           and custom consulting for supported apps, contact our `sales team <https://nextcloud.com/enterprise/>`_.
 
 .. note:: If you would like to develop your own Nextcloud app, you can find out
-          more information in our `developer manual <https://docs.nextcloud.com/server/latest/go.php?to=developer-manual>`_.
+          more information in our `developer manual <https://docs.nextcloud.com/server/25/go.php?to=developer-manual>`_.
 .. TODO ON RELEASE: Update version number above on release
 
 All apps must be licensed under AGPLv3+ or any compatible license.
@@ -55,11 +55,11 @@ in the Application View field. Clicking the **Enable** button will enable the ap
 If the app is not part of the Nextcloud installation, it will be downloaded from
 the app store, installed and enabled.
 
-App updates will also be offered to you on this page. Simply click on the **Update** 
-button to update a specific app or use the **Update all** button on top of the page to 
+App updates will also be offered to you on this page. Simply click on the **Update**
+button to update a specific app or use the **Update all** button on top of the page to
 update all apps.
 
-.. note:: **Beta releases**: You can also install beta releases of apps directly from here by 
+.. note:: **Beta releases**: You can also install beta releases of apps directly from here by
           switching your Nextcloud to the beta channel in the admin overview.
 
 Using private API
@@ -124,6 +124,6 @@ To enable a self hosted apps store:
     "appstoreurl" => "https://my.appstore.instance/v1",
 
 
-By default the apps store is enabled and configured to use ``https://apps.nextcloud.com/api/v1`` as apps store url. Nextcloud will fetch ``apps.json`` and ``categories.json`` from there. To use the defaults again remove **appstoreenabled** and **appstoreurl** from the configuration. 
+By default the apps store is enabled and configured to use ``https://apps.nextcloud.com/api/v1`` as apps store url. Nextcloud will fetch ``apps.json`` and ``categories.json`` from there. To use the defaults again remove **appstoreenabled** and **appstoreurl** from the configuration.
 
 Example: If ``categories.json`` is available at ``https://apps.nextcloud.com/api/v1/categories.json`` the apps store url is ``https://apps.nextcloud.com/api/v1``.

--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -2,15 +2,15 @@
 Uploading big files > 512MB
 ===========================
 
-The default maximum file size for uploads is 512MB. You can increase this 
-limit up to what your filesystem and operating system allows. There are certain 
+The default maximum file size for uploads is 512MB. You can increase this
+limit up to what your filesystem and operating system allows. There are certain
 hard limits that cannot be exceeded:
 
 * < 2GB on 32Bit OS-architecture
 * < 2GB with IE6 - IE8
 * < 4GB with IE9 - IE11
 
-64-bit filesystems have much higher limits; consult the documentation for your 
+64-bit filesystems have much higher limits; consult the documentation for your
 filesystem.
 
 .. note:: The Nextcloud sync client is not affected by these upload limits
@@ -22,9 +22,9 @@ System configuration
 
 * Make sure that the latest version of PHP is installed
 * Disable user quotas, which makes them unlimited
-* Your temp file or partition has to be big enough to hold multiple 
-  parallel uploads from multiple users; e.g. if the max upload size is 10GB and 
-  the average number of users uploading at the same time is 100: temp space has 
+* Your temp file or partition has to be big enough to hold multiple
+  parallel uploads from multiple users; e.g. if the max upload size is 10GB and
+  the average number of users uploading at the same time is 100: temp space has
   to hold at least 10x100 GB
 
 Configuring your Web server
@@ -34,19 +34,21 @@ Configuring your Web server
    can't read PHP settings in ``.htaccess`` these settings must be set in the
    ``nextcloud/.user.ini`` file.
 
-Set the following two parameters inside the corresponding php.ini file (see the 
-**Loaded Configuration File** section of :ref:`label-phpinfo` to find your 
+Set the following two parameters inside the corresponding php.ini file (see the
+**Loaded Configuration File** section of :ref:`label-phpinfo` to find your
 relevant php.ini files) ::
 
  php_value upload_max_filesize 16G
  php_value post_max_size 16G
- 
-The ``upload_max_filesize`` and ``post_max_size`` settings may not apply to file uploads 
+
+The ``upload_max_filesize`` and ``post_max_size`` settings may not apply to file uploads
 through WebDAV single file PUT requests or `Chunked file uploads
-<https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/chunking.html>`_ 
+<https://docs.nextcloud.com/server/25/developer_manual/client_apis/WebDAV/chunking.html>`_
 For those, PHP and webserver timeouts are the limiting factor on the upload size.
 
-Adjust these values for your needs. If you see PHP timeouts in your logfiles, 
+.. TODO ON RELEASE: Update version number above on release
+
+Adjust these values for your needs. If you see PHP timeouts in your logfiles,
 increase the timeout values, which are in seconds::
 
  php_value max_input_time 3600
@@ -76,7 +78,7 @@ Apache with mod_fcgid
    ``FcgidMaxRequestInMem`` still needs to be significantly increased from its default value
    to avoid the occurrence of segmentation faults when uploading big files. This is not a regular
    setting but serves as a workaround for `Apache with mod_fcgid bug #51747 <https://bz.apache.org/bugzilla/show_bug.cgi?id=51747>`_.
-   
+
    Setting ``FcgidMaxRequestInMem`` significantly higher than normal may no longer be
    necessary, once bug #51747 is fixed.
 
@@ -96,13 +98,13 @@ is available. Setting this option to ``fastcgi_request_buffering off;`` in your 
 might help with timeouts during the upload. Furthermore it helps if you're running out of
 disc space on the tmp partition of your system.
 
-.. note:: Make sure that ``client_body_temp_path`` points to a partition with 
+.. note:: Make sure that ``client_body_temp_path`` points to a partition with
    adequate space for your upload file size, and on the same partition as
-   the ``upload_tmp_dir`` or ``tempdirectory`` (see below). For optimal 
-   performance, place these on a separate hard drive that is dedicated to 
+   the ``upload_tmp_dir`` or ``tempdirectory`` (see below). For optimal
+   performance, place these on a separate hard drive that is dedicated to
    swap and temp storage.
-   
-If your site is behind a nginx frontend (for example a loadbalancer): 
+
+If your site is behind a nginx frontend (for example a loadbalancer):
 
 By default, downloads will be limited to 1GB due to ``proxy_buffering`` and ``proxy_max_temp_file_size`` on the frontend.
 
@@ -112,24 +114,24 @@ By default, downloads will be limited to 1GB due to ``proxy_buffering`` and ``pr
 Configuring PHP
 ---------------
 
-If you don't want to use the Nextcloud ``.htaccess`` or ``.user.ini`` file, you may 
-configure PHP instead. Make sure to comment out any lines ``.htaccess`` 
+If you don't want to use the Nextcloud ``.htaccess`` or ``.user.ini`` file, you may
+configure PHP instead. Make sure to comment out any lines ``.htaccess``
 pertaining to upload size, if you entered any.
 
-If you are running Nextcloud on a 32-bit system, any ``open_basedir`` directive 
+If you are running Nextcloud on a 32-bit system, any ``open_basedir`` directive
 in your ``php.ini`` file needs to be commented out.
 
-Set the following two parameters inside ``php.ini``, using your own desired 
+Set the following two parameters inside ``php.ini``, using your own desired
 file size values::
 
  upload_max_filesize = 16G
  post_max_size = 16G
- 
+
 Tell PHP which temp directory you want it to use::
- 
+
  upload_tmp_dir = /var/big_temp_file/
 
-**Output Buffering** must be turned off in ``.htaccess`` or ``.user.ini`` or ``php.ini``, or PHP 
+**Output Buffering** must be turned off in ``.htaccess`` or ``.user.ini`` or ``php.ini``, or PHP
 will return memory-related errors:
 
 * ``output_buffering = 0``
@@ -142,7 +144,7 @@ As an alternative to the ``upload_tmp_dir`` of PHP (e.g. if you don't have acces
 ``tempdirectory`` setting in your ``config.php`` (See :doc:`../configuration_server/config_sample_php_parameters`).
 
 If you have configured the ``session_lifetime`` setting in your ``config.php``
-(See :doc:`../configuration_server/config_sample_php_parameters`) file then 
+(See :doc:`../configuration_server/config_sample_php_parameters`) file then
 make sure it is not too
 low. This setting needs to be configured to at least the time (in seconds) that
 the longest upload will take. If unsure remove this completely from your
@@ -164,9 +166,11 @@ Default is 10485760 (10 MiB).
 Large file upload on object storage
 -----------------------------------
 
-`Chunked file uploads <https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/chunking.html>`_ 
+`Chunked file uploads <https://docs.nextcloud.com/server/25/developer_manual/client_apis/WebDAV/chunking.html>`_
 do have a larger space consumption on the temporary folder when processing those uploads
 on object storage as the individual chunks get downloaded from the storage and will be assembled
 to the actual file on the Nextcloud servers temporary directory. It is recommended to increase
 the size of your temp directory accordingly and also ensure that request timeouts are high
 enough for PHP, webservers or any load balancers involved.
+
+.. TODO ON RELEASE: Update version number above on release

--- a/admin_manual/configuration_files/encryption_details.rst
+++ b/admin_manual/configuration_files/encryption_details.rst
@@ -36,7 +36,7 @@ The recovery key is used to provide a restore mechanism in cases where the user 
 Key type: user key
 ------------------
 
-User key encryption needs to be explicitly activated by calling ``./occ encryption:disable-master-key``. In older versions of Nextcloud this had been enabled by default. 
+User key encryption needs to be explicitly activated by calling ``./occ encryption:disable-master-key``. In older versions of Nextcloud this had been enabled by default.
 With user key encryption enabled all users have their own user keys that are used to secure the files handled by Nextcloud. The user keys are protected by the user passwords. The advantage is that the server administrator is not able to decrypt user files without knowing any user password - unless the file is publicly shared or a recovery key is defined - but has the disadvantage that files are permanently lost if the users forget their user passwords - unless the files are (publicly) shared or a recovery key is defined.
 
 .. note:: This method cannot be used with SAML authentication, because Nextcloud does not get a hold of any credentials whatsoever and therefore cannot use any users' passwords for encryption.
@@ -346,7 +346,7 @@ Sources
 -------
 
 - `nextcloud-tools repository on GitHub <https://github.com/syseleven/nextcloud-tools>`_
-- `Nextcloud Encryption Configuration documentation <https://docs.nextcloud.com/server/stable/admin_manual/configuration_files/encryption_configuration.html>`_
+- `Nextcloud Encryption Configuration documentation <https://docs.nextcloud.com/server/25/admin_manual/configuration_files/encryption_configuration.html>`_
 - `Nextcloud Help response concering the usage of version information <https://help.nextcloud.com/t/allow-file-decryption-with-only-the-files-keys-and-passwords/436/12>`_
 - `Overview of ownCloud Encryption Model <https://owncloud.com/wp-content/uploads/2015/07/Overview_of_ownCloud_Encryption_Model_2.2.pdf>`_
 - `Sourcecode: Creation of the Message Authentication Code <https://github.com/nextcloud/server/blob/a374d8837d6de459500e619cf608e0721ea14574/apps/encryption/lib/Crypto/Crypt.php#L504>`_
@@ -357,3 +357,5 @@ Sources
 - `Sourcecode: Generation of the File Key <https://github.com/nextcloud/server/blob/a374d8837d6de459500e619cf608e0721ea14574/apps/encryption/lib/Crypto/Crypt.php#L645>`_
 - `Sourcecode: Generation of the Initialization Vector <https://github.com/nextcloud/server/blob/a374d8837d6de459500e619cf608e0721ea14574/apps/encryption/lib/Crypto/Crypt.php#L634>`_
 - `Sourcecode: Generation of a Key Pair <https://github.com/nextcloud/server/blob/a374d8837d6de459500e619cf608e0721ea14574/apps/encryption/lib/Crypto/Crypt.php#L153>`_
+
+.. TODO ON RELEASE: Update version number above on release

--- a/admin_manual/configuration_files/file_sharing_configuration.rst
+++ b/admin_manual/configuration_files/file_sharing_configuration.rst
@@ -2,15 +2,15 @@
 File Sharing
 ============
 
-Nextcloud users can share files with their Nextcloud groups and other users on 
-the same Nextcloud server, with Nextcloud users on :doc:`other Nextcloud servers <federated_cloud_sharing_configuration>`, and create public shares for people who are not 
+Nextcloud users can share files with their Nextcloud groups and other users on
+the same Nextcloud server, with Nextcloud users on :doc:`other Nextcloud servers <federated_cloud_sharing_configuration>`, and create public shares for people who are not
 Nextcloud users. You have control of a number of user permissions on file shares.
 
 Configure your sharing policy on your Admin page in the Sharing section.
 
 .. figure:: images/sharing-files-1.png
 
-* Check ``Allow apps to use the Share API`` to enable users to share files. If 
+* Check ``Allow apps to use the Share API`` to enable users to share files. If
   this is not checked, no users can create file shares.
 * Check ``Set default expiration date for shares`` to set a default expiration date
   on local user and group shares.
@@ -18,27 +18,27 @@ Configure your sharing policy on your Admin page in the Sharing section.
   on local user and group shares.
 
     .. note:: Users will not be able to set the expiration date further
-        in the future than the enforced expiration date, although they 
+        in the future than the enforced expiration date, although they
         will be able to set a more recent date.
         Also note that users will be able to update the expiration date again at
         a later point. The expiration date is based on the current date and not on the share
         creation date. The user will be able to extend the expiration date again whenever a
         previous expiration date is close to be reached.
 
-* Check ``Allow users to share via link`` to enable creating public shares for  
+* Check ``Allow users to share via link`` to enable creating public shares for
   people who are not Nextcloud users via hyperlink.
 * Check ``Allow public uploads`` to allow anyone to upload files to public shares.
 * Check ``Always ask for a password`` to proactively ask a user to set a password
   for a share link.
-* Check ``Enforce password protection`` to force users to set a password on all 
+* Check ``Enforce password protection`` to force users to set a password on all
   public share links. This does not apply to local user and group shares.
-* Check ``Set default expiration date for link shares`` to set a default expiration date on 
+* Check ``Set default expiration date for link shares`` to set a default expiration date on
   public shares.
 * Check ``Enforce expiration date`` to always enforce the configured expiration date
-  on public shares. 
+  on public shares.
 
     .. note:: Users will not be able to set the expiration date further
-        in the future than the enforced expiration date, although they 
+        in the future than the enforced expiration date, although they
         will be able to set a more recent date.
         Also note that users will be able to update the expiration date again at
         a later point. The expiration date is based on the current date and not on the share
@@ -47,39 +47,39 @@ Configure your sharing policy on your Admin page in the Sharing section.
 
 * Check ``Allow resharing`` to enable users to re-share files shared with them.
 * Check ``Allow sharing with groups`` to enable users to share with groups.
-* Check ``Restrict users to only share with users in their groups`` to confine 
+* Check ``Restrict users to only share with users in their groups`` to confine
   sharing within group memberships.
-  
-    .. note:: This setting does not apply to the Federated Cloud sharing 
-       feature. If :doc:`Federated Cloud Sharing 
+
+    .. note:: This setting does not apply to the Federated Cloud sharing
+       feature. If :doc:`Federated Cloud Sharing
        <federated_cloud_sharing_configuration>` is
        enabled, users can still share items with any users on any instances
        (including the one they are on) via a remote share.
-  
-* Check ``Exclude groups from sharing`` to prevent members of specific groups 
-  from creating any file shares in those groups. When you check this, you'll 
-  get a dropdown list of all your groups to choose from. Members of excluded 
+
+* Check ``Exclude groups from sharing`` to prevent members of specific groups
+  from creating any file shares in those groups. When you check this, you'll
+  get a dropdown list of all your groups to choose from. Members of excluded
   groups can still receive shares, but not create any.
-* Check ``Allow username autocompletion in share dialog`` to enable 
+* Check ``Allow username autocompletion in share dialog`` to enable
   auto-completion of Nextcloud usernames.
 * Check ``Restrict username autocompletion to users within the same groups`` to limit
   username autocompletion to users from within the same groups as the share owner.
 * Check ``Show disclaimer text on the public link upload page`` to set and show
   a disclaimer text on public links with hidden file lists.
 
-With ``Default share permissions`` you are able to set the default permissions 
+With ``Default share permissions`` you are able to set the default permissions
 for user-shares (``Create``, ``Change``, ``Delete`` and ``Reshare``) without
 forcing them.
 
-.. note:: Nextcloud does not preserve the mtime (modification time) of 
-   directories, though it does update the mtimes on files. See  
-   `Wrong folder date when syncing 
+.. note:: Nextcloud does not preserve the mtime (modification time) of
+   directories, though it does update the mtimes on files. See
+   `Wrong folder date when syncing
    <https://github.com/owncloud/core/issues/7009>`_ for discussion of this.
 
-.. note:: There are more sharing options on config.php level available: 
+.. note:: There are more sharing options on config.php level available:
    :ref:`Configuration Parameters<configPHP_Sharing>`
 
-.. _transfer_userfiles_label:   
+.. _transfer_userfiles_label:
 
 Distinguish between max expiration date and default expiration date
 -------------------------------------------------------------------
@@ -109,34 +109,34 @@ A notification will be send for all shares which expire within the next 24 hours
 Transferring files to another user
 ----------------------------------
 
-You may transfer files from one user to another with ``occ``. This is useful 
-when you have to remove a user. Be sure to transfer the files before you delete 
-the user!  This transfers all files from user1 to user2, and the shares and 
-metadata info associated with those files (shares, tags, comments, etc). 
+You may transfer files from one user to another with ``occ``. This is useful
+when you have to remove a user. Be sure to transfer the files before you delete
+the user!  This transfers all files from user1 to user2, and the shares and
+metadata info associated with those files (shares, tags, comments, etc).
 Trashbin contents are not transferred::
 
  occ files:transfer-ownership user1 user2
- 
-(See :doc:`../configuration_server/occ_command` for a complete ``occ`` 
-reference.) 
+
+(See :doc:`../configuration_server/occ_command` for a complete ``occ``
+reference.)
 
 Users may also transfer files or folders selectively by themselves.
-See `user documentation <https://docs.nextcloud.com/server/latest/user_manual/en/files/transfer_ownership.html>`_ for details.
+See `user documentation <https://docs.nextcloud.com/server/25/user_manual/en/files/transfer_ownership.html>`_ for details.
 
-   
+
 Creating persistent file Shares
 -------------------------------
 
-When a user is deleted, their files are also deleted. As you can imagine, this 
-is a problem if they created file shares that need to be preserved, because 
-these disappear as well. In Nextcloud files are tied to their owners, so 
+When a user is deleted, their files are also deleted. As you can imagine, this
+is a problem if they created file shares that need to be preserved, because
+these disappear as well. In Nextcloud files are tied to their owners, so
 whatever happens to the file owner also happens to the files.
 
-One solution is to create persistent shares for your users. You can retain 
-ownership of them, or you could create a special user for the purpose of 
-establishing permanent file shares. Simply create a shared folder in the usual 
-way, and share it with the users or groups who need to use it. Set the 
-appropriate permissions on it, and then no matter which users come and go, the 
-file shares will remain. Because all files added to the share, or edited in it, 
-automatically become owned by the owner of the share regardless of who adds or 
-edits them.   
+One solution is to create persistent shares for your users. You can retain
+ownership of them, or you could create a special user for the purpose of
+establishing permanent file shares. Simply create a shared folder in the usual
+way, and share it with the users or groups who need to use it. Set the
+appropriate permissions on it, and then no matter which users come and go, the
+file shares will remain. Because all files added to the share, or edited in it,
+automatically become owned by the owner of the share regardless of who adds or
+edits them.

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -757,11 +757,11 @@ The command ``occ files:transfer-ownership`` can be used to transfer files from 
 
  Usage:
    files:transfer-ownership [options] [--] <source-user> <destination-user>
- 
+
  Arguments:
    source-user                                                owner of files which shall be moved
    destination-user                                           user who will be the new owner of the files
- 
+
  Options:
        --path=PATH                                            selectively provide the path to transfer. For example --path="folder_name" [default: ""]
        --move                                                 move data from source user to root directory of destination user, which must be empty
@@ -795,7 +795,7 @@ The command line option ``--transfer-incoming-shares`` overwrites the config.php
  sudo -u www-data php occ files:transfer-ownership --transfer-incoming-shares=0 <source-user> <destination-user>
 
 Users may also transfer files or folders selectively by themselves.
-See `user documentation <https://docs.nextcloud.com/server/latest/user_manual/en/files/transfer_ownership.html>`_ for details.
+See `user documentation <https://docs.nextcloud.com/server/25/user_manual/en/files/transfer_ownership.html>`_ for details.
 
 .. _occ_sharing_label:
 
@@ -864,7 +864,7 @@ Verify your app::
   sudo -u www-data php occ integrity:check-app --path=/pathto/app appname
 
 When it returns nothing, your app is signed correctly. When it returns a message then there is an error. See `Code Signing
-<https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/code_signing.html#how-to-get-your-app-signed>`_ in the Developer manual for more detailed information.
+<https://docs.nextcloud.com/server/25/developer_manual/app_publishing_maintenance/code_signing.html#how-to-get-your-app-signed>`_ in the Developer manual for more detailed information.
 
 .. TODO ON RELEASE: Update version number above on release
 
@@ -1544,7 +1544,7 @@ Edit a tag::
 
   sudo -u www-data php occ tag:edit --name <name> --access <access> <id>
 
-`--name` and `--access` are optional. 
+`--name` and `--access` are optional.
 
 Delete a tag::
 
@@ -1553,7 +1553,7 @@ Delete a tag::
 Access level
 
 ========== ======== ==========
-Level      Visible¹ Assignable²    
+Level      Visible¹ Assignable²
 ========== ======== ==========
 public     Yes      Yes
 restricted Yes      No
@@ -1561,7 +1561,7 @@ invisible  No       No
 ========== ======== ==========
 
 | ¹ User can see the tag
-| ² User can assign the tag to a file 
+| ² User can assign the tag to a file
 
 .. _occ_debugging:
 

--- a/admin_manual/configuration_user/two_factor-auth.rst
+++ b/admin_manual/configuration_user/two_factor-auth.rst
@@ -9,11 +9,11 @@ of the Nextcloud Server component but provided by featured and 3rd-party Nextclo
 
 
 Several 2FA apps are already available including
-`TOTP <https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm>`_, 
-a Telegram/Signal/SMS gateway and `U2F <https://en.wikipedia.org/wiki/Universal_2nd_Factor>`_. 
+`TOTP <https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm>`_,
+a Telegram/Signal/SMS gateway and `U2F <https://en.wikipedia.org/wiki/Universal_2nd_Factor>`_.
 
 
-Developers can `build new two-factor provider apps <https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/two-factor-provider.html>`_.
+Developers can `build new two-factor provider apps <https://docs.nextcloud.com/server/25/developer_manual/digging_deeper/two-factor-provider.html>`_.
 
 .. TODO ON RELEASE: Update version number above on release
 
@@ -27,7 +27,7 @@ you want, 2FA will be installed and enabled on your Nextcloud server.
 
 .. figure:: ../images/2fa-app-install.png
 
-Once 2FA has been enabled, users have to `activate it in their personal settings. <https://docs.nextcloud.com/server/latest/user_manual/en/user_2fa.html>`_
+Once 2FA has been enabled, users have to `activate it in their personal settings. <https://docs.nextcloud.com/server/25/user_manual/en/user_2fa.html>`_
 
 .. TODO ON RELEASE: Update version number above on release
 

--- a/admin_manual/index.rst
+++ b/admin_manual/index.rst
@@ -37,7 +37,7 @@ respective manuals:
 * `Nextcloud User Manual`_
 * `Nextcloud Desktop Client`_
 
-.. _`Nextcloud User Manual`: https://docs.nextcloud.com/server/latest/user_manual/en/
+.. _`Nextcloud User Manual`: https://docs.nextcloud.com/server/25/user_manual/en/
 .. _`Nextcloud Desktop Client`: https://docs.nextcloud.com/desktop/latest/
 
 .. TODO ON RELEASE: Update version number above on release

--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -32,7 +32,7 @@ configuration report with the :ref:`occ config command
 .. _the Nextcloud Forums: https://help.nextcloud.com
 .. _FAQ page: https://help.nextcloud.com/c/faq
 .. _bugtracker: https://github.com/nextcloud/server/issues
-   https://docs.nextcloud.com/server/latest/developer_manual/prologue/bugtracker/index.html
+   https://docs.nextcloud.com/server/25/developer_manual/prologue/bugtracker/index.html
 
 .. TODO ON RELEASE: Update version number above on release
 

--- a/admin_manual/release_schedule.rst
+++ b/admin_manual/release_schedule.rst
@@ -19,5 +19,7 @@ Maintenance releases are scheduled in a 4 week cycle with one week before the re
 Critical changes
 ----------------
 
-You can find important documentation for app developers here: https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.html
+You can find important documentation for app developers here: https://docs.nextcloud.com/server/25/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.html
 Each document lists a link to the breaking changes of the corresponding release.
+
+.. TODO ON RELEASE: Update version number above on release

--- a/developer_manual/basics/logging.rst
+++ b/developer_manual/basics/logging.rst
@@ -47,8 +47,10 @@ Admin audit logging
 
 If you want to log things less for system administration but for compliance reasons, e.g. who accessed which file,
 who changed the password of an item or made it public, the
-`admin audit log <https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/logging_configuration.html#admin-audit-log>`_
+`admin audit log <https://docs.nextcloud.com/server/25/admin_manual/configuration_server/logging_configuration.html#admin-audit-log>`_
 is the correct place.
+
+.. TODO ON RELEASE: Update version number above on release
 
 You can easily add a log by simply emitting an ``OCP\Log\Audit\CriticalActionPerformedEvent`` event:
 

--- a/developer_manual/basics/setting.rst
+++ b/developer_manual/basics/setting.rst
@@ -110,10 +110,12 @@ The last missing part is to register both classes inside **<myapp>/appinfo/info.
    `<personal>` instead.
 
 Additionally since Nextcloud 23, groups can be granted authorization to access individual
-admin settings (`see admin docs <https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/admin_delegation_configuration>`_).
+admin settings (`see admin docs <https://docs.nextcloud.com/server/25/admin_manual/configuration_server/admin_delegation_configuration>`_).
 This is a feature that needs to be enabled for each admin setting class.
 To do so, the setting class needs to implement `IDelegatedSettings` instead of `ISettings`
 and implement two additional methods.
+
+.. TODO ON RELEASE: Update version number above on release
 
 .. code-block:: php
 

--- a/developer_manual/client_apis/OCS/ocs-share-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-share-api.rst
@@ -142,7 +142,7 @@ Federated Cloud Shares
 ----------------------
 
 Both the sending and the receiving instance need to have federated cloud sharing
-enabled and configured. See `Configuring Federated Cloud Sharing <https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/federated_cloud_sharing_configuration.html>`_.
+enabled and configured. See `Configuring Federated Cloud Sharing <https://docs.nextcloud.com/server/25/admin_manual/configuration_files/federated_cloud_sharing_configuration.html>`_.
 
 .. TODO ON RELEASE: Update version number above on release
 

--- a/developer_manual/getting_started/devenv.rst
+++ b/developer_manual/getting_started/devenv.rst
@@ -11,7 +11,7 @@ Please follow the steps on this page to set up your development environment.
 Set up Web server and database
 ------------------------------
 
-First `set up your Web server and database <https://docs.nextcloud.com/server/stable/admin_manual/installation/index.html>`_ (**Section**: Manual Installation - Prerequisites).
+First `set up your Web server and database <https://docs.nextcloud.com/server/25/admin_manual/installation/index.html>`_ (**Section**: Manual Installation - Prerequisites).
 
 .. TODO ON RELEASE: Update version number above on release
 
@@ -20,7 +20,7 @@ Get the source
 
 There are two ways to obtain Nextcloud sources:
 
-* Using the `stable version <https://docs.nextcloud.com/server/stable/admin_manual/installation/index.html>`_
+* Using the `stable version <https://docs.nextcloud.com/server/25/admin_manual/installation/index.html>`_
 * Using the development version from `GitHub`_ which will be explained below.
 
 .. TODO ON RELEASE: Update version number above on release

--- a/user_manual/external_storage/external_storage.rst
+++ b/user_manual/external_storage/external_storage.rst
@@ -2,11 +2,11 @@
 Configuring External Storage
 ============================
 
-The External Storage application allows you to mount external storage services, 
+The External Storage application allows you to mount external storage services,
 such as Amazon S3, SMB/CIFS file servers and FTP servers…
-in Nextcloud. Your Nextcloud server administrator controls which of these are 
-available to you. Please see `Configuring External Storage (GUI) 
-<https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/external_storage_configuration_gui.html>`_ in the Nextcloud Administrator's 
+in Nextcloud. Your Nextcloud server administrator controls which of these are
+available to you. Please see `Configuring External Storage (GUI)
+<https://docs.nextcloud.com/server/25/admin_manual/configuration_files/external_storage_configuration_gui.html>`_ in the Nextcloud Administrator's
 manual for configuration how-tos and examples.
 
 .. TODO ON RELEASE: Update version number above on release

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -209,7 +209,9 @@ path of your certificate as in this example::
 Accessing files using macOS
 ---------------------------
 
-.. note:: The macOS Finder suffers from a `series of implementation problems <http://sabre.io/dav/clients/finder/>`_ and should only be used if the Nextcloud server runs on **Apache** and **mod_php**, or **Nginx 1.3.8+**. Alternative macOS-compatible clients capable of accessing WebDAV shares include open source apps like `Cyberduck <https://cyberduck.io/>`_ (see instructions `here <https://docs.nextcloud.com/server/stable/user_manual/files/access_webdav.html#accessing-files-using-cyberduck>`_) and `Filezilla <https://filezilla-project.org>`_. Commercial clients include `Mountain Duck <https://mountainduck.io/>`_, `Forklift <https://binarynights.com/>`_, `Transmit <https://panic.com/>`_, and `Commander One <https://mac.eltima.com/>`_.
+.. note:: The macOS Finder suffers from a `series of implementation problems <http://sabre.io/dav/clients/finder/>`_ and should only be used if the Nextcloud server runs on **Apache** and **mod_php**, or **Nginx 1.3.8+**. Alternative macOS-compatible clients capable of accessing WebDAV shares include open source apps like `Cyberduck <https://cyberduck.io/>`_ (see instructions `here <https://docs.nextcloud.com/server/25/user_manual/files/access_webdav.html#accessing-files-using-cyberduck>`_) and `Filezilla <https://filezilla-project.org>`_. Commercial clients include `Mountain Duck <https://mountainduck.io/>`_, `Forklift <https://binarynights.com/>`_, `Transmit <https://panic.com/>`_, and `Commander One <https://mac.eltima.com/>`_.
+
+.. TODO ON RELEASE: Update version number above on release
 
 To access files through the macOS Finder:
 
@@ -232,14 +234,14 @@ Accessing files using Microsoft Windows
 ---------------------------------------
 
 If you use the native Windows implementation of WebDAV, you can map Nextcloud to a new
-drive using Windows Explorer. Mapping to a drive enables you to browse files stored on a 
+drive using Windows Explorer. Mapping to a drive enables you to browse files stored on a
 Nextcloud server the way you would files stored in a mapped network drive.
 
 Using this feature requires network connectivity. If you want to store your
 files offline, use the Desktop Client to sync all files on your
 Nextcloud to one or more directories of your local hard drive.
 
-.. note:: Windows 10 now defaults to allow Basic Authentication if HTTPS is 
+.. note:: Windows 10 now defaults to allow Basic Authentication if HTTPS is
     enabled prior to mapping your drive. On older versions of Windows,
     you must permit the use of Basic Authentication in the Windows
     Registry: launch ``regedit`` and navigate to
@@ -515,14 +517,14 @@ To get the properties of files in the root folder:
         </d:propstat>
       </d:response>
     </d:multistatus>
-    
-    
-    
-    
+
+
+
+
 Accessing files using WinSCP
 -------------------------------
 
-`WinSCP <https://winscp.net/eng/docs/introduction/>`_  is an open source free SFTP client, FTP client, WebDAV client, S3 client and SCP client for Windows. Its main function is file transfer between a local and a remote computer. Beyond this, WinSCP offers scripting and basic file manager functionality. 
+`WinSCP <https://winscp.net/eng/docs/introduction/>`_  is an open source free SFTP client, FTP client, WebDAV client, S3 client and SCP client for Windows. Its main function is file transfer between a local and a remote computer. Beyond this, WinSCP offers scripting and basic file manager functionality.
 
 You can `download <https://winscp.net/eng/downloads.php/>`_ the portable version of WinSCP and run it on Linux through `Wine <https://wiki.winehq.org/Main_Page/>`_.
 

--- a/user_manual/files/deleted_file_management.rst
+++ b/user_manual/files/deleted_file_management.rst
@@ -55,5 +55,7 @@ file is added. If the deleted files exceed the new maximum allowed space
 Nextcloud will permanently delete those trashed files with the soonest expiration
 until the space limit is met again.
 
-.. note:: Your administrator may have configured the trash bin retention period 
-   to override the storage space management. See `admin documentation <https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#deleted-items-trash-bin>`_ for more details.
+.. note:: Your administrator may have configured the trash bin retention period
+   to override the storage space management. See `admin documentation <https://docs.nextcloud.com/server/25/admin_manual/configuration_server/config_sample_php_parameters.html#deleted-items-trash-bin>`_ for more details.
+
+.. TODO ON RELEASE: Update version number above on release

--- a/user_manual/files/encrypting_files.rst
+++ b/user_manual/files/encrypting_files.rst
@@ -34,15 +34,15 @@ How can encryption be disabled?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The only way to disable encryption is to run the `"decrypt all"
-<https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html#encryption-label>`_
+<https://docs.nextcloud.com/server/25/admin_manual/configuration_server/occ_command.html#encryption-label>`_
 script, which decrypts all files and disables encryption.
 
 Is it possible to disable encryption with the recovery key?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Yes, *if* every user uses the `file recovery key
-<https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html#enabling-users-file-recovery-keys>`_, `"decrypt all"
-<https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html#encryption-label>`_ will use it to decrypt all files.
+<https://docs.nextcloud.com/server/25/admin_manual/configuration_files/encryption_configuration.html#enabling-users-file-recovery-keys>`_, `"decrypt all"
+<https://docs.nextcloud.com/server/25/admin_manual/configuration_server/occ_command.html#encryption-label>`_ will use it to decrypt all files.
 
 .. TODO ON RELEASE: Update version number above on release
 
@@ -50,7 +50,7 @@ Can encryption be disabled without the user's password?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you don't have the users password or `file recovery key
-<https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html#enabling-users-file-recovery-keys>`_,
+<https://docs.nextcloud.com/server/25/admin_manual/configuration_files/encryption_configuration.html#enabling-users-file-recovery-keys>`_,
 then there is no way to decrypt all files. What's more, running it on login
 would be dangerous, because you would most likely run into timeouts.
 

--- a/user_manual/files/large_file_upload.rst
+++ b/user_manual/files/large_file_upload.rst
@@ -9,7 +9,7 @@ Modifying certain Nextcloud variables requires administrative access. If you req
 * Contact your administrator to request an increase in these variables
 
 * Refer to the section in the `Administration Documentation
-  <https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/big_file_upload_configuration.html>`_ that describes how to manage file
+  <https://docs.nextcloud.com/server/25/admin_manual/configuration_files/big_file_upload_configuration.html>`_ that describes how to manage file
   upload size limits.
 
 .. TODO ON RELEASE: Update version number above on release

--- a/user_manual/files/quota.rst
+++ b/user_manual/files/quota.rst
@@ -7,32 +7,34 @@ your the Personal page to see what your quota is, and how much you have used.
 
 .. figure:: ../images/quota1.png
 
-It may be helpful to understand how your quota is calculated. 
+It may be helpful to understand how your quota is calculated.
 
-Metadata (thumbnails, temporary files, cache, and encryption keys) takes up 
-about 10% of disk space, but is not counted against user quotas. Some apps 
-store information in the database, such as the Calendar and Contacts apps. This 
+Metadata (thumbnails, temporary files, cache, and encryption keys) takes up
+about 10% of disk space, but is not counted against user quotas. Some apps
+store information in the database, such as the Calendar and Contacts apps. This
 data is excluded from your quota.
 
-When other users share files with you, the shared files count against the 
-original share owner's quota. When you share a folder and allow other users or 
-groups to upload files to it, all uploaded and edited files count against your 
-quota. When you re-share files shared with you, the re-share still counts 
+When other users share files with you, the shared files count against the
+original share owner's quota. When you share a folder and allow other users or
+groups to upload files to it, all uploaded and edited files count against your
+quota. When you re-share files shared with you, the re-share still counts
 against the quota of the original share owner.
 
-Encrypted files are a little larger than unencrypted files; the unencrypted size 
+Encrypted files are a little larger than unencrypted files; the unencrypted size
 is calculated against your quota.
 
-Deleted files that are still in the trash bin do not count against quotas. The 
-trash bin is set at 50% of quota. Deleted file aging is set at 30 days. When 
-deleted files exceed 50% of quota then the oldest files are removed until the 
+Deleted files that are still in the trash bin do not count against quotas. The
+trash bin is set at 50% of quota. Deleted file aging is set at 30 days. When
+deleted files exceed 50% of quota then the oldest files are removed until the
 total is below 50%.
 
-.. note:: Your administrator may have configured the trash bin retention period 
-   to override the storage space management. See `administrator documentation <https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#deleted-items-trash-bin>`_ for more details.
+.. note:: Your administrator may have configured the trash bin retention period
+   to override the storage space management. See `administrator documentation <https://docs.nextcloud.com/server/25/admin_manual/configuration_server/config_sample_php_parameters.html#deleted-items-trash-bin>`_ for more details.
 
-When version control is enabled, the older file versions are not counted against 
+.. TODO ON RELEASE: Update version number above on release
+
+When version control is enabled, the older file versions are not counted against
 quotas.
 
-If you create a public share via URL and allow uploads, any uploaded files 
+If you create a public share via URL and allow uploads, any uploaded files
 count against your quota.

--- a/user_manual/files/sharing.rst
+++ b/user_manual/files/sharing.rst
@@ -12,8 +12,9 @@ Nextcloud users can share files and folders. Possible targets are:
 * users or groups on federated Nextcloud servers
 
 .. note:: Some options may not be available due to administrative configuration.
-   See `administrator documentation <https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/file_sharing_configuration.html>`__ for details.
+   See `administrator documentation <https://docs.nextcloud.com/server/25/admin_manual/configuration_files/file_sharing_configuration.html>`__ for details.
 
+.. TODO ON RELEASE: Update version number above on release
 
 Public link shares
 ------------------
@@ -49,7 +50,7 @@ When sharing with users, groups, circles or members of a Talk conversation, righ
 
 .. figure:: ../images/sharing_internal.png
 
-As a sharee, you can configure if you automatically want to accept all incoming shares and have them added to your root folder, or if you 
+As a sharee, you can configure if you automatically want to accept all incoming shares and have them added to your root folder, or if you
 want to be asked each time if you want to accept or decline the share.
 
 .. figure:: ../images/sharing_internal_acceptNotification.png
@@ -62,7 +63,7 @@ For adjusting the acceptance setting, go to **Settings** > **Personal** > **Shar
 Others with access
 ------------------
 
-In order to find out if a file or folder is accessible to others through sharing of a superior folder 
+In order to find out if a file or folder is accessible to others through sharing of a superior folder
 hierarchy level, click on **Others with access** in the sharing tab:
 
 .. figure:: ../images/sharing_others-with-access__collapsed.png
@@ -86,8 +87,8 @@ Click on the three dots to:
 Federated Shares
 ================
 
-Federation Sharing allows you to mount file shares from remote Nextcloud servers, in effect 
-creating your own cloud of Nextclouds. You can create direct share links with 
+Federation Sharing allows you to mount file shares from remote Nextcloud servers, in effect
+creating your own cloud of Nextclouds. You can create direct share links with
 users on other Nextcloud servers.
 
 Creating a new Federation Share
@@ -95,7 +96,7 @@ Creating a new Federation Share
 
 Federation sharing is enabled by default. Follow these steps to create a new share with other Nextcloud or ownCloud servers:
 
-Go to your ``Files`` page and click the Share icon on the file or directory 
+Go to your ``Files`` page and click the Share icon on the file or directory
 you want to share. In the sidebar enter the username and URL of the remote user
 in this form: ``<username>@<nc-server-url>``. In this example, that is
 ``bob@cloud.example.com``:

--- a/user_manual/files/transfer_ownership.rst
+++ b/user_manual/files/transfer_ownership.rst
@@ -2,7 +2,7 @@
 Transfer Ownership
 ==================
 
-Users can transfer the ownership of files and folders to other users. Sharing 
+Users can transfer the ownership of files and folders to other users. Sharing
 ownerships of those transferred files/folders will also be transferred.
 
 #. Navigate to *Settings* > *Personal* > *Sharing* > *Files*.
@@ -13,13 +13,15 @@ ownerships of those transferred files/folders will also be transferred.
 #. Click on *Transfer*.
 
 	.. note:: The username autocompletion or listing may be limited due to administrative visibility configuration.
-	   See `administrator documentation <https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/file_sharing_configuration.html>`_ for details.
+	   See `administrator documentation <https://docs.nextcloud.com/server/25/admin_manual/configuration_files/file_sharing_configuration.html>`_ for details.
+
+.. TODO ON RELEASE: Update version number above on release
 
 #. The target user receives a notification where they are being asked whether to
    accept or reject the incoming transfer.
 
 	.. figure:: ../images/transfer_ownership-accept.png
 
-#. If accepted, the target user finds the transferred files and folders in their 
+#. If accepted, the target user finds the transferred files and folders in their
    root under a folder *Transferred from [user] on [timestamp]*.
 #. The source user gets informed about the acceptance or rejection by a notification.

--- a/user_manual/groupware/sync_gnome.rst
+++ b/user_manual/groupware/sync_gnome.rst
@@ -6,7 +6,7 @@ The `GNOME desktop <https://www.gnome.org>`_ has built-in support for Nextcloud'
 contacts and tasks which will be displayed by the Evolution PIM or the
 Calendar, Tasks and Contacts app as well has for files, which it
 integrates into the Nautilus file manager via WebDAV. The latter works
-only while the computer is connected. 
+only while the computer is connected.
 
 This can be done by following these steps:
 
@@ -18,13 +18,15 @@ This can be done by following these steps:
 3. Enter your server URL, username and password. If you have enabled two
    factor authentification, you need to generate an app-password/token, because GNOME Online Accounts
    `doesn't support Nextcloud's webflow login yet <https://gitlab.gnome.org/GNOME/gnome-online-accounts/issues/81>`_
-   (`Learn more <https://docs.nextcloud.com/server/stable/user_manual/session_management.html#managing-devices>`_):
+   (`Learn more <https://docs.nextcloud.com/server/25/user_manual/session_management.html#managing-devices>`_):
+
+.. TODO ON RELEASE: Update version number above on release
 
 .. image:: ../images/goa-add-nextcloud-account.png
-   
+
 4. In the next window, select which resources GNOME should access and
    press the cross in the top right to close:
-   
+
 .. image:: ../images/goa-nextcloud-select.png
 
 Nextcloud tasks, calendars and contacts should now be visible in the
@@ -36,5 +38,5 @@ dialogues). Documents should be integrated into the GNOME Documents
 app.
 
 All resources should also be searchable from anywhere by pressing the Windows key and entering a
-search term. 
+search term.
 

--- a/user_manual/groupware/sync_ios.rst
+++ b/user_manual/groupware/sync_ios.rst
@@ -42,6 +42,6 @@ You should now find your contacts in the address book of your iPhone.
 
 If it's still not working, have a look at `Troubleshooting Contacts & Calendar`_ or `Troubleshooting Service Discovery`_.
 
-.. _Troubleshooting Contacts & Calendar: https://docs.nextcloud.com/server/stable/admin_manual/issues/general_troubleshooting.html#troubleshooting-contacts-calendar
-.. _Troubleshooting Service Discovery: https://docs.nextcloud.com/server/stable/admin_manual/issues/general_troubleshooting.html#service-discovery
+.. _Troubleshooting Contacts & Calendar: https://docs.nextcloud.com/server/25/admin_manual/issues/general_troubleshooting.html#troubleshooting-contacts-calendar
+.. _Troubleshooting Service Discovery: https://docs.nextcloud.com/server/25/admin_manual/issues/general_troubleshooting.html#service-discovery
 .. TODO ON RELEASE: Update version number above on release

--- a/user_manual/groupware/sync_kde.rst
+++ b/user_manual/groupware/sync_kde.rst
@@ -28,7 +28,9 @@ In Kalendar:
 
 In KOrganizer and Kalendar:
 
-3. Enter your username. As password, you need to generate an app-password/token (`Learn more <https://docs.nextcloud.com/server/stable/user_manual/session_management.html#managing-devices>`_):
+3. Enter your username. As password, you need to generate an app-password/token (`Learn more <https://docs.nextcloud.com/server/25/user_manual/session_management.html#managing-devices>`_):
+
+.. TODO ON RELEASE: Update version number above on release
 
 .. image:: ../images/korganizer_credentials.png
 

--- a/user_manual/groupware/sync_osx.rst
+++ b/user_manual/groupware/sync_osx.rst
@@ -5,7 +5,7 @@ Synchronizing with macOS
 Setup your Accounts
 -------------------
 
-In the following steps you will add your server resources for **CalDAV** (Calendar) 
+In the following steps you will add your server resources for **CalDAV** (Calendar)
 and **CardDAV** (Contacts) to your Nextcloud.
 
 1. Open the **system preferences** of your macOS device.
@@ -25,9 +25,11 @@ and **CardDAV** (Contacts) to your Nextcloud.
 4. Select **Manual** as Account-Type and type in your respective credentials:
 
    **Username**: Your Nextcloud username or email
-   
-   **Password**: Your generated app-password/token (`Learn more <https://docs.nextcloud.com/server/stable/user_manual/session_management.html#managing-devices>`_).
-   
+
+   **Password**: Your generated app-password/token (`Learn more <https://docs.nextcloud.com/server/25/user_manual/session_management.html#managing-devices>`_).
+
+.. TODO ON RELEASE: Update version number above on release
+
    **Server Address**: URL of your Nextcloud server (e.g. ``https://cloud.example.com``)
 
 .. figure:: ./images/macos_3.png


### PR DESCRIPTION
Links inside the documentation should always link to the same version they are from.