### PR TITLE
Add the required OCS-APIRequest header to User Provisioning API examples

### DIFF
--- a/admin_manual/configuration_user/instruction_set_for_apps.rst
+++ b/admin_manual/configuration_user/instruction_set_for_apps.rst
@@ -23,7 +23,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/apps?filter=enabled
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/apps?filter=enabled -H "OCS-APIRequest: true"
 
 * Gets enabled apps
 
@@ -64,7 +64,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/apps/files
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/apps/files -H "OCS-APIRequest: true"
 
 * Get app info for the ``files`` app
 
@@ -121,7 +121,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/apps/files_texteditor
+  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/apps/files_texteditor -H "OCS-APIRequest: true"
 
 * Enable the ``files_texteditor`` app
 
@@ -157,7 +157,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/apps/files_texteditor
+  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/apps/files_texteditor -H "OCS-APIRequest: true"
 
 * Disable the ``files_texteditor`` app
 

--- a/admin_manual/configuration_user/instruction_set_for_groups.rst
+++ b/admin_manual/configuration_user/instruction_set_for_groups.rst
@@ -23,7 +23,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/groups?search=adm
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/groups?search=adm -H "OCS-APIRequest: true"
 
 * Returns list of groups matching the search string.
 
@@ -67,7 +67,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/groups -d groupid="newgroup"
+  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/groups -d groupid="newgroup" -H "OCS-APIRequest: true"
 
 * Adds a new group called ``newgroup``
 
@@ -103,7 +103,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/groups/admin
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/groups/admin -H "OCS-APIRequest: true"
 
 * Returns a list of users in the ``admin`` group
 
@@ -145,7 +145,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X GET https://admin:secret@example.com/ocs/v1.php/cloud/groups/mygroup/subadmins
+  $ curl -X GET https://admin:secret@example.com/ocs/v1.php/cloud/groups/mygroup/subadmins -H "OCS-APIRequest: true"
 
 * Return the subadmins of the group: ``mygroup``
 
@@ -191,7 +191,7 @@ Examples
 
 ::
 
-  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/groups/mygroup -d key="displayname" -d value="My Group Name"
+  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/groups/mygroup -d key="displayname" -d value="My Group Name" -H "OCS-APIRequest: true"
 
 * Updates the display name for the group ``mygroup``
 
@@ -229,7 +229,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/groups/mygroup
+  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/groups/mygroup -H "OCS-APIRequest: true"
 
 * Delete the group ``mygroup``
 

--- a/admin_manual/configuration_user/instruction_set_for_users.rst
+++ b/admin_manual/configuration_user/instruction_set_for_users.rst
@@ -37,7 +37,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users -d userid="Frank" -d password="frankspassword"
+  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users -d userid="Frank" -d password="frankspassword" -H "OCS-APIRequest: true"
 
 * Creates the user ``Frank`` with password ``frankspassword``
 * optionally groups can be specified by one or more ``groups[]`` query parameters:
@@ -79,7 +79,7 @@ Example
 ^^^^^^^
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/users?search=Frank
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/users?search=Frank -H "OCS-APIRequest: true"
 
 * Returns list of users matching the search string.
 
@@ -120,7 +120,7 @@ Example
 
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank -H "OCS-APIRequest: true"
 
 * Returns information on the user ``Frank``
 
@@ -189,13 +189,13 @@ Examples
 
 ::
 
-  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank -d key="email" -d value="franksnewemail@example.org"
+  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank -d key="email" -d value="franksnewemail@example.org" -H "OCS-APIRequest: true"
 
 * Updates the email address for the user ``Frank``
 
 ::
 
-  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank -d key="quota" -d value="100MB"
+  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank -d key="quota" -d value="100MB" -H "OCS-APIRequest: true"
 
 * Updates the quota for the user ``Frank``
 
@@ -235,7 +235,7 @@ Examples
 
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/user/fields
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/user/fields -H "OCS-APIRequest: true"
 
 * Gets the list of fields
 
@@ -282,7 +282,7 @@ Example
 
 ::
 
-  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/disable
+  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/disable -H "OCS-APIRequest: true"
 
 * Disables the user ``Frank``
 
@@ -321,7 +321,7 @@ Example
 
 ::
 
-  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/enable
+  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/enable -H "OCS-APIRequest: true"
 
 * Enables the user ``Frank``
 
@@ -360,7 +360,7 @@ Example
 
 ::
 
-  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank
+  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank -H "OCS-APIRequest: true"
 
 * Deletes the user ``Frank``
 
@@ -397,7 +397,7 @@ Example
 
 ::
 
-  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/groups
+  $ curl -X GET http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/groups -H "OCS-APIRequest: true"
 
 * Retrieves a list of groups of which ``Frank`` is a member
 
@@ -445,7 +445,7 @@ Example
 
 ::
 
-  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/groups -d groupid="newgroup"
+  $ curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/groups -d groupid="newgroup" -H "OCS-APIRequest: true"
 
 * Adds the user ``Frank`` to the group ``newgroup``
 
@@ -488,7 +488,7 @@ Example
 
 ::
 
-  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/groups -d groupid="newgroup"
+  $ curl -X DELETE http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/groups -d groupid="newgroup" -H "OCS-APIRequest: true"
 
 * Removes the user ``Frank`` from the group ``newgroup``
 
@@ -530,7 +530,7 @@ Example
 
 ::
 
-  $ curl -X POST https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/subadmins -d groupid="group"
+  $ curl -X POST https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/subadmins -d groupid="group" -H "OCS-APIRequest: true"
 
 * Makes the user ``Frank`` a subadmin of the ``group`` group
 
@@ -572,7 +572,7 @@ Example
 
 ::
 
-  $ curl -X DELETE https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/subadmins -d groupid="oldgroup"
+  $ curl -X DELETE https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/subadmins -d groupid="oldgroup" -H "OCS-APIRequest: true"
 
 * Removes ``Frank's`` subadmin rights from the ``oldgroup`` group
 
@@ -611,7 +611,7 @@ Example
 
 ::
 
-  $ curl -X GET https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/subadmins
+  $ curl -X GET https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/subadmins -H "OCS-APIRequest: true"
 
 * Returns the groups of which ``Frank`` is a subadmin
 
@@ -652,7 +652,7 @@ Example
 
 ::
 
-  $ curl -X POST https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/welcome
+  $ curl -X POST https://admin:secret@example.com/ocs/v1.php/cloud/users/Frank/welcome -H "OCS-APIRequest: true"
 
 * Sends the welcome email to ``Frank``
 


### PR DESCRIPTION
Confusingly the required header isn't in the `curl` examples. Fixed.

Added across the Users, Groups, and Apps pages.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

e.g.
<img width="811" alt="image" src="https://github.com/nextcloud/documentation/assets/1731941/112cf5bf-eaa0-4ec4-a377-ba22fd012cf3">
