### PR TITLE
Remove doc links for Nextcloud 9-11 because they don't exist nor build

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,20 +324,6 @@
 										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.2">Manual</a>
 									</ul>
 								</div>
-								<div class="section" id="desktop-31">
-									<h2>Desktop 3.1<a class="headerlink" href="#desktop-31" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.2">Manual</a>
-									</ul>
-								</div>
-								<div class="section" id="desktop-30">
-									<h2>Desktop 3.0<a class="headerlink" href="#desktop-30" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.0">Manual</a>
-									</ul>
-								</div>
 							</div>
 
 							<div class="section" id="nextcloud-older">

--- a/index.html
+++ b/index.html
@@ -480,42 +480,6 @@
 											(<a class="reference external" href="https://docs.nextcloud.com/server/12/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
 									</ul>
 								</div>
-
-								<div class="section" id="nextcloud-11">
-									<h2>Nextcloud 11<a class="headerlink" href="#nextcloud-11" title="Permalink to this headline">¶</a></h2>
-									<ul class="simple">
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/11/user_manual/">User Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/11/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/11/admin_manual/">Administration Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/11/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/11/developer_manual/">Developer Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/11/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
-									</ul>
-								</div>
-
-								<div class="section" id="nextcloud-10">
-									<h2>Nextcloud 10<a class="headerlink" href="#nextcloud-10" title="Permalink to this headline">¶</a></h2>
-									<ul class="simple">
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/10/user_manual/">User Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/10/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/10/admin_manual/">Administration Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/10/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/10/developer_manual/">Developer Manual</a>
-									(<a class="reference external" href="https://docs.nextcloud.com/server/10/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
-									</ul>
-								</div>
-
-								<div class="section" id="nextcloud-9">
-									<h2>Nextcloud 9<a class="headerlink" href="#nextcloud-9" title="Permalink to this headline">¶</a></h2>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/server/9/user_manual/">User Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/9/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
-										<li><a class="reference external" href="https://docs.nextcloud.com/server/9/admin_manual/">Administration Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/9/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-										<li><a class="reference external" href="https://docs.nextcloud.com/server/9/developer_manual/">Developer Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/9/NextcloudDeveloperManual.pdf">Download PDF</a>)</li>
-									</ul>
-								</div>
 							</div>
 						</div><!-- server -->
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix dead links on docs.nextcloud.com frontpage