### PR TITLE
Fix missing jquery - take 2 (`requirements.txt`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 rst2pdf
 pillow
-sphinx-rtd-theme
+sphinx-rtd-theme==1.2.0rc2
 sphinxcontrib-phpdomain

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ rst2pdf
 pillow
 sphinx-rtd-theme==1.2.0rc2
 sphinxcontrib-phpdomain
+
+# https://github.com/readthedocs/readthedocs.org/issues/9037#issuecomment-1077818554
+jinja2<3.1.0


### PR DESCRIPTION
I needed to pin jinja2, otherwise the build process errors out. Another argument for https://github.com/nextcloud/documentation/issues/9546.

Ref https://github.com/readthedocs/readthedocs.org/issues/9037#issuecomment-1077818554