### PR TITLE
feat(devmanual): Start 27 upgrade docs

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
@@ -9,6 +9,7 @@ These sub pages will cover the most important changes in Nextcloud, as well as s
 .. toctree::
    :maxdepth: 1
 
+   upgrade_to_27.rst
    upgrade_to_26.rst
    upgrade_to_25.rst
    upgrade_to_24.rst

--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_27.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_27.rst
@@ -1,0 +1,51 @@
+=======================
+Upgrade to Nextcloud 27
+=======================
+
+.. note:: Critical changes were collected `on GitHub <https://github.com/nextcloud/server/issues/37039>`_.
+    See the original ticket for links to the pull requests and tickets.
+
+General
+-------
+
+info.xml
+^^^^^^^^
+
+Make sure your ``appinfo/info.xml`` allows for Nextcloud 27.
+
+.. code-block:: xml
+
+    <dependencies>
+        <nextcloud min-version="23" max-version="27" />
+    </dependencies>
+
+Front-end changes
+-----------------
+
+Removed APIs
+^^^^^^^^^^^^
+
+* tbd
+
+Back-end changes
+----------------
+
+Added APIs
+^^^^^^^^^^
+
+* tbd
+
+Changed APIs
+^^^^^^^^^^^^
+
+* tbd
+
+Deprecated APIs
+^^^^^^^^^^^^^^^
+
+* tbd
+
+Removed APIs
+^^^^^^^^^^^^
+
+* tbd


### PR DESCRIPTION
Continuation of https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_26.html

## 🖼️ Screenshots

![Screenshot 2023-04-19 at 16-36-04 Upgrade to Nextcloud 27 — Nextcloud latest Developer Manual latest documentation](https://user-images.githubusercontent.com/1374172/233109662-59131d37-819f-479f-8e98-4212e5664e0e.png)

