### PR TITLE
Updated link to WebDAV FAQ on OwnCloud forum

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -223,7 +223,7 @@ See:
   (Describes problems with Finder on various Web servers)
 
 There is also a well maintained FAQ thread available at the `ownCloud Forums
-<https://forum.owncloud.org/viewtopic.php?f=17&t=7536>`_
+<https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852>`_
 which contains various additional information about WebDAV problems.
 
 .. _service-discovery-label:


### PR DESCRIPTION
It seems, that forum was migrated, thus old URL leaded (was redirected) to forum homepage. Fixed by searching new URL of mentioned thread.

Signed-off-by: p-bo <pavel.borecki@gmail.com>