### PR TITLE
fix bugtracker link

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -31,8 +31,7 @@ configuration report with the :ref:`occ config command
 
 .. _the Nextcloud Forums: https://help.nextcloud.com
 .. _FAQ page: https://help.nextcloud.com/t/how-to-faq-wiki
-.. _bugtracker: https://github.com/nextcloud/server/issues
-   https://docs.nextcloud.com/server/latest/developer_manual/prologue/bugtracker/index.html
+.. _bugtracker: https://docs.nextcloud.com/server/latest/developer_manual/prologue/bugtracker/index.html
 
 .. TODO ON RELEASE: Update version number above on release
 


### PR DESCRIPTION
There can be only one link (two links results in broken link) and also link to server bug tracker is part of linked list of bugtrackers, so shouldn't appear there.

Signed-off-by: p-bo <pavel.borecki@gmail.com>