### PR TITLE
Explain preview_max_memory configuration parameter

### DIFF
--- a/admin_manual/configuration_files/previews_configuration.rst
+++ b/admin_manual/configuration_files/previews_configuration.rst
@@ -106,3 +106,16 @@ Default JPEG quality setting for preview images is '90'. Change this with:
 :: 
 
   occ config:app:set preview jpeg_quality --value="60"
+
+Maximum memory for image generation:
+^^^^^^^^^^^^^^^^^^^^^
+
+By default, image previews are generated with imagegd.
+If creating the image would allocate more memory than the limit, preview generation will
+be disabled and the default mimetype icon is shown.
+Default limit is 256 MB. Set to -1 for no limit.
+
+::
+
+  <?php
+    'preview_max_memory' => 256,


### PR DESCRIPTION
This adds a section to the documentation that explains the `preview_max_memory` parameter. Having the explanation in the documentation makes it easier to find the configuration option if one experiences that for certain images no preview is generated (see https://github.com/nextcloud/server/issues/31014).