### PR TITLE
[SubPR for #10468] chore(release_notes): Use subpages per release

### DIFF
--- a/admin_manual/contents.rst
+++ b/admin_manual/contents.rst
@@ -6,7 +6,7 @@ Table of contents
     :maxdepth: 2
 
     index
-    release_notes
+    release_notes/index
     release_schedule
     installation/index
     configuration_server/index

--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -2,24 +2,4 @@
 Release notes
 =============
 
-.. _critical-changes:
-
-Critical changes
-----------------
-
-Here you find all important infos about the new release before you upgrade.
-
-System requirements
-^^^^^^^^^^^^^^^^^^^
-
-* PHP8.2 is recommended over PHP8.1.
-
-Exposed system address book
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Nextcloud 27 exposes the :ref:`system address book<system-address-book>`. Restrict the enumeration settings if your users should not see other users.
-
-Changelog
----------
-
-See `the official changelog <https://nextcloud.com/changelog/>`_ for a complete list of changes.
+The release notes have been split into :ref:`subpages per Nextcloud release<critical-changes>`.

--- a/admin_manual/release_notes/index.rst
+++ b/admin_manual/release_notes/index.rst
@@ -1,0 +1,14 @@
+=============
+Release notes
+=============
+
+.. _critical-changes:
+
+Once you've installed and configured your server, you will want to keep it up to date with the latest Nextcloud features.
+
+These sub pages will cover the most important changes in Nextcloud, as well as some guides on how to upgrade existing installations.
+
+.. toctree::
+   :maxdepth: 1
+
+   upgrade_to_27.rst

--- a/admin_manual/release_notes/upgrade_to_27.rst
+++ b/admin_manual/release_notes/upgrade_to_27.rst
@@ -1,0 +1,18 @@
+=======================
+Upgrade to Nextcloud 27
+=======================
+
+System requirements
+^^^^^^^^^^^^^^^^^^^
+
+* PHP8.2 is recommended over PHP8.1.
+
+Exposed system address book
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Nextcloud 27 exposes the :ref:`system address book<system-address-book>`. Restrict the enumeration settings if your users should not see other users.
+
+Changelog
+---------
+
+See `the official changelog <https://nextcloud.com/changelog/>`_ for a complete list of changes.


### PR DESCRIPTION
Follow up to #10468 

## Deprecated: release_notes.html
![Bildschirmfoto vom 2023-05-26 14-50-15](https://github.com/nextcloud/documentation/assets/213943/5a6aaaf2-a1e7-4568-937b-1e70d08ee21a)

## New release notes list: release_notes/index.html
![Bildschirmfoto vom 2023-05-26 14-51-32](https://github.com/nextcloud/documentation/assets/213943/fde1f2a7-2e6a-4963-93bf-459f80ccfbe1)

