### PR TITLE
Allow "wasm-unsafe-eval" in CSP

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
@@ -124,6 +124,10 @@ Added APIs
 * ``\OCP\Preview\BeforePreviewFetchedEvent::getWidth``
 * ``\OCP\IPhoneNumberUtil::convertToStandardFormat`` to convert input into an E164 formatted phone number. See :ref:`phonenumberutil` for an example.
 * ``\OCP\IPhoneNumberUtil::getCountryCodeForRegion`` to get the E164 country code for a given region. See :ref:`phonenumberutil` for an example.
+* ``\OCP\AppFramework\Http\EmptyContentSecurityPolicy::allowEvalWasm(bool)``: sets ``wasm-unsafe-eval`` in ``script-src`` of the Content Security Policy `to allow compilation and execution of WebAssembly on the page <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution>`_
+
+  * ``wasm-unsafe-eval`` is `supported by most browsers <https://caniuse.com/mdn-http_headers_content-security-policy_script-src_wasm-unsafe-eval>`_
+  * WebAssembly compilation and execution in worker threads is not affected by this directive (browsers allow compilation and execution of WebAssembly in worker threads by default)
 
 Changed APIs
 ^^^^^^^^^^^^


### PR DESCRIPTION
Documentation for https://github.com/nextcloud/server/pull/38082

### 🖼️ Screenshots

![Documentation-Wasm-Unsafe-Eval](https://user-images.githubusercontent.com/26858233/236315778-1bfff0e8-14bd-4463-9329-78ca1a96c6bb.png)
