### PR TITLE
(occ command) Adds apc.enable_cli instructions

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -12,6 +12,16 @@ setting, and more.
 run it as your HTTP user** to ensure that the correct permissions are maintained
 on your Nextcloud files and directories.
 
+.. note:: 
+  Since APCu is disabled by default for the command-line mode of PHP, it can cause issues with Nextcloud’s ``occ`` command. Please make sure you set the ``apc.enable_cli`` parameter to ``1`` in your PHP CLI's ``php.ini`` configuration file or append ``--define apc.enable_cli=1`` each time you invoke ``occ`` - e.g.::
+
+    sudo -u www-data php --define apc.enable_cli=1 occ config:list system
+
+  If you fail to do this, you will receive output such as the following:: 
+
+    An unhandled exception has been thrown:
+    OCP\HintException: [0]: Memcache \OC\Memcache\APCu not available for local cache (Is the matching PHP module installed and enabled?)
+
 occ command Directory
 ---------------------
 


### PR DESCRIPTION
The proper setup of `apc.enable_cli` is mentioned elsewhere in the manual (for cron and the updater), but not mentioned in the occ command section. Since this triggers an exception, let's help people solve the problem themselves.

### ☑️ Resolves

* Fix (various) (it's a recurring issue in various repo Issues and the Help Forums)

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
![image](https://github.com/nextcloud/documentation/assets/1731941/8c3446f2-c755-4b78-a834-683c390d9a5a)
