### PR TITLE
fix(admin_manual): Add module js (`mjs`) as static resource to nginx config

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -165,7 +165,8 @@ server {
         fastcgi_max_temp_file_size 0;
     }
 
-    location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
+    # Serve static files
+    location ~ \.(?:css|js|mjs|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
         try_files $uri /index.php$request_uri;
         add_header Cache-Control "public, max-age=15778463, $asset_immutable";
         access_log off;     # Optional: Don't log access to assets

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -163,7 +163,8 @@ server {
             fastcgi_max_temp_file_size 0;
         }
 
-        location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
+        # Serve static files
+        location ~ \.(?:css|js|mjs|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
             try_files $uri /nextcloud/index.php$request_uri;
             add_header Cache-Control "public, max-age=15778463, $asset_immutable";
             access_log off;     # Optional: Don't log access to assets


### PR DESCRIPTION
### ☑️ Resolves

Not sure how this slipped through, but the nginx config was missing `mjs` as static files, adding this so we can finally make use of it.