### PR TITLE
(primary+external storage) S3 bucket naming requirements

### DIFF
--- a/admin_manual/configuration_files/external_storage/amazons3.rst
+++ b/admin_manual/configuration_files/external_storage/amazons3.rst
@@ -7,8 +7,7 @@ To connect an Amazon S3 (or compatible) bucket to Nextcloud you will need to kno
 - S3 bucket name
 - S3 access key ID
 - S3 secret access key
-- S3 region (if Amazon hosted)
-- S3 hostname (if non-Amazon hosted)
+- S3 region (if Amazon hosted) or S3 hostname (if non-Amazon hosted) [Note: If specifying a hostname, use the generic S3 endpoint hostname, **not** the hostname that contains your bucket name]
 
 In the **Folder name** field enter a folder name to use as the local mountpoint for this
 external storage. If this does not exist it will be created.
@@ -17,7 +16,7 @@ In the **External storage** field select **Amazon S3**.
 
 In the **Authentication** field select **Access key**.
 
-In the **Bucket** field enter your *S3 bucket name*.
+In the **Bucket** field enter your *S3 bucket name*. [Note: Even if non-Amazon hosted, bucket names must meet AWS S3 naming requirements regardless of what your S3 provider/platform considers acceptable - i.e. no underscores]
 
 In the **Access key** field enter your *S3 access key ID*.
 

--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -166,7 +166,7 @@ Non-Amazon hosted S3:
 
 Minimum required parameters are:
 
-* :code:`bucket`
+* :code:`bucket` [Note: Even if non-Amazon hosted, bucket names must meet AWS S3 naming requirements regardless of what your S3 provider/platform considers acceptable - i.e. no underscores]
 * :code:`key`
 * :code:`secret`
 


### PR DESCRIPTION
* Adds note about S3 bucket naming requirements needing to be compliant with AWS S3 rules even if using a third-party S3 provider/platform (in order to work with the aws-sdk-php we use).
* Adds note about S3 endpoint usage for hostname to External Storage doc (to be consistent with Primary Storage doc change recently made in #10595)

### ☑️ Resolves

* Fix nextcloud/server#35364

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
