### PR TITLE
(hardening and security) Add disabling debug mode recommendation

### DIFF
--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -88,6 +88,15 @@ setting the ``enable_previews`` switch to ``false`` in ``config.php``. As an
 administrator you are also able to manage which preview providers are enabled by 
 modifying the ``enabledPreviewProviders`` option switch.
 
+Disable Debug Mode
+^^^^^^^^^^^^^^^^^^
+
+Verify that ``debug`` is ``false`` in your ``config.php``. The default is ``false`` 
+in new installations (or when not specified). It should not be enabled in production 
+environments or outside of targeted troubleshooting situations. When enabled, things 
+like server-wide WebDAV collection listings are permitted. It is intended for local 
+development and usage in controlled environments only.
+
 .. _use_https_label:
 
 Use HTTPS


### PR DESCRIPTION
### ☑️ Resolves

Enabling `debug` mode at all (and certainly leaving it on) in production environments has security implications. This adds a section about it to the Hardening and security guidance chapter.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
<img width="826" alt="image" src="https://github.com/nextcloud/documentation/assets/1731941/9510d11b-9519-4004-85c8-a30318714a3f">
