### PR TITLE
chore(github): Define code owners for Groupware docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+/*/groupware/                                               @ChristophWurst
+/*/groupware/calendar.rst                                   @miaulalala
+/*/groupware/contacts.rst                                   @hamza221
+/*/groupware/mail.rst                                       @GretaD
+/developer_manual/digging_deeper/groupware/                 @ChristophWurst
+/developer_manual/digging_deeper/groupware/calendar.rst     @miaulalala


### PR DESCRIPTION
### ☑️ Resolves

* Fix open PRs that do not receive a review in reasonable time

With this declaration we will be pinged for reviews whenever groupware pages are touched :) 
