### PR TITLE
Use --option=value version for occ maintenance:install

### DIFF
--- a/admin_manual/installation/command_line_installation.rst
+++ b/admin_manual/installation/command_line_installation.rst
@@ -19,14 +19,15 @@ this example for Debian/Ubuntu. You must run ``occ`` as your HTTP user; see
 of running the graphical Installation Wizard::
 
  $ cd /var/www/nextcloud/
- $ sudo -u www-data php occ  maintenance:install --database \
- "mysql" --database-name "nextcloud"  --database-user "root" --database-pass \
- "password" --admin-user "admin" --admin-pass "password" 
+ $ sudo -u www-data php occ  maintenance:install \
+ --database='mysql' --database-name='nextcloud' \
+ --database-user='root' --database-pass='password' \
+ --admin-user='admin' --admin-pass='password'
  Nextcloud is not installed - only a limited number of commands are available
  Nextcloud was successfully installed
  
 Note that you must change to the root Nextcloud directory, as in the example 
-above, to run ``occ  maintenance:install``, or the installation will fail with 
+above, to run ``occ maintenance:install``, or the installation will fail with 
 a PHP fatal error message.
 
 Supported databases are::


### PR DESCRIPTION
The `--option=value` version of passing options to the `occ maintenance:install` command is now used in the documentation, instead of the `--option value` variant. This  solves issues with leading dashes in values, especially passwords. It also matches the `occ help maintenance:install` output.

Solves:
- https://github.com/nextcloud/server/issues/26109
- https://github.com/nextcloud/documentation/issues/8190

Furthermore values are now single quoted, which is important to avoid variable expansion and special treatment of the backlash character in random passwords, and a doubled space was removed.