### PR TITLE
Add removal of `OC.addTranslations` to NC26 upgrade guide

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_26.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_26.rst
@@ -28,7 +28,10 @@ If your app provides groupware-related settings, see if they make can be shown o
 Front-end changes
 -----------------
 
-tbd
+Removed APIs
+^^^^^^^^^^^^
+
+* :code:`OC.addTranslations` was deprecated since Nextcloud 17 and is now removed.
 
 Back-end changes
 ----------------


### PR DESCRIPTION
Belongs to server PR: https://github.com/nextcloud/server/pull/36287