### PR TITLE
Dev Manual - 3 Unexpected indentations errors and 3 warnings.

### DIFF
--- a/developer_manual/app_development/intro.rst
+++ b/developer_manual/app_development/intro.rst
@@ -22,20 +22,19 @@ Alternatively, if you would like to contribute to an existing app instead of cre
     
 You can then configure Nextcloud to run apps from this directory, by changing your `app_paths` system config in your `config.php`
 
-    'apps_paths' => 
-    array (
-      0 => 
-      array (
-        'path' => '/var/www/html/apps',
-        'url' => '/apps',
-        'writable' => false,
-      ),
-      1 => 
-      array (
-        'path' => '/var/www/html/apps-extra',
-        'url' => '/apps-extra',
-        'writable' => false,
-      ),
+.. code-block:: php
+
+    'apps_paths' => array (
+        0 => array (
+            'path' => '/var/www/html/apps',
+            'url' => '/apps',
+            'writable' => false,
+        ),
+        1 => array (
+            'path' => '/var/www/html/apps-extra',
+            'url' => '/apps-extra',
+            'writable' => false,
+        ),
     ),
     
 Finally, clone the app to which you would like to contribute inside the `apps-extra` folder. For example:


### PR DESCRIPTION
```
developer_manual/app_development/intro.rst:27: ERROR: Unexpected indentation.
developer_manual/app_development/intro.rst:29: ERROR: Unexpected indentation.
developer_manual/app_development/intro.rst:32: WARNING: Block quote ends without a blank line; unexpected unindent.
developer_manual/app_development/intro.rst:35: ERROR: Unexpected indentation.
developer_manual/app_development/intro.rst:38: WARNING: Block quote ends without a blank line; unexpected unindent.
developer_manual/app_development/intro.rst:39: WARNING: Block quote ends without a blank line; unexpected unindent.

```

Before:
<img width="710" alt="image" src="https://user-images.githubusercontent.com/13381981/226864729-dfe4c46c-d496-48e7-8c7c-25126aee9e0b.png">

After:
![image](https://user-images.githubusercontent.com/13381981/226864778-32eefeb4-2ded-45a6-b1b4-7942369f9dac.png)
