### PR TITLE
traefik middleware k8s style

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -111,6 +111,19 @@ Using a TOML file:
       regex = "https://(.*)/.well-known/(?:card|cal)dav"
       replacement = "https://${1}/remote.php/dav"
 
+Using a CRD for kubernetes:
+::
+
+  apiVersion: traefik.containo.us/v1alpha1
+  kind: Middleware
+  metadata:
+    name: nextcloud-redirectregex
+  spec:
+    redirectRegex:
+      regex: "https://(.*)/.well-known/(card|cal)dav"
+      replacement: "https://${1}/remote.php/dav"
+      permanent: true
+
 HAProxy
 ^^^^^^^
 ::


### PR DESCRIPTION
For kubernetes instances where traefik is used as Ingress controller the following middleware syntax fixes the warning about caldav in the admin interface.

Basically yet another traefik2 syntax which can be copy pasted for people running kubernetes.