### PR TITLE
Update Service Discovery example for Caddy …

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -142,8 +142,8 @@ Caddy
 ::
 
     subdomain.example.com {
-        rewrite /.well-known/carddav /remote.php/dav
-        rewrite /.well-known/caldav /remote.php/dav
+        redir /.well-known/carddav /remote.php/dav 301
+        redir /.well-known/caldav /remote.php/dav 301
 
         reverse_proxy {$NEXTCLOUD_HOST:localhost}
     }


### PR DESCRIPTION
… in  reverse_proxy_configuration.rst

While the rewrite rules should work I guess, they still trigger a warning on the admin page. Using 301 redirects make the warning go away.