### PR TITLE
Removed the duplicate extension "js" warning from the NGINX configuration

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -84,7 +84,7 @@ server {
     # only for Nextcloud like below:
     include mime.types;
     types {
-        text/javascript js mjs;
+        text/javascript mjs;
 	application/wasm wasm;
     }
 

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -45,7 +45,7 @@ server {
     # only for Nextcloud like below:
     include mime.types;
     types {
-        text/javascript js mjs;
+        text/javascript mjs;
 	application/wasm wasm;
     }
 


### PR DESCRIPTION
The current NGINX configuration triggers the following warning

```
nginx: [warn] duplicate extension "js", content type: "text/javascript", previous content type: "application/javascript" in /etc/nginx/sites-enabled/www.example.com.conf:124
```
