### PR TITLE
(admin) user_auth_ldap: add warnings about LDAP quota precedence

### DIFF
--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -436,16 +436,19 @@ Special attributes
 Quota Field:
   Nextcloud can read an LDAP attribute and set the user quota according to its
   value. Specify the attribute here, and it will return human-readable values,
-  e.g. "2 GB". Any quota set in LDAP overrides quotas set on the Nextcloud user
-  management page.
+  e.g. "2 GB".
 
   * Example: *NextcloudQuota*
 
+.. warning:: LDAP quota parameters override quota parameters set in the Nextcloud user management page.
+
 Quota Default:
-  Override Nextcloud default quota for LDAP users who do not have a quota set in
-  the Quota Field.
+  Specifies a default quota for LDAP users who do not have a quota set in
+  the above Quota Field.
 
   * Example: *15 GB*
+
+.. warning:: LDAP quota parameters override quota parameters set in the Nextcloud user management page.
 
 Email Field:
   Set the user's email from their LDAP attribute. Leave it empty for default


### PR DESCRIPTION
Addresses documentation TODO items in nextcloud/server#28052

> From times to times, people get confused about the fact that setting the LDAP quota attribute or the LDAP default quota will override any quota in the user management page.

* Moves the warning into a warning/note block for "Quota Field"
* Adds a similar warning for "Quota Default"

### ☑️ Resolves

* Fix nextcloud/server#28052 (Note: this PR only fixes the documentation TODO items *not* the UI hint TODO items)

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
