### PR TITLE
Add note about Group Folders

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -1109,7 +1109,7 @@ Trashbin
 ::
 
  trashbin
-  trashbin:cleanup  [--all-users] [--] [<user_id>...]  Remove deleted files
+  trashbin:cleanup  [--all-users] [--] [<user_id>...]  Permanently remove deleted files
   trashbin:restore  [--all-users] [--] [<user_id>...]  Restore deleted files
 
 .. note::
@@ -1119,7 +1119,7 @@ Trashbin
 The ``trashbin:cleanup  [--all-users] [--] [<user_id>...]`` command removes the deleted files of the specified
 users in a space-delimited list, or all users if --all-users is specified.
 
-This example removes the deleted files of all users::
+This example permanently removes the deleted files of all users::
 
   sudo -u www-data php occ trashbin:cleanup --all-users
   Remove all deleted files for all users
@@ -1130,7 +1130,7 @@ This example removes the deleted files of all users::
    rosa
    edward
 
-This example removes the deleted files of users molly and freda::
+This example permanently removes the deleted files of users molly and freda::
 
  sudo -u www-data php occ trashbin:cleanup molly freda
  Remove deleted files of   molly
@@ -1146,6 +1146,10 @@ This example restores the deleted files of all users::
 This example restores the deleted files of users molly and freda::
 
  sudo -u www-data php occ trashbin:restore molly freda
+ 
+.. note::
+  This command only restores Users deleted files.
+  If you're using Group Folders app, such files are not restored.
 
 .. _user_commands_label:
 


### PR DESCRIPTION
Using Group Folders, files are visible in the Users trash, but such files are not restored by this command.