### PR TITLE
Fixed `unexpected unindent` in `note`.

### DIFF
--- a/developer_manual/digging_deeper/continuous_integration.rst
+++ b/developer_manual/digging_deeper/continuous_integration.rst
@@ -99,9 +99,9 @@ Afterwards you'll be able to check the app with the following ``psalm.xml`` that
         </issueHandlers>
     </psalm>
 
-.. Note:: The definition suppresses usages of the global and static class ``OC`` like ``\OC::$server``, which is
-discouraged but still found in some apps. The doctrine suppression is currently necessary as the database mappers and
-schema abstractions leak some of the 3rd party libraries of Nextcloud that are not known to Psalm.
+.. note:: The definition suppresses usages of the global and static class ``OC`` like ``\OC::$server``, which is
+    discouraged but still found in some apps. The doctrine suppression is currently necessary as the database mappers
+    and schema abstractions leak some of the 3rd party libraries of Nextcloud that are not known to Psalm.
 
 
 You can put this process into a GitHub Action that is run for every pull request.


### PR DESCRIPTION
Fixed documentation/developer_manual/digging_deeper/continuous_integration.rst:103: WARNING: Explicit markup ends without a blank line; unexpected unindent.
