### PR TITLE
lowercase instead of uppercase, colon instead of comma

### DIFF
--- a/admin_manual/maintenance/package_upgrade.rst
+++ b/admin_manual/maintenance/package_upgrade.rst
@@ -6,7 +6,7 @@ Upgrade quickstart
 ------------------
 
 One effective, if unofficial method for keeping Nextcloud current on Linux servers is by configuring 
-your system to use Nextcloud via a self contained "Snap" package, A technology allowing users to 
+your system to use Nextcloud via a self contained "Snap" package: a technology allowing users to 
 always have the latest version of an "app".
 
 That version from Canonical is quite restrictive. It is not aimed at developers or advanced users 

--- a/admin_manual/maintenance/package_upgrade.rst
+++ b/admin_manual/maintenance/package_upgrade.rst
@@ -6,7 +6,7 @@ Upgrade quickstart
 ------------------
 
 One effective, if unofficial method for keeping Nextcloud current on Linux servers is by configuring 
-your system to use Nextcloud via a self contained "Snap" package: a technology allowing users to 
+your system to use Nextcloud via a self-contained "Snap" package: a technology allowing users to 
 always have the latest version of an "app".
 
 That version from Canonical is quite restrictive. It is not aimed at developers or advanced users 


### PR DESCRIPTION
There was combination of comma, followed by uppercase article which is not correct. So replaced upper case article with lowercase one and tried also other variants instead of comma between sentences. It seems, that colon fits best (but may be only subjective perception).

Signed-off-by: p-bo <pavel.borecki@gmail.com>