### PR TITLE
chore(deps): Disable Dependabot for stable branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,31 +13,3 @@ updates:
       time: "06:00"
     target-branch: master
     open-pull-requests-limit: 10
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      time: "06:00"
-    target-branch: stable26
-    open-pull-requests-limit: 10
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      time: "06:00"
-    target-branch: stable25
-    open-pull-requests-limit: 10
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      time: "06:00"
-    target-branch: stable24
-    open-pull-requests-limit: 10
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      time: "06:00"
-    target-branch: stable23
-    open-pull-requests-limit: 10


### PR DESCRIPTION
### ☑️ Resolves

* 133 open PRs that nobody reviews

Ref https://github.com/nextcloud/documentation/pull/10283#discussion_r1185819721