### PR TITLE
fix: occ encryption:decrypt-all handles maintenance mode and disables…

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -262,17 +262,19 @@ Disabling encryption
 --------------------
 
 You may disable encryption only with ``occ``. Make sure you have backups of all 
-encryption keys, including users'. Put your Nextcloud server into 
-maintenance mode, and then disable your encryption module with these commands::
+encryption keys, including users'.
+Disable your encryption module with this command::
 
- occ maintenance:mode --on
- occ encryption:disable
  occ encryption:decrypt-all
 
-Take it out of maintenance mode when you are finished::
+It will put your server into maintenance mode and back.
+It also takes care of disabling encryption when all files have been decrypted.
+If the command is aborted some files have been decrypted and others are still encrypted.
+In this case the command will keep the encryption turned on
+and Nextcloud can handle this situation fine.
+You can proceed decrypting the remaining files by calling the command again
+once the problems that caused the abortion have been resolved.
 
- occ maintenance:mode --off
- 
 .. warning:: Disabling encryption without decrypting all the files will lead to decryption errors in the future as this state causes unpredictable behaviors.
 .. note:: The ``occ encryption:decrypt-all`` can take a lot of time. You can run one user at a time like so: ``occ encryption:decrypt-all <user-id>``.
 


### PR DESCRIPTION
… encryption

When the command is started in maintenance mode it will even err out. Also one should not disable encryption without decrypting all files first.
