### PR TITLE
Document 32bits known limitations

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -41,6 +41,10 @@ CPU Architecture and OS
 ^^^^^^^^^^^^^^^^^^^^^^^
 A 64-bit CPU, OS and PHP is required for Nextcloud to run well.
 
+32-bit systems are supported, with the following known limitations:
+- Dates before Unix Epoch (1970-01-01) are not supported
+- Dates after 2038 are not supported
+
 Memory
 ^^^^^^
 


### PR DESCRIPTION
Dates before Epoch or after 2038 cannot be represented as an integer and
 throw when calling getTimestamp on the DateTime object.

Ref https://github.com/nextcloud/server/pull/36120