### PR TITLE
feat(devmanual): Add go.php shortcut for the backports doc

### DIFF
--- a/go.php
+++ b/go.php
@@ -45,6 +45,7 @@ $mapping = array(
     'admin-warnings'          => '/admin_manual/configuration_server/security_setup_warnings.html',
     'admin-workflowengine'    => '/admin_manual/file_workflows/index.html',
 
+    'developer-backports'     => '/developer_manual/getting_started/development_process.html#bugfixes',
     'developer-code-integrity'=> '/developer_manual/app/code_signing.html',
     'developer-manual'        => '/developer_manual',
     'developer-theming'       => '/developer_manual/core/theming.html',


### PR DESCRIPTION
This will allow the URL https://docs.nextcloud.com/server/stable/go.php?to=developer-backports