### PR TITLE
Fix an error in sync_android documentation

### DIFF
--- a/user_manual/groupware/sync_android.rst
+++ b/user_manual/groupware/sync_android.rst
@@ -59,9 +59,8 @@ steps are required:
    `F-Droid <https://f-droid.org/packages/org.dmfs.tasks/>`__).
 3. Create a new account ("+" button).
 4. Select **Connection with URL and username**.
-   **Base URL:** URL of your Nextcloud instance (e.g. ``https://sub.example.com/remote.php/dav``) and 
-   **Contact Group Method:** as credentials.
-5. Choose the option ``Groups are per-contact categories``.
+   **Base URL:** URL of your Nextcloud instance (e.g. ``https://sub.example.com/remote.php/dav``) and your credentials.
+5. For the **Contact Group Method:** choose the option ``Groups are per-contact categories``.
 6. Click **Connect**.
 7. Select the data you want to sync.
 8. When requested, grant access permissions to DAVx⁵ for your


### PR DESCRIPTION
It could be updated more to match the current copywriting of DAVx5, but this fixes a confusing outright mistake.

| Before | After |
|--------|--------|
| ![Screenshot from 2023-08-03 21-31-53](https://github.com/nextcloud/documentation/assets/3902676/988bb915-421b-4ac0-b7f4-978a5ac49312) | ![Screenshot from 2023-08-03 21-31-02](https://github.com/nextcloud/documentation/assets/3902676/3678abe9-fca5-4553-9b4e-da5769eef43d) | 


