### PR TITLE
fix default_language doc

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -238,13 +238,14 @@ values, where present, are shown.
 
 This sets the default language on your Nextcloud server, using ISO_639-1
 language codes such as ``en`` for English, ``de`` for German, and ``fr`` for
-French. It overrides automatic language detection on public pages like login
-or shared items. User's language preferences configured under "personal ->
-language" override this setting after they have logged in. Nextcloud has two
-distinguished language codes for German, 'de' and 'de_DE'. 'de' is used for
-informal German and 'de_DE' for formal German. By setting this value to 'de_DE'
-you can enforce the formal version of German unless the user has chosen
-something different explicitly.
+French. The default_language parameter is only used, when the browser does
+not send any language, and the user hasn’t configured own language
+preferences.
+
+Nextcloud has two distinguished language codes for German, 'de' and 'de_DE'.
+'de' is used for informal German and 'de_DE' for formal German. By setting
+this value to 'de_DE' you can enforce the formal version of German unless
+the user has chosen something different explicitly.
 
 Defaults to ``en``
 


### PR DESCRIPTION
This aligns with the server commit https://github.com/nextcloud/server/pull/37486/commits/ddc423ab39c2d522516417798422a5aae9e0f5e6
