### PR TITLE
Fixes migrations:execute description in migrations.rst.

### DIFF
--- a/developer_manual/basics/storage/migrations.rst
+++ b/developer_manual/basics/storage/migrations.rst
@@ -155,8 +155,8 @@ with migrations, which are only available if you are running your
 Nextcloud **in debug mode**:
 
 * `migrations:execute`: Executes a single migration version manually.
-  The version argument is the class name of the migration, while the 
-  postfix "Version" is skipped. For example if your migration was named
+  The version argument is the class name of the migration, without the 
+  "Version" prefix. For example if your migration was named
   `Version2404Date20220903071748` the version would be `2404Date20220903071748`.
 * `migrations:generate`:
   This is needed to create a new migration file. This takes 2 arguments,


### PR DESCRIPTION
"Version" is the "prefix" of the class name, not the "postfix".