### PR TITLE
add a section to server-tuning about asset compression

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -50,6 +50,14 @@ Caching improves performance by storing data, code, and other objects in memory.
 Memory cache configuration for the Nextcloud server must be installed and configured.
 See :doc:`../configuration_server/caching_configuration`.
 
+Compression
+-----------
+
+Enabling compression in your web server for plain filetypes like javascript, css and svg files
+improves the performance because less bytes need to be transferred to the clients. Only these 
+file types are necessary because all other plain filetypes are usually served by Nextcloud PHP
+code and compressed on the fly by it automatically if the client accepts gzip encoding.
+
 Using MariaDB/MySQL instead of SQLite
 -------------------------------------
 

--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -53,10 +53,8 @@ See :doc:`../configuration_server/caching_configuration`.
 Compression
 -----------
 
-Enabling compression in your web server for plain filetypes like javascript, css and svg files
-improves the performance because less bytes need to be transferred to the clients. Only these 
-file types are necessary because all other plain filetypes are usually served by Nextcloud PHP
-code and compressed on the fly by it automatically if the client accepts gzip encoding.
+Enabling compression in your web server for JavaScript, CSS, and SVG files improves the 
+performance because fewer bytes need to be transferred to the clients.
 
 Using MariaDB/MySQL instead of SQLite
 -------------------------------------


### PR DESCRIPTION
After an intense debugging session, I came to the conclusion that javascript, css and svg are not compressed by default because they are not served via Nextcloud's PHP code but instead via the web server. So enabling compression for these file types makes sense. See https://github.com/nextcloud/all-in-one/pull/2576#issuecomment-1595831206