### PR TITLE
Add docs for defaultTemplateDirectory app config

### DIFF
--- a/admin_manual/configuration_files/default_files_configuration.rst
+++ b/admin_manual/configuration_files/default_files_configuration.rst
@@ -27,3 +27,16 @@ They appear on the user's Nextcloud Files page just like any other files.
 .. note:: Overwriting the files in ``core/skeleton`` is not recommended,
   because those changes will be overwritten on the next update of the Nextcloud
   server.
+
+
+Default file templates
+----------------------
+
+The default path for user templates is at ``/Templates`` (translated in the user's language).
+If you need to override this path for all users, you can set
+
+::
+
+  occ config:app:set core defaultTemplateDirectory --value="CustomPath"
+
+This will only apply to new users.


### PR DESCRIPTION
For https://github.com/nextcloud/server/pull/35759

**Important note:** I've tried everything, but I really can't figure out why this new section wants to be **inside** the previous *note* admonition. Please test and try to fix it on your system before merging this one.