### PR TITLE
Add new OCS API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ _build
 developer_manual/html_css_design/img
 developer_manual/html_css_design/icons.txt
 
+# OpenAPI file
+developer_manual/_static/openapi.json
+developer_manual/_static/stoplight-elements.js
+developer_manual/_static/stoplight-elements.css
+
 # Exclude Eclipse project
 .project
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build/openapi-extractor"]
+	path = build/openapi-extractor
+	url = https://github.com/nextcloud/openapi-extractor

--- a/developer_manual/_static/openapi.html
+++ b/developer_manual/_static/openapi.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+        <title>OCS API</title>
+        <script src="stoplight-elements.js"></script>
+        <link rel="stylesheet" href="stoplight-elements.css">
+    </head>
+    <body>
+        <elements-api apiDescriptionUrl="openapi.json" router="hash" hideTryIt="true" logo="logo-blue.png"></elements-api>
+    </body>
+</html>

--- a/developer_manual/client_apis/OCS/index.rst
+++ b/developer_manual/client_apis/OCS/index.rst
@@ -4,6 +4,10 @@
 OCS API
 ===============================
 
+To browse the new OCS API documentation please go `here <../../_static/openapi.html>`_.
+
+The old documentation is still kept as it provides some additional documentation that is not completely covered in the new documentation:
+
 .. toctree::
 
    ocs-api-overview

--- a/developer_manual/conf.py
+++ b/developer_manual/conf.py
@@ -126,7 +126,7 @@ html_short_title = "Developer Manual"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['../_shared_assets/static']
+html_static_path = ['../_shared_assets/static', '_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
I wanted to link to the static file directly from the TOC, but it's not possible :/
Please don't merge yet, as the spec itself is not finalized.