### PR TITLE
fix: pin sphinx-rtd-theme to fix missing jquery lib

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 
 [packages]
 rst2pdf = "*"
-sphinx-rtd-theme = "*"
+sphinx-rtd-theme = "==1.2.0rc2"
 Sphinx = "*"
 Pillow = "*"
 


### PR DESCRIPTION
JQuery was removed as of Sphinx 6. The maintainers of our theme already reacted to this but the release is not final yet.

Ref https://github.com/sphinx-doc/sphinx/issues/10070
Ref https://github.com/readthedocs/sphinx_rtd_theme/pull/1385

## Alternative

We could also wait until sphinx-rtd-theme v1.2 is released.