### PR TITLE
Adjust ROW_FORMAT note to changes in Nextcloud 24

### DIFF
--- a/admin_manual/configuration_database/mysql_4byte_support.rst
+++ b/admin_manual/configuration_database/mysql_4byte_support.rst
@@ -48,7 +48,7 @@ Note::
 
 .. note::
 
-    This will also change the `ROW_FORMAT` to `COMPRESSED` for your tables, to make sure the used database storage size is not getting out of hand.
+    This will also change the `ROW_FORMAT` to `DYNAMIC` for your tables.
 
 7. Disable maintenance mode::
 


### PR DESCRIPTION
Since Nextcloud 24 [ROW_FORMAT is no longer set to "COMPRESSED"](https://github.com/nextcloud/server/commit/e49233a79546f36771e31b96e330eedf61b63a34) when changing the character set of tables to "utf8mb4" in the "Repair MySQL collation" repair step. However, that repair step [still sets the ROW_FORMAT to "DYNAMIC"](https://github.com/nextcloud/server/blob/6be7aa112f6174c1406cfef5449836124a7f6f50/lib/private/Repair/Collation.php#L82) before changing the collation of tables, no matter the character set.
