### PR TITLE
Fix .htaccess configuration to actually work

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -268,15 +268,14 @@ document root of your Web server and add the following lines::
 
 Make sure to change /nextcloud to the actual subfolder your Nextcloud instance is running in.
 
-.. note:: Note, that if you are putting the above configureation directly to
-   the apache configuration (generaly in ``/etc/apache2/sites-enabled/``),
-   you will need to prepend the first argument of each of the above
-   ``RewriteRule`` option with a forward slash ``/``, for example
+.. note:: If you put the above directives directly into an Apache
+   configuration file (usually within ``/etc/apache2/``)
+   instead of ``.htaccess``, you need to prepend the first argument of
+   each ``RewriteRule`` option with a forward slash ``/``, for example
    ``^/\.well-known/carddav``.
-   This is because Apache already normalizes the values for the use in
-   ``.htaccess`` by dropping any number of leading slashes, but it does
-   not for the use in its main site configuration where the forward slash
-   is still present.
+   This is because Apache normalizes paths for the use in ``.htaccess``
+   files by dropping any number of leading slashes, but it does not
+   do so for the use in its main configuration files.
 
 If you are running NGINX, make sure ``location = /.well-known/carddav {`` and ``location = /.well-known/caldav {`` are properly configured as described in :doc:`../installation/nginx`, adapt to use a subfolder if necessary.
 

--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -260,13 +260,23 @@ document root of your Web server and add the following lines::
 
     <IfModule mod_rewrite.c>
       RewriteEngine on
-      RewriteRule ^/\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
-      RewriteRule ^/\.well-known/caldav /nextcloud/remote.php/dav [R=301,L]
-      RewriteRule ^/\.well-known/webfinger /nextcloud/index.php/.well-known/webfinger [R=301,L]
-      RewriteRule ^/\.well-known/nodeinfo /nextcloud/index.php/.well-known/nodeinfo [R=301,L]
+      RewriteRule ^\.well-known/carddav /nextcloud/remote.php/dav [R=301,L]
+      RewriteRule ^\.well-known/caldav /nextcloud/remote.php/dav [R=301,L]
+      RewriteRule ^\.well-known/webfinger /nextcloud/index.php/.well-known/webfinger [R=301,L]
+      RewriteRule ^\.well-known/nodeinfo /nextcloud/index.php/.well-known/nodeinfo [R=301,L]
     </IfModule>
 
 Make sure to change /nextcloud to the actual subfolder your Nextcloud instance is running in.
+
+.. note:: Note, that if you are putting the above configureation directly to
+   the apache configuration (generaly in ``/etc/apache2/sites-enabled/``),
+   you will need to prepend the first argument of each of the above
+   ``RewriteRule`` option with a forward slash ``/``, for example
+   ``^/\.well-known/carddav``.
+   This is because Apache already normalizes the values for the use in
+   ``.htaccess`` by dropping any number of leading slashes, but it does
+   not for the use in its main site configuration where the forward slash
+   is still present.
 
 If you are running NGINX, make sure ``location = /.well-known/carddav {`` and ``location = /.well-known/caldav {`` are properly configured as described in :doc:`../installation/nginx`, adapt to use a subfolder if necessary.
 


### PR DESCRIPTION
The .htaccess rules should not have the starting slash otherwise they will never get matched. This is done correctly when the nextcloud is installed in the root directory, but not in the documentation which proposes solving this common use case.

I actually copied these instructions to my root directory ages ago and wondered why they still do not work. Now I had to spend another hour figuring out why it wont work.