### PR TITLE
fix(deps): Downgrade pillow to <9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sphinx>=4.5.0, <5.0
 rst2pdf
-pillow
+pillow<9.0
 sphinx-rtd-theme==1.2.0
 sphinxcontrib-phpdomain
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/documentation/issues/10272

Went through all direct dependencies and forced a downgrade. Pillow downgrade was the one the allowed me to build again. I don't know why.