### PR TITLE
Update dev docs build and instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ user-manual-html:
 	cd user_manual && make html
 	@echo "User manual build finished; HTML is updated"
 
-developer-manual-html: openapi-spec icons-docs
+developer-manual-html: openapi-spec # icons-docs
 	rm -rf developer_manual/_build/html/com
 	cd developer_manual && make html
 	@echo "Developer manual build finished; HTML is updated"

--- a/README.rst
+++ b/README.rst
@@ -127,15 +127,19 @@ Building HTML
 3. Change into the environment: ``pipenv shell``
 4. Install the dependencies ``pip install -r requirements.txt``
 5. Now you can use ``make ...`` to build all the stuff - for example ``make html`` to build the HTML flavor of all manuals
+   The build assets will be put into the individual documentation subdirectories like ``developer_manual/_build/html/com``
+
 
 To change into this environment you need to run ``pipenv shell`` to launch the shell and to exit you can use either ``exit`` or ``Ctrl`` + ``D``.
 
 When editing the documentation installing ``sphinx-autobuild`` though pip can be helpful. This will watch file changes and automatically reload the html preview:
 
+
 1. Install ``pip install sphinx-autobuild``
-2. Enter the documentation section ``cd user_manual``
-3. Watch for file changes ``make SPHINXBUILD=sphinx-autobuild html``
-4. Open http://127.0.0.1:8000 in the browser and start editing
+2. When building the developer documentation make sure to execute ``make openapi-spec`` in the repository root
+3. Enter the documentation section ``cd user_manual``
+4. Watch for file changes ``make SPHINXBUILD=sphinx-autobuild html``
+5. Open http://127.0.0.1:8000 in the browser and start editing
 
 Building PDF
 ============


### PR DESCRIPTION
Based on #10006

- fix: Disable icon-docs as they are broken anyways
- docs: Update readme with required steps for developer docs
