### PR TITLE
Added date format of PHP date function

### DIFF
--- a/admin_manual/configuration_server/logging_configuration.rst
+++ b/admin_manual/configuration_server/logging_configuration.rst
@@ -43,7 +43,7 @@ been configured by the **datadirectory** parameter in :file:`config/config.php`.
 
 The desired date format can optionally be defined using the **logdateformat** parameter in :file:`config/config.php`.
 By default the `PHP date function`_ parameter ``c`` is used, and therefore the
-date/time is written in the format ``2013-01-10T15:20:25+02:00``. By using the
+date/time is written in the format ``2013-01-10T15:20:25+02:00``. This format complies to RFC3339 without time zone and with numeric time zone offset. The respective GO time format is ``2006-01-02T15:04:05+0700``. By using the
 date format in the example below, the date/time format will be written in the format
 ``January 10, 2013 15:20:25``.
 


### PR DESCRIPTION
It is very helpfull to see, according to which format the timestamp in the logs is created.

E.g. for the input plugin "tail" of the program Telegraf it is essential to parse the time given in every log entry. To do so, a date format according to the "time" package of GO is required. 

Signed-off-by: grafjan <83698849+grafjan@users.noreply.github.com>