### PR TITLE
feat(dev-manual): Document performance optimizations with class loaders

### DIFF
--- a/developer_manual/digging_deeper/classloader.rst
+++ b/developer_manual/digging_deeper/classloader.rst
@@ -10,7 +10,7 @@ The classloader is provided by Nextcloud and loads all your classes automaticall
 PSR-4 autoloading
 -----------------
 
-Nextcloud uses a PSR-4 autoloader. The namespace **\\OCA\\MyApp**
+Nextcloud uses a  :ref:`PSR-0 autoloader<psr4>`. The namespace **\\OCA\\MyApp**
 is mapped to :file:`/apps/myapp/lib/`. Afterwards normal PSR-4 rules apply, so
 a folder is a namespace section in the same casing and the class name matches
 the file name.
@@ -32,3 +32,26 @@ info.xml in the following way:
 
 A second PSR-4 root is available when running tests. **\\OCA\\MyApp\\Tests** is
 thereby mapped to :file:`/apps/myapp/tests/`.
+
+.. _app-custom-classloader:
+
+Replacing Nextcloud's autoloader
+--------------------------------
+
+Nextcloud's autoloader for apps is flexible and robust but not always the fastest. You can improve the loading speed of your app by shipping and optimizing a Composer class loader with the app.
+
+First of all, familiarize yourself with the `Composer autoloader optimization options <https://getcomposer.org/doc/articles/autoloader-optimization.md>`_ and how they work. (Authoritative) class maps are a good fit for Nextcloud apps.
+
+Once Composer is set up and class maps have been dumped, you can replace the generic Nextcloud class loader with the Composer class loader. This is done by placing a file at `composer/autoload.php`. If Nextcloud finds this file for an app, no generic class loader will be registered. The following contents will wire the file to Composer's generated ``autoloader.php`` file:
+
+.. code-block:: php
+  :caption: composer/autoload.php
+
+  <?php
+
+  declare(strict_types=1);
+
+  require_once __DIR__ . '/../vendor/autoload.php';
+
+
+.. note:: Make sure the auto loader is generated at release time and all files are included in the release tarball

--- a/developer_manual/digging_deeper/performance.rst
+++ b/developer_manual/digging_deeper/performance.rst
@@ -8,6 +8,11 @@ This document introduces some common considerations and tips on improving perfor
 
 .. note::**Tips welcome**: More tips and ideas on performance are very welcome!
 
+PHP Performance
+---------------
+
+* Autoloader: Consider using an :ref:`optimized class loader<app-custom-classloader>`. The application code does not have to change for this optimization.
+
 Database performance
 --------------------
 


### PR DESCRIPTION
This feature was added with https://github.com/nextcloud/server/pull/6853 a while ago for shipped apps in the server repo but has not gained much popularity. I assume it's because nobody knew or profiled the difference.

Thanks to Blackfire profiles I saw warnings that Composer still had to *find* hundreds of files, even if apps had an automated autoloader. My theory: Nextcloud registered its own loader before the app loader is there. So the app loader doesn't even get a chance. Effectively, app loader would only be used for app dependencies.

## Benchmarks

* https://github.com/nextcloud/calendar/pull/4912 showed that we can get from 795 to 101 Composer finds if I optimize the four Groupware apps.
* https://github.com/nextcloud/spreed/pull/8578 allowed me to fully get rid of the Blackfire warning.

As a positive side effect, replacing the server class loader not only disables the PSR-4 loader but also the PSR-0. We know that this gives a significant boost for Nextcloud processes: https://github.com/nextcloud/server/pull/36114 https://github.com/nextcloud/documentation/pull/9553.

## Preview

![Bildschirmfoto vom 2023-01-20 16-57-46](https://user-images.githubusercontent.com/1374172/213745124-5cac1c41-ed6d-4e26-8309-7410c6a2d002.png)
![Bildschirmfoto vom 2023-01-20 16-57-36](https://user-images.githubusercontent.com/1374172/213745130-551e1ad3-c05e-4bf3-b0c6-1eb5dc888184.png)
