### PR TITLE
Note PHP8.0 deprecation

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -30,7 +30,7 @@ For best performance, stability and functionality we have documented some recomm
 | Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |
 |                  | - nginx with ``php-fpm``                                              |
 +------------------+-----------------------------------------------------------------------+
-| PHP Runtime      | - 8.0                                                                 |
+| PHP Runtime      | - 8.0 (*deprecated*)                                                  |
 |                  | - **8.1** (*recommended*)                                             |
 |                  | - 8.2                                                                 |
 +------------------+-----------------------------------------------------------------------+

--- a/admin_manual/release_schedule.rst
+++ b/admin_manual/release_schedule.rst
@@ -19,7 +19,7 @@ Maintenance releases are scheduled in a 4 week cycle with one week before the re
 Critical changes
 ----------------
 
-* PHP 7.4 is not supported anymore. Please upgrade to PHP 8.0 or higher.
+* PHP 8.0 is now deprecated. Please upgrade to PHP 8.1 or higher.
 * PHP 8.2 is now supported.
 * The recommended webserver configuration has changed to no longer include a default redirect to the login page
     * For Apache this change will automatically come with the ``.htaccess`` file provided by the release


### PR DESCRIPTION
PHP8.0 is now deprecated in Nextcloud 27.

Resolves: #9964 
Ref : https://github.com/nextcloud/server/pull/37451