### PR TITLE
nginx: add http2 directive

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -23,8 +23,9 @@ server {
 }
 
 server {
-    listen 443      ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443      ssl;
+    listen [::]:443 ssl;
+    http2 on;
     server_name cloud.example.com;
 
     # Path to the root of your installation

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -24,8 +24,9 @@ server {
 }
 
 server {
-    listen 443      ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443      ssl;
+    listen [::]:443 ssl;
+    http2 on;
     server_name cloud.example.com;
 
     # Path to the root of the domain

--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -23,6 +23,9 @@ NGINX configuration
   broken for page display and result in an invalid configuration files.
 - Some environments might need a ``cgi.fix_pathinfo`` set to ``1`` in their
   ``php.ini``.
+- If you are using nginx < 1.25.1, remove the :code:`http2` directive and add http2 to the following lines:
+| :code:`listen 443      ssl http2;`
+| :code:`listen [::]:443 ssl http2;`
 
 .. nginx_webroot_example:
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix: the latest nginx 1.25.1 adds the http2 directive. The nginx conf of nextcloud needs to implement the changes to avoid any warnings or related errors.
