### PR TITLE
fix(adminmanual): Recommend basic auth over NTLM for Exchange

### DIFF
--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -42,7 +42,7 @@ connect Nextcloud to a remote SMTP server:
 .. warning:: There were changes to the 3rd party mailer library in Nextcloud 26:
     
     * STARTTLS cannot be enforced. It will be used automatically if the mail server supports it. The encryption type should be set to 'None/STARTTLS' in this case. See :ref:`here<TLSPeerVerification>` for an example on how to configure self signed certificates.
-    * NTLM authentication for Microsoft Exchange is not supported by the new mailer library
+    * NTLM authentication for Microsoft Exchange is not supported by the new mailer library. Try using `basic authentication <https://learn.microsoft.com/en-us/exchange/client-developer/exchange-web-services/authentication-and-ews-in-exchange#basic-authentication>`_ instead.
 
 * Encryption type: None/STARTTLS or SSL
 


### PR DESCRIPTION
### ☑️ Resolves

Follow-up to https://github.com/nextcloud/documentation/pull/10452

### 🖼️ Screenshots

![Bildschirmfoto vom 2023-05-26 12-43-36](https://github.com/nextcloud/documentation/assets/1374172/d7dc6352-c954-41ad-af7b-1768d36dd9f7)
