### PR TITLE
Add section for troubleshooting quota issues

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -383,7 +383,7 @@ does not match the actual data stored in the user's ``data/$userId/files`` direc
 .. note::
 
    Metadata, versions, trashbin and encryption keys are not counted in the used space above.
-   Please refer to the quota documentation for details.
+   Please refer to the `quota documentation <https://docs.nextcloud.com/server/latest/user_manual/en/files/quota.html>`_ for details.
 
 Running the following command can help fix the sizes and quota for a given user::
 

--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -374,6 +374,29 @@ For a safe moving of data directory, supported by Nextcloud, recommended actions
 .. warning
    Note, you may need to configure your webserver to support symlinks.
 
+Troubleshooting quota or size issues
+------------------------------------
+
+Sometimes it can happen that the used space reported in the web UI or with ``occ user:info $userId``
+does not match the actual data stored in the user's ``data/$userId/files`` directory.
+
+.. note::
+
+   Metadata, versions, trashbin and encryption keys are not counted in the used space above.
+   Please refer to the quota documentation for details.
+
+Running the following command can help fix the sizes and quota for a given user::
+
+ sudo -u www-data php occ files:scan -vvv <user-id>
+
+If **encryption was enabled earlier on the instance and disabled later on**, it is likely that some
+size values in the database did not correctly get reset upon decrypting.
+You can run the following SQL query to reset those after **backing up the database**:
+
+.. code-block:: sql
+
+ UPDATE oc_filecache SET unencrypted_size=0 WHERE encrypted=0; 
+
 Troubleshooting downloading or decrypting files
 -----------------------------------------------
 


### PR DESCRIPTION
The workaround about `unencrypted_size` comes from https://github.com/nextcloud/server/issues/25283 and was proven to work for many people already, see https://github.com/nextcloud/server/issues/25283#issuecomment-1386927818 and further below

I had a debugging session with @JuliaKirschenheuter and we did observe that the column `unencrypted_size` is unused when encryption is disabled, so it's safe to set it to zero for non-encrypted file.

I've also verified this on my personal instance where encryption is disabled (`select * from oc_filecache where unencrypted_size > 0;` returns zero results)