### PR TITLE
Add DevContainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.9 as final
+
+USER root
+
+# Add dev tools needed for building
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends \
+        curl gnupg2 git nano make graphviz imagemagick inkscape sass unzip wget php-cli npm latexmk texlive-latex-extra tex-gyre \
+    && wget https://getcomposer.org/installer -qO /tmp/composer-setup.php \
+    && php /tmp/composer-setup.php \
+    && mv composer.phar /usr/local/bin/composer \
+    && npm install svgexport -g \
+    && rm -f /tmp/composer-setup.php \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "Nextcloud documentation DevContainer",
+	"context": "..",
+	"dockerFile": "Dockerfile",
+	"containerUser": "root",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"tht13.rst-vscode",
+				"tomoki1207.pdf"
+			]
+		}
+	},
+	"postCreateCommand": "python3 -m pip install -r requirements.txt && python3 -m pip install sphinx-autobuild && cd build && composer install --ignore-platform-reqs"
+}

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,16 @@ Building PDF
 5. Install the dependencies `pip install -r requirements.txt`
 6. Now you can use `make ...` to build all the stuff - for example `make pdf` to build the PDF flavor of all manuals
 
+Using the VSCode DevContainer
+=============================
+
+This repository contains a full-featured `VSCode DevContainer <https://code.visualstudio.com/docs/devcontainers/containers>`_.
+You can use it in your local development environment or via `GitHub Codespaces <https://github.com/features/codespaces>`_.
+Just open the container an use one of the commands from above to build the project. For example ``make`` to build the full
+documentaion, ``make html`` to build the HTML documentaion or ``make pdf`` to build the PDF documentation. You can also use
+``make SPHINXBUILD=sphinx-autobuild html`` in combination with `port forwarding <https://code.visualstudio.com/docs/devcontainers/containers#_forwarding-or-publishing-a-port>`_
+to  watch file changes and automatically reload the html preview.
+
 Icons
 -----
 


### PR DESCRIPTION
This PR adds an appropriate DevContainer configuration to the project. We can now directly open the project inside GitHub Codespaces or a local VSCode DevContainer.

All required dependencies are bundled into the container, so commands like `make html`,  `make pdf` or `make` will work out of the box. Also development via file watching with `make SPHINXBUILD=sphinx-autobuild html` is possible.