### PR TITLE
Fix a wrong „use“

### DIFF
--- a/developer_manual/digging_deeper/http_client.rst
+++ b/developer_manual/digging_deeper/http_client.rst
@@ -13,7 +13,7 @@ HTTP client instances are built using the client service `factory <https://en.wi
 
     <?php
 
-    use OCP\Http\IClientService;
+    use OCP\Http\Client\IClientService;
 
     class MyRemoteServerIntegration {
         private IClientService $clientService;


### PR DESCRIPTION
The namespace is another: https://github.com/nextcloud/server/blob/acca2bdf20a32a4e6113fbab03861aa6639163e8/lib/public/Http/Client/IClientService.php