### PR TITLE
Fixed `unexpected unindent` in public_share_template.rst

### DIFF
--- a/developer_manual/basics/public_share_template.rst
+++ b/developer_manual/basics/public_share_template.rst
@@ -1,10 +1,10 @@
-=======
+=====================
 Public share template
-=======
+=====================
 
 .. sectionauthor:: Louis Chmn <louis@chmn.me>
 
-It is possible to overrite the default public share view. This is possible by implementing the ``IPublicShareTemplateProvider`` interface.
+It is possible to override the default public share view. This is possible by implementing the ``IPublicShareTemplateProvider`` interface.
 
 .. code-block:: php
 


### PR DESCRIPTION
`documentation/developer_manual/basics/public_share_template.rst:1: WARNING: Title overline too short.`