### PR TITLE
feat(adminmanual): Create critical changes section for admins

### DIFF
--- a/admin_manual/maintenance/manual_upgrade.rst
+++ b/admin_manual/maintenance/manual_upgrade.rst
@@ -2,6 +2,10 @@
 Upgrade manually
 ================
 
+.. seealso::
+
+   If you upgrade from a previous major version please see :ref:`critical changes<critical-changes>` first.
+
 Always start by making a fresh backup and disabling all 3rd party apps.
 
 1. Back up your existing Nextcloud Server database, data directory, and 

--- a/admin_manual/maintenance/package_upgrade.rst
+++ b/admin_manual/maintenance/package_upgrade.rst
@@ -58,6 +58,10 @@ using Snappy Base 16.04 as it's currently unreleased.
 Upgrade tips
 ------------
 
+.. seealso::
+
+   If you upgrade from a previous major version please see :ref:`critical changes<critical-changes>` first.
+
 Upgrading Nextcloud from a Snap is just like upgrading any snap package.
 For example:
 
@@ -85,6 +89,10 @@ This example is for CentOS/RHEL/Fedora::
    
 Upgrading across skipped releases
 ---------------------------------
+
+.. seealso::
+
+   If you upgrade from a previous major version please see :ref:`critical changes<critical-changes>` first.
 
 It is best to update your Nextcloud installation with every new point release, 
 and to never skip any major releases. While this requirement is being worked on, 

--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -58,6 +58,10 @@ based updater but on the command line.
 Prerequisites
 -------------
 
+.. seealso::
+
+   If you upgrade from a previous major version please see :ref:`critical changes<critical-changes>` first.
+
 You should always maintain :doc:`regular backups <backup>` and make a fresh
 backup before every upgrade.
 

--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -2,4 +2,24 @@
 Release notes
 =============
 
-See `the official changelog <https://nextcloud.com/changelog/>`_ for release notes.
+.. _critical-changes:
+
+Critical changes
+----------------
+
+Here you find all important infos about the new release before you upgrade.
+
+System requirements
+^^^^^^^^^^^^^^^^^^^
+
+* PHP8.2 is recommended over PHP8.1.
+
+Exposed system address book
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Nextcloud 27 exposes the :ref:`system address book<system-address-book>`. Restrict the enumeration settings if your users should not see other users.
+
+Changelog
+---------
+
+See `the official changelog <https://nextcloud.com/changelog/>`_ for a complete list of changes.

--- a/admin_manual/release_notes/index.rst
+++ b/admin_manual/release_notes/index.rst
@@ -4,6 +4,9 @@ Release notes
 
 .. _critical-changes:
 
+Critical changes
+----------------
+
 Once you've installed and configured your server, you will want to keep it up to date with the latest Nextcloud features.
 
 These sub pages will cover the most important changes in Nextcloud, as well as some guides on how to upgrade existing installations.
@@ -12,3 +15,8 @@ These sub pages will cover the most important changes in Nextcloud, as well as s
    :maxdepth: 1
 
    upgrade_to_27.rst
+
+Changelog
+---------
+
+See `the official changelog <https://nextcloud.com/changelog/>`_ for a complete list of changes.

--- a/admin_manual/release_notes/upgrade_to_27.rst
+++ b/admin_manual/release_notes/upgrade_to_27.rst
@@ -3,16 +3,11 @@ Upgrade to Nextcloud 27
 =======================
 
 System requirements
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 * PHP8.2 is recommended over PHP8.1.
 
 Exposed system address book
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Nextcloud 27 exposes the :ref:`system address book<system-address-book>`. Restrict the enumeration settings if your users should not see other users.
-
-Changelog
----------
-
-See `the official changelog <https://nextcloud.com/changelog/>`_ for a complete list of changes.

--- a/admin_manual/release_schedule.rst
+++ b/admin_manual/release_schedule.rst
@@ -15,18 +15,3 @@ Maintenance releases
 --------------------
 
 Maintenance releases are scheduled in a 4 week cycle with one week before the release date having the freeze and RC 1.
-
-Critical changes
-----------------
-
-* PHP 8.0 is now deprecated. Please upgrade to PHP 8.1 or higher.
-* PHP 8.2 is now supported.
-* The recommended webserver configuration has changed to no longer include a default redirect to the login page
-    * For Apache this change will automatically come with the ``.htaccess`` file provided by the release
-    * for nginx administrators should ensure that their config is up to date with the `documentation <https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html>`_
-        * The relevant lines to remove are ``error_page 403 /core/templates/403.php;`` and ``error_page 404 /core/templates/404.php;``
-
-You can find important documentation for app developers here: https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.html
-Each document lists a link to the breaking changes of the corresponding release.
-
-.. TODO ON RELEASE: Update version number above on release


### PR DESCRIPTION
* Moves critical changes from *Release schedule* to *Release notes*
* Update all update pages to link to the changes for admins to see before the upgrade

This is the state for 27. We'll need to write the critical changes for 28 still.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1374172/d7676968-d913-4ec5-ac57-7928be6fa295)

