### PR TITLE
fix(dev-manual): Update middleware docs to state of the art

### DIFF
--- a/developer_manual/basics/middlewares.rst
+++ b/developer_manual/basics/middlewares.rst
@@ -28,15 +28,54 @@ To generate your own middleware, simply inherit from the Middleware class and ov
       /**
        * this replaces "bad words" with "********" in the output
        */
-      public function beforeOutput($controller, $methodName, $output) {
+      public function beforeOutput($controller, $methodName, $output): string {
           return str_replace('bad words', '********', $output);
       }
 
   }
 
-The middleware can be registered in the :doc:`dependency_injection` and added using the **registerMiddleware** method:
+The middleware can be registered in the app's ``Application`` class:
 
 .. code-block:: php
+    :caption: lib/AppInfo/Application.php
+    :emphasize-lines: 20
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\AppInfo;
+
+    use OCA\MyApp\Middleware\CensorMiddleware;
+    use OCP\AppFramework\App;
+    use OCP\AppFramework\Bootstrap\IBootContext;
+    use OCP\AppFramework\Bootstrap\IBootstrap;
+    use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+    class Application extends App implements IBootstrap {
+
+        public function __construct() {
+            parent::__construct('myapp');
+        }
+
+        public function register(IRegistrationContext $context): void {
+            $context->registerMiddleware(CensorMiddleware::class);
+        }
+
+        public function boot(IBootContext $context): void {}
+
+    }
+
+Dependency Injection Container Registration
+-------------------------------------------
+
+.. deprecated:: 20
+
+Middlewares can also be added using the **registerMiddleware** method of the container:
+
+.. code-block:: php
+  :caption: lib/AppInfo/Application.php
+  :emphasize-lines: 14-17
 
   <?php
 
@@ -48,20 +87,10 @@ The middleware can be registered in the :doc:`dependency_injection` and added us
 
   class MyApp extends App {
 
-      /**
-       * Define your dependencies in here
-       */
       public function __construct(array $urlParams = []) {
           parent::__construct('myapp', $urlParams);
   
           $container = $this->getContainer();
-  
-          /**
-           * Middleware
-           */
-          $container->registerService(CensorMiddleware::class, function(IServerContainer $c): CensorMiddleware{
-              return new CensorMiddleware();
-          });
 
           // executed in the order that it is registered
           $container->registerMiddleware(CensorMiddleware::class);
@@ -100,47 +129,12 @@ Sometimes it is useful to conditionally execute code before or after a controlle
     /**
      * Add custom header if @MyHeader is used
      */
-    public function afterController($controller, $methodName, Response $response) {
+    public function afterController($controller, $methodName, Response $response): Response {
         if($this->reflector->hasAnnotation('MyHeader')) {
             $response->addHeader('My-Header', 3);
         }
         return $response;
     }
-  }
-
-Now adjust the container to inject the reflector:
-
-.. code-block:: php
-
-  <?php
-
-  namespace OCA\MyApp\AppInfo;
-
-  use OCP\AppFramework\App;
-  use OCP\IServerContainer;
-  use OCA\MyApp\Middleware\HeaderMiddleware;
-
-  class MyApp extends App {
-
-      /**
-       * Define your dependencies in here
-       */
-      public function __construct(array $urlParams=array()){
-          parent::__construct('myapp', $urlParams);
-  
-          $container = $this->getContainer();
-  
-          /**
-           * Middleware
-           */
-          $container->registerService(HeaderMiddleware::class, function(IServerContainer $c): HeaderMiddleware {
-              return new HeaderMiddleware($c->get('ControllerMethodReflector'));
-          });
-
-          // executed in the order that it is registered
-          $container->registerMiddleware(HeaderMiddleware::class);
-      }
-
   }
 
 .. note:: An annotation always starts with an uppercase letter


### PR DESCRIPTION
* Register with bootstrap
* Add return types in examples
* Drop obsolete manual DI wiring example

## Rendered

![Bildschirmfoto vom 2023-01-25 10-28-01](https://user-images.githubusercontent.com/1374172/214527859-aca21f48-1932-4189-91ed-08deccd013de.png)
