### PR TITLE
Bash completion

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -163,6 +163,9 @@ and ``encryption:list-modules``
 Enabling autocompletion
 -----------------------
 
+Method 1: Using an alias and standard built-in ``complete``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Two script files are used to enable autocompletion::
 
 * bash-add-alias.sh
@@ -201,6 +204,9 @@ offer available options, regardless of present working directory.
 * apps if, i.e. occ ``talk:command:list [tab][tab]`` is entered
 * file system entries if, i.e. ``occ files:scan --path [tab][tab]`` is entered
 
+
+Method 2: Using symfony
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: Command autocompletion currently only works if the user you use to execute the occ commands has a profile.
   ``www-data`` in most cases is ``nologon`` and therefor **cannot** use this feature.

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -203,7 +203,7 @@ offer available options, regardless of present working directory.
 * user_ids if, i.e. ``occ files:scan [tab][tab]`` is entered
 * apps if, i.e. occ ``talk:command:list [tab][tab]`` is entered
 * file system entries if, i.e. ``occ files:scan --path [tab][tab]`` is entered
-
+* file system entries if, i.e. ``occ config:import`` is entered
 
 Method 2: Using symfony
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -163,6 +163,44 @@ and ``encryption:list-modules``
 Enabling autocompletion
 -----------------------
 
+Two script files are used to enable autocompletion::
+
+* bash-add-alias.sh
+* occ.bash
+
+Run ``bash-add-alias.sh`` by sourcing the file, using one of these methods:
+ * ``source bash-add-alias.sh``
+ * ``. bash-add-alias.sh``
+
+That script will generate an alias for ``occ`` in the form of::
+
+ ``alias occ='sudo user=... php /path/to/nextcloud/occ'``
+
+where the ``user=`` name is derived from the owner of the file
+``config/config.php``.
+
+
+Once the alias has been created, there is an option to run it, then
+have it persist across logins and reboots by optionally appending it to
+``~/.bash_aliases``, if it exists, otherwise to ``~/.bashrc``.
+
+Next, the script will optionally run ``occ.bash``, which enables and handles
+the autocompletions.
+
+Finally, the script will offer to copy the ``occ.bash`` to the system
+directory ``/etc/bash_completion.d/`` so it is automatically available for
+future sessions.
+
+Afterwards running the alias and ``occ.bash``, ``occ [tab][tab]`` will
+offer available options, regardless of present working directory.
+
+``occ.bash`` will attempt to offer completion options of
+
+* user_ids if, i.e. ``occ files:scan [tab][tab]`` is entered
+* file system options if, i.e. ``occ files:scan --path [tab][tab]`` is entered
+* apps if, i.e. occ ``talk:command:list [tab][tab]`` is entered
+
+
 .. note:: Command autocompletion currently only works if the user you use to execute the occ commands has a profile.
   ``www-data`` in most cases is ``nologon`` and therefor **cannot** use this feature.
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -169,12 +169,13 @@ Two script files are used to enable autocompletion::
 * occ.bash
 
 Run ``bash-add-alias.sh`` by sourcing the file, using one of these methods:
- * ``source bash-add-alias.sh``
- * ``. bash-add-alias.sh``
+
+* ``source bash-add-alias.sh``
+* ``. bash-add-alias.sh``
 
 That script will generate an alias for ``occ`` in the form of::
 
- ``alias occ='sudo user=... php /path/to/nextcloud/occ'``
+ alias occ='sudo user=... php /path/to/nextcloud/occ'
 
 where the ``user=`` name is derived from the owner of the file
 ``config/config.php``.
@@ -185,7 +186,7 @@ have it persist across logins and reboots by optionally appending it to
 ``~/.bash_aliases``, if it exists, otherwise to ``~/.bashrc``.
 
 Next, the script will optionally run ``occ.bash``, which enables and handles
-the autocompletions.
+the tab completions.
 
 Finally, the script will offer to copy the ``occ.bash`` to the system
 directory ``/etc/bash_completion.d/`` so it is automatically available for
@@ -194,11 +195,11 @@ future sessions.
 Afterwards running the alias and ``occ.bash``, ``occ [tab][tab]`` will
 offer available options, regardless of present working directory.
 
-``occ.bash`` will attempt to offer completion options of
+``occ.bash`` will attempt to offer completion options of:
 
 * user_ids if, i.e. ``occ files:scan [tab][tab]`` is entered
-* file system options if, i.e. ``occ files:scan --path [tab][tab]`` is entered
 * apps if, i.e. occ ``talk:command:list [tab][tab]`` is entered
+* file system entries if, i.e. ``occ files:scan --path [tab][tab]`` is entered
 
 
 .. note:: Command autocompletion currently only works if the user you use to execute the occ commands has a profile.

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -191,11 +191,11 @@ have it persist across logins and reboots by optionally appending it to
 Next, the script will optionally run ``occ.bash``, which enables and handles
 the tab completions.
 
-Finally, the script will offer to copy the ``occ.bash`` to the system
-directory ``/etc/bash_completion.d/`` so it is automatically available for
-future sessions.
+Finally, the script will offer to copy the ``occ.bash`` to the user's
+completions directory ``~/.local/share/bash-completion/completions/`` so it is
+automatically available for future sessions.
 
-Afterwards running the alias and ``occ.bash``, ``occ [tab][tab]`` will
+Once the alias is installed and ``occ.bash`` sourced, ``occ [tab][tab]`` will
 offer available options, regardless of present working directory.
 
 ``occ.bash`` will attempt to offer completion options of:

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -168,13 +168,13 @@ Method 1: Using an alias and standard built-in ``complete``
 
 Two script files are used to enable autocompletion::
 
-* bash-add-alias.sh
+* bash-tab-completion-occ.sh
 * occ.bash
 
-Run ``bash-add-alias.sh`` by sourcing the file, using one of these methods:
+Run ``bash-tab-completion-occ.sh`` by sourcing the file, using one of these methods:
 
-* ``source bash-add-alias.sh``
-* ``. bash-add-alias.sh``
+* ``source bash-tab-completion-occ.sh``
+* ``. bash-tab-completion-occ.sh``
 
 That script will generate an alias for ``occ`` in the form of::
 


### PR DESCRIPTION
Documentation for method of bash autocompletion from https://github.com/nextcloud/server/pull/35451.

Leaves the current method (Method 2: Using symfony) in place, but adds Method 1: Using an alias and standard built-in `complete` sub-section.