### PR TITLE
add link to desktop cleint doc for version 3.7

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,9 +259,16 @@
 								<h1>Nextcloud Desktop Client<a class="headerlink" href="#desktop" title="Permalink to this headline">¶</a></h1>
 								<p>Once you have a Nextcloud Server running, you can connect to it with various <a class="reference external" href="https://nextcloud.com/install/#install-clients">clients like our mobile and desktop client.</a>
 								Find documentation for the desktop client below.</p>
+                                                                <div class="section" id="desktop-37">
+                                                                        <h2>Desktop 3.7<a class="headerlink" href="#desktop-37" title="Permalink to this headline">¶</a></h2>
+                                                                        <p>This documents the <em>latest</em> version of the Nextcloud desktop client.</p>
+                                                                        <ul class="simple">
+                                                                                <li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.7">Manual</a>
+                                                                        </ul>
+                                                                </div>
 								<div class="section" id="desktop-36">
-									<h2>Desktop 3.6<a class="headerlink" href="#desktop-35" title="Permalink to this headline">¶</a></h2>
-									<p>This documents the <em>latest</em> version of the Nextcloud desktop client.</p>
+									<h2>Desktop 3.6<a class="headerlink" href="#desktop-36" title="Permalink to this headline">¶</a></h2>
+									<p>This documents the <em>previous</em> version of the Nextcloud desktop client.</p>
 									<ul class="simple">
 										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.6">Manual</a>
 									</ul>


### PR DESCRIPTION
clean a wrong anchor for desktop doc 3.6

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>