### PR TITLE
fix(devmanual): Clarify privacy requirements of unified search providers

### DIFF
--- a/developer_manual/digging_deeper/search.rst
+++ b/developer_manual/digging_deeper/search.rst
@@ -416,3 +416,8 @@ The unified search is available via OCS, which means client application like the
     $entry->addAttribute("boardId", "567");
 
 .. note:: This method was added in Nextcloud 21. If your app also targets Nextcloud 20 you should either not use it or add a version check to invoke the method only conditionally.
+
+Privacy
+-------
+
+All search providers have to value privacy and prevent leaking of sensitive data by default. Therefore search terms must not be sent to third parties by default. If a search provider makes use of third party services, user consent has to be acquired, e.g. by an opt-in toggle in the user's personal settings.


### PR DESCRIPTION
Updates the developer manual to make it clear how search provider implementers should treat user privacy by default.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1374172/bbb3b5d3-0768-46f1-a35e-d9e295e3592c)

Ref https://github.com/nextcloud/integration_giphy/issues/11
Ref https://github.com/nextcloud/integration_peertube/issues/10