### PR TITLE
feat(adminmanual): PHP8.0 deprecation in Nextcloud 27

### DIFF
--- a/admin_manual/release_notes/upgrade_to_27.rst
+++ b/admin_manual/release_notes/upgrade_to_27.rst
@@ -6,6 +6,7 @@ System requirements
 -------------------
 
 * PHP8.2 is recommended over PHP8.1.
+* PHP8.0 is deprecated and will be removed in Nextcloud 28.
 
 Exposed system address book
 ---------------------------


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/issues/36437

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1374172/dabae4dc-bd3f-439f-925e-33b4ec6f2282)
