### PR TITLE
ci(sphinxbuild): drop custom action and build directly

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -12,11 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "user_manual/"
-        pre-build-command: pip install -r requirements.txt
-        build-command: make html
+    - name: Install pip dependencies
+      run: pip install -r requirements.txt
+    - name: Build using Makefile
+      run: cd user_manual && make html
     - name: Pack  the results in local tar file
       shell: bash
       run: tar czf /tmp/documentation.tar.gz -C user_manual/_build/html .
@@ -30,21 +29,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "user_manual/"
-        pre-build-command: pip install -r requirements.txt
-        build-command: make html-lang-en
+    - name: Install pip dependencies
+      run: pip install -r requirements.txt
+    - name: Build using Makefile
+      run: cd user_manual && make html-lang-en
 
   developer_manual:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "developer_manual/"
-        pre-build-command: pip install -r requirements.txt
-        build-command: make html
+    - name: Install pip dependencies
+      run: pip install -r requirements.txt
+    - name: Build using Makefile
+      run: cd developer_manual && make html
     - name: Pack the results in local tar file
       shell: bash
       run: tar czf /tmp/documentation.tar.gz -C developer_manual/_build/html/com .
@@ -58,11 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "admin_manual/"
-        pre-build-command: pip install -r requirements.txt
-        build-command: make html
+    - name: Install pip dependencies
+      run: pip install -r requirements.txt
+    - name: Build using Makefile
+      run: cd admin_manual && make html
     - name: Pack the results in local tar file
       shell: bash
       run: tar czf /tmp/documentation.tar.gz -C admin_manual/_build/html/com .


### PR DESCRIPTION
The action we use to build the documentation is outdated (last commit over a year ago). We use the Makefile to build it anyway so we can just run it directly on the runner.

This will also fix possible issues we'll run into once a dependency requires to build a wheel (e.g. pycairo). Many required dev depedencies like gcc, pkg-config and cairo are already installed on the runners by default.