### PR TITLE
fix(developer): Move removed backend API to the backend section

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
@@ -37,8 +37,7 @@ Deprecated APIs
 Removed APIs
 ^^^^^^^^^^^^
 
-* ``\OC_App::isEnabled``: inject ``\OCP\App\IAppManager`` and call ``\OCP\App\IAppManager::isEnabledForUser``.
-* ``\OC_Defaults::getLogoClaim``: There is no replacement.
+* tbd
 
 Back-end changes
 ----------------
@@ -61,4 +60,5 @@ Deprecated APIs
 Removed APIs
 ^^^^^^^^^^^^
 
-* tbd
+* ``\OC_App::isEnabled``: inject ``\OCP\App\IAppManager`` and call ``\OCP\App\IAppManager::isEnabledForUser``.
+* ``\OC_Defaults::getLogoClaim``: There is no replacement.


### PR DESCRIPTION
Those changes are removals of backend API and belong to the backend section, not the front end section.