### PR TITLE
fix(adminmanual): Update grammar for calendar backend docs

### DIFF
--- a/admin_manual/groupware/calendar.rst
+++ b/admin_manual/groupware/calendar.rst
@@ -115,13 +115,13 @@ Where the value is the number of seconds for the period. Setting the value to ``
 Resources and rooms
 -------------------
 
-The Nextcloud CalDAV back end support resources and rooms. Resources and room can be booked for appointments and the system will schedule them so they can only be used once at a time. Those resources and rooms have to be provided by an app that provides a back end for this.
+The Nextcloud CalDAV backend supports resources and rooms. Resources and rooms can be booked for appointments, and the system will schedule them so they can only be used once at a time. Those resources and rooms have to be provided by an app that provides a backend for this.
 
-Once a back end app is installed the app typically allows admins or even users to define the resources, but this is subject of the specific implementation.
+Once a backend app is installed, the app typically allows admins, or even users, to define the resources, but this is subject of the specific implementation.
 
-Nextcloud periodically queries all registered back ends. Therefore new and updated resources and rooms will show with a delay.
+Nextcloud periodically queries all registered backends, therefore new/updated resources and rooms will show with a delay.
 
-Known back ends
+Known backends
 ~~~~~~~~~~~~~~~
 
-* `Calendar Resource Management <https://github.com/nextcloud/calendar_resource_management>`_: database back end with CLI configuration for admins
+* `Calendar Resource Management <https://github.com/nextcloud/calendar_resource_management>`_: database backend with CLI configuration for admins

--- a/admin_manual/groupware/calendar.rst
+++ b/admin_manual/groupware/calendar.rst
@@ -122,6 +122,6 @@ Once a backend app is installed, the app typically allows admins, or even users,
 Nextcloud periodically queries all registered backends, therefore new/updated resources and rooms will show with a delay.
 
 Known backends
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 * `Calendar Resource Management <https://github.com/nextcloud/calendar_resource_management>`_: database backend with CLI configuration for admins


### PR DESCRIPTION
### ☑️ Resolves

None, this just makes the docs more readable

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
This is mostly fixing the word "back end" to be "[backend](https://en.wikipedia.org/wiki/Frontend_and_backend)" and adding commas and missing "s" where needed:
<img width="997" alt="Screenshot 2023-07-02 at 18 15 58" src="https://github.com/nextcloud/documentation/assets/2389292/beef453a-662a-47d5-b8a1-8a4652ea359e">
