### PR TITLE
(Primary Storage) Generic S3 endpoint for hostname 

### DIFF
--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -168,7 +168,7 @@ unconfigured):
 
 * :code:`region` defaults to :code:`eu-west-1`
 * :code:`storageClass` defaults to :code:`STANDARD`
-* :code:`hostname` defaults to :code:`s3.REGION.amazonaws.com`
+* :code:`hostname` defaults to :code:`s3.REGION.amazonaws.com` [Note: If using this parameter (non-Amazon), specify the generic S3 endpoint hostname, **not** the hostname that contains your bucket name]
 * :code:`use_ssl` defaults to :code:`true`
 
 Optional parameters sometimes needing adjustment:


### PR DESCRIPTION
It's important to use the correct hostname when configuring S3 storage. It's easy to confuse the S3 endpoint with the direct bucket URL. The former is the correct one to use, but the latter *sort of* works in many cases. This eventually creates problems.

### ☑️ Resolves

* Fix #9679 

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
<img width="864" alt="image" src="https://github.com/nextcloud/documentation/assets/1731941/82b656de-e9fe-4320-96c1-461f28700199">
