### PR TITLE
fix(deps): Limit sphinx version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=4.5.0, <5.0
 rst2pdf
 pillow
 sphinx-rtd-theme==1.2.0


### PR DESCRIPTION
Prevents installing an outdated version that breaks on Python 3.10 due to https://github.com/sphinx-doc/sphinx/issues/9562