### PR TITLE
fix(devmanual): Deprecations are documented by release, not year

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
@@ -1,8 +1,8 @@
+.. _app-upgrade-guide:
+
 =================
 App upgrade guide
 =================
-
-.. _app-upgrade-guide:
 
 Once you've created and published the first version of your app, you will want to keep it up to date with the latest Nextcloud features.
 

--- a/developer_manual/digging_deeper/changelog.rst
+++ b/developer_manual/digging_deeper/changelog.rst
@@ -7,7 +7,9 @@ Changelog
 Deprecations
 ------------
 
-This is a deprecation roadmap which lists all current deprecation targets and will be updated from release to release. This lists the year when a specific method or class will be removed.
+Deprecations are now documented by Nextcloud major release, not time. See :ref:`app-upgrade-guide`.
+
+Below is the old deprecation roadmap which lists older deprecations by year.
 
 .. note:: Deprecations on interfaces also affect the implementing classes!
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix outdated "Changelog" page claiming it's still being updated.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1374172/6f6022a2-3b2d-4fb0-a0dd-a0c4e8d2ac02)
