### PR TITLE
Fix RST syntax in readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,9 +115,9 @@ Building HTML
 4. Install the dependencies ``pip install -r requirements.txt``
 5. Now you can use ``make ...`` to build all the stuff - for example ``make html`` to build the HTML flavor of all manuals
 
-To change into this environment you need to run `pipenv shell` to launch the shell and to exit you can use either ``exit`` or ``Ctrl`` + ``D``.
+To change into this environment you need to run ``pipenv shell`` to launch the shell and to exit you can use either ``exit`` or ``Ctrl`` + ``D``.
 
-When editing the documentation installing `sphinx-autobuild` though pip can be helpful. This will watch file changes and automatically reload the html preview:
+When editing the documentation installing ``sphinx-autobuild`` though pip can be helpful. This will watch file changes and automatically reload the html preview:
 
 1. Install ``pip install sphinx-autobuild``
 2. Enter the documentation section ``cd user_manual``

--- a/README.rst
+++ b/README.rst
@@ -109,30 +109,30 @@ Building
 Building HTML
 =============
 
-1. Install `pipenv` - https://pipenv.readthedocs.io/en/latest/
-2. Create a Python environment (typically inside this repository): `pipenv --python 3.9`
-3. Change into the environment: `pipenv shell`
-4. Install the dependencies `pip install -r requirements.txt`
-5. Now you can use `make ...` to build all the stuff - for example `make html` to build the HTML flavor of all manuals
+1. Install ``pipenv`` - https://pipenv.readthedocs.io/en/latest/
+2. Create a Python environment (typically inside this repository): ``pipenv --python 3.9``
+3. Change into the environment: ``pipenv shell``
+4. Install the dependencies ``pip install -r requirements.txt``
+5. Now you can use ``make ...`` to build all the stuff - for example ``make html`` to build the HTML flavor of all manuals
 
-To change into this environment you need to run `pipenv shell` to launch the shell and to exit you can use either `exit` or `Ctrl` + `D`.
+To change into this environment you need to run `pipenv shell` to launch the shell and to exit you can use either ``exit`` or ``Ctrl`` + ``D``.
 
 When editing the documentation installing `sphinx-autobuild` though pip can be helpful. This will watch file changes and automatically reload the html preview:
 
-1. Install `pip install sphinx-autobuild`
-2. Enter the documentation section `cd user_manual`
-3. Watch for file changes `make SPHINXBUILD=sphinx-autobuild html`
+1. Install ``pip install sphinx-autobuild``
+2. Enter the documentation section ``cd user_manual``
+3. Watch for file changes ``make SPHINXBUILD=sphinx-autobuild html``
 4. Open http://127.0.0.1:8000 in the browser and start editing
 
 Building PDF
 ============
 
 1. Follow instructions for "Building HTML" above
-2. Install `latexmk` and `texlive-latex-extra` - https://pipenv.readthedocs.io/en/latest/
-3. Create a Python environment (typically inside this repository): `pipenv --python 3.9`
-4. Change into the environment: `pipenv shell`
-5. Install the dependencies `pip install -r requirements.txt`
-6. Now you can use `make ...` to build all the stuff - for example `make pdf` to build the PDF flavor of all manuals
+2. Install ``latexmk`` and ``texlive-latex-extra`` - https://pipenv.readthedocs.io/en/latest/
+3. Create a Python environment (typically inside this repository): ``pipenv --python 3.9``
+4. Change into the environment: ``pipenv shell``
+5. Install the dependencies ``pip install -r requirements.txt``
+6. Now you can use ``make ...`` to build all the stuff - for example ``make pdf`` to build the PDF flavor of all manuals
 
 Using the VSCode DevContainer
 =============================


### PR DESCRIPTION
Before | After
---|---
https://github.com/nextcloud/documentation/tree/3bc39af017c00a0f7fa16c5c65253b6c8c804567#building | https://github.com/nextcloud/documentation/tree/nickvergessen-patch-1#building
![Bildschirmfoto vom 2023-03-08 11-26-32](https://user-images.githubusercontent.com/213943/223688665-48e78edc-5904-46fb-8fb4-784e0588db7a.png) | ![grafik](https://user-images.githubusercontent.com/213943/223688638-ecfd8b56-5cd2-454f-b1a5-5eadca33deb1.png)
