### PR TITLE
fix webdav fstab entry

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -160,8 +160,7 @@ automatically every time you log in to your Linux computer.
 
 7. Add the mount information to ``/etc/fstab``::
 
-    https://example.com/nextcloud/remote.php/dav/files/USERNAME/ /home/<linux_username>/nextcloud
-    davfs user,rw,auto 0 0
+    https://example.com/nextcloud/remote.php/dav/files/USERNAME/ /home/<linux_username>/nextcloud davfs user,rw,auto 0 0
 
 
 8. Then test that it mounts and authenticates by running the following


### PR DESCRIPTION
The fstab entry of the command-line webdav mount is split in 2 lines, but needs to be a one liner to be mounted correctly.
I followed all the steps to mount Nextcloud as webdav on my Raspberry Pi 1 model B with Raspbian OS Lite but only with a one liner it mounted correctly.
