### PR TITLE
ci(transifex): increase waiting time between mergen retries

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -15,6 +15,7 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     name: Auto-merge
+    needs: approve
     steps:
       - uses: pascalgn/automerge-action@v0.15.6
         if: github.actor == 'transifex-integration[bot]'
@@ -22,4 +23,4 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: ""
           MERGE_RETRIES: 10
-          MERGE_RETRY_SLEEP: 60000
+          MERGE_RETRY_SLEEP: 120000


### PR DESCRIPTION
From time to time transifex pull requests are piling up.

I assume we are low on runners because transifex creates a lot of pull requests within a short timeframe.

1) Set a dependency for approve
2) Increase the timeout to 120 seconds

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
