### PR TITLE
Use versionadded directive for added OCP events

### DIFF
--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -171,236 +171,236 @@ Here you find an overview of the public events that can be consumed in apps. See
 ``\OCA\DAV\Events\AddressBookCreatedEvent``
 *******************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user creates a new address-book.
 
 ``\OCA\DAV\Events\AddressBookDeletedEvent``
 *******************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user deletes an address-book.
 
 ``\OCA\DAV\Events\AddressBookShareUpdatedEvent``
 ************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user shares or unshares an address-book.
 
 ``\OCA\DAV\Events\AddressBookUpdatedEvent``
 *******************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user updates an address-book.
 
 ``\OCA\DAV\Events\CachedCalendarObjectCreatedEvent``
 ****************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a cached calendar object is being created while fetching a calendar-subscription.
 
 ``\OCA\DAV\Events\CachedCalendarObjectDeletedEvent``
 ****************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a cached calendar object is being deleted while fetching a calendar-subscription.
 
 ``\OCA\DAV\Events\CachedCalendarObjectUpdatedEvent``
 ****************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a cached calendar object is being updated while fetching a calendar-subscription.
 
 ``\OCA\DAV\Events\CalendarCreatedEvent``
 ****************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user creates a new calendar.
 
 ``\OCA\DAV\Events\CalendarDeletedEvent``
 ****************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user deletes a calendar.
 
 ``\OCA\DAV\Events\CalendarObjectCreatedEvent``
 **********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user creates a calendar-object.
 
 ``\OCA\DAV\Events\CalendarObjectDeletedEvent``
 **********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user deletes a calendar-object.
 
 ``\OCA\DAV\Events\CalendarObjectUpdatedEvent``
 **********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user updates a calendar-object.
 
 ``\OCA\DAV\Events\CalendarPublishedEvent``
 ******************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user publishes a calendar.
 
 ``\OCA\DAV\Events\CalendarShareUpdatedEvent``
 *********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user shares or unshares a calendar.
 
 ``\OCA\DAV\Events\CalendarUnpublishedEvent``
 ********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user unpublishes calendar.
 
 ``\OCA\DAV\Events\CalendarUpdatedEvent``
 ****************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user updates a calendar.
 
 ``\OCA\DAV\Events\CardCreatedEvent``
 ************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user creates a new card in an address-book.
 
 ``\OCA\DAV\Events\CardDeletedEvent``
 ************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user deletes a card in an address-book.
 
 ``\OCA\DAV\Events\CardUpdatedEvent``
 ************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user updates a card in an address-book.
 
 ``\OCA\DAV\Events\SabrePluginAuthInitEvent``
 ********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered during the setup of the SabreDAV server to allow the registration of additional authentication backends.
 
 ``\OCA\DAV\Events\SubscriptionCreatedEvent``
 ********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user creates a new calendar-subscription.
 
 ``\OCA\DAV\Events\SubscriptionDeletedEvent``
 ********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user deletes a calendar-subscription.
 
 ``\OCA\DAV\Events\SubscriptionUpdatedEvent``
 ********************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a user deletes a calendar-subscription.
 
 ``\OCA\FederatedFileSharing\Events\FederatedShareAddedEvent``
 *************************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered when a federated share is successfully added.
 
 ``\OCA\Files\Event\LoadAdditionalScriptsEvent``
 ***********************************************
 
-*Available in Nextcloud 17 and later.*
+.. versionadded:: 17
 
 This event is triggered when the files app is rendered. It can be used to add additional scripts to the files app.
 
 ``\OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent``
 ********************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 Emitted before the rendering step of the public share page happens. The event holds a flag that specifies if it is the authentication page of a public share.
 
 ``\OCA\Settings\Events\BeforeTemplateRenderedEvent``
 ********************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered right before the user management template is rendered.
 
 ``\OCA\User_LDAP\Events\GroupBackendRegistered``
 ************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered right after the LDAP group backend is registered.
 
 ``\OCA\User_LDAP\Events\UserBackendRegistered``
 ************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 This event is triggered right after the LDAP user backend is registered.
 
 ``\OCA\Viewer\Event\LoadViewer``
 ********************************
 
-*Available in Nextcloud 17 and later.*
+.. versionadded:: 17
 
 This event is triggered whenever the viewer is loaded and extensions should be loaded.
 
 ``\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent``
 *************************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 Emitted before the rendering step of each TemplateResponse. The event holds a flag that specifies if an user is logged in.
 
 ``\OCP\Authentication\Events\LoginFailedEvent``
 ***********************************************
 
-*Available in Nextcloud 19 and later.*
+.. versionadded:: 19
 
 Emitted when the authentication fails, but only if the login name can be associated with an existing user.
 
 ``\OCP\Authentication\TwoFactorAuth\TwoFactorProviderDisabled``
 ***************************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 ``\OCP\Contacts\Events\ContactInteractedWithEvent``
 ***************************************************
 
-*Available in Nextcloud 19 and later.*
+.. versionadded:: 19
 
 Event emitted by apps whenever there was an interaction with another user or contact.
 
@@ -411,108 +411,108 @@ Emitters should add at least one identifier (uid, email, federated cloud ID) of 
 ``\OCP\DirectEditing\RegisterDirectEditorEvent``
 ************************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Event to allow to register the direct editor.
 
 ``\OCP\Files\Events\BeforeFileScannedEvent``
 ********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Files\Events\BeforeFolderScannedEvent``
 **********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Files\Events\FileCacheUpdated``
 **************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Files\Events\FileScannedEvent``
 **************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Files\Events\FolderScannedEvent``
 ****************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Files\Events\NodeAddedToCache``
 **************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Files\Events\NodeRemovedFromCache``
 ******************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Group\Events\BeforeGroupCreatedEvent``
 *********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Group\Events\BeforeGroupDeletedEvent``
 *********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Group\Events\BeforeUserAddedEvent``
 ******************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Group\Events\BeforeUserRemovedEvent``
 ********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Deprecated in 20.0.0 - it can't be guaranteed that this event is triggered in all case (e.g. for LDAP users this isn't possible)
 
 ``\OCP\Group\Events\GroupCreatedEvent``
 ***************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Group\Events\GroupDeletedEvent``
 ***************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Group\Events\SubAdminAddedEvent``
 ****************************************
 
-*Available in Nextcloud 21 and later.*
+.. versionadded:: 21
 
 ``\OCP\Group\Events\SubAdminRemovedEvent``
 ******************************************
 
-*Available in Nextcloud 21 and later.*
+.. versionadded:: 21
 
 ``\OCP\Group\Events\UserAddedEvent``
 ************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Group\Events\UserRemovedEvent``
 **************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Mail\Events\BeforeMessageSent``
 **************************************
 
-*Available in Nextcloud 19 and later.*
+.. versionadded:: 19
 
 Emitted before a system mail is sent. It can be used to alter the message.
 
 ``\OCP\Security\CSP\AddContentSecurityPolicyEvent``
 ***************************************************
 
-*Available in Nextcloud 17 and later.*
+.. versionadded:: 17
 
 Allows to inject something into the default content policy. This is for example useful when you're injecting Javascript code into a view belonging to another controller and cannot modify its Content-Security-Policy itself. Note that the adjustment is only applied to applications that use AppFramework controllers.
 
@@ -521,142 +521,142 @@ WARNING: Using this API incorrectly may make the instance more insecure. Do thin
 ``\OCP\Security\Events\GenerateSecurePasswordEvent``
 ****************************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Security\Events\ValidatePasswordPolicyEvent``
 ****************************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Security\FeaturePolicy\AddFeaturePolicyEvent``
 *****************************************************
 
-*Available in Nextcloud 17 and later.*
+.. versionadded:: 17
 
 Event that allows to register a feature policy header to a request.
 
 ``\OCP\Share\Events\ShareCreatedEvent``
 ***************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\Share\Events\VerifyMountPointEvent``
 *******************************************
 
-*Available in Nextcloud 19 and later.*
+.. versionadded:: 19
 
 ``\OCP\User\Events\BeforeUserLoggedInWithCookieEvent``
 ******************************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted before a user is logged in via remember-me cookies.
 
 ``\OCP\User\Events\UserLoggedInWithCookieEvent``
 ************************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted when a user has been successfully logged in via remember-me cookies.
 
 ``\OCP\User\Events\BeforePasswordUpdatedEvent``
 ***********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted before the user password is updated.
 
 ``\OCP\User\Events\PasswordUpdatedEvent``
 *****************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted when the user password has been updated.
 
 ``\OCP\User\Events\BeforeUserCreatedEvent``
 *******************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted before a new user is created on the back-end.
 
 ``\OCP\User\Events\UserCreatedEvent``
 *************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted when a new user has been created on the back-end.
 
 ``\OCP\User\Events\BeforeUserDeletedEvent``
 *******************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\User\Events\UserDeletedEvent``
 *************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\User\Events\BeforeUserLoggedInEvent``
 ********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\User\Events\BeforeUserLoggedOutEvent``
 *********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted before a user is logged out.
 
 ``\OCP\User\Events\PostLoginEvent``
 ***********************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\User\Events\UserChangedEvent``
 *************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\User\Events\UserLiveStatusEvent``
 ****************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 ``\OCP\User\Events\UserLoggedInEvent``
 **************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\User\Events\UserLoggedOutEvent``
 ***************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Emitted when a user has been logged out successfully.
 
 ``\OCP\WorkflowEngine\LoadSettingsScriptsEvent``
 ************************************************
 
-*Available in Nextcloud 20 and later.*
+.. versionadded:: 20
 
 Emitted when the workflow engine settings page is loaded.
 
 ``\OCP\WorkflowEngine\RegisterChecksEvent``
 *******************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\WorkflowEngine\RegisterEntitiesEvent``
 *********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 ``\OCP\WorkflowEngine\RegisterOperationsEvent``
 ***********************************************
 
-*Available in Nextcloud 18 and later.*
+.. versionadded:: 18
 
 Symfony event dispatcher
 ------------------------


### PR DESCRIPTION
Why write it out when sphinx can write the text for us?

| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-11-14 14-38-20](https://user-images.githubusercontent.com/1374172/201674634-7a658b43-1ba7-4111-af68-3098cfde05aa.png) | ![Bildschirmfoto vom 2022-11-14 14-38-07](https://user-images.githubusercontent.com/1374172/201674679-e169b7ee-969f-4539-9f2b-0e8984592c99.png) |

