### PR TITLE
Use default redis socket name in example config

### DIFF
--- a/admin_manual/configuration_files/files_locking_transactional.rst
+++ b/admin_manual/configuration_files/files_locking_transactional.rst
@@ -49,7 +49,7 @@ recommended if Redis is running on the same system as Nextcloud) use this exampl
 
   'memcache.locking' => '\OC\Memcache\Redis',
   'redis' => array(
-       'host' => '/var/run/redis/redis-server.sock',
+       'host' => '/run/redis/redis-server.sock',
        'port' => 0,
        'timeout' => 0.0,
         ),

--- a/admin_manual/configuration_files/files_locking_transactional.rst
+++ b/admin_manual/configuration_files/files_locking_transactional.rst
@@ -49,7 +49,7 @@ recommended if Redis is running on the same system as Nextcloud) use this exampl
 
   'memcache.locking' => '\OC\Memcache\Redis',
   'redis' => array(
-       'host' => '/var/run/redis/redis.sock',
+       'host' => '/var/run/redis/redis-server.sock',
        'port' => 0,
        'timeout' => 0.0,
         ),


### PR DESCRIPTION
### ☑️ Resolves

* Update example config to connect to default `redis-server.sock` file
* Matches https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/caching_configuration.html#connecting-to-single-redis-server-over-unix-socket

### 🖼️ Screenshots
Before
![Before](https://github.com/nextcloud/documentation/assets/14607273/f99a574c-fd7b-4e0e-ac69-fe5d99970382)

After
![After](https://github.com/nextcloud/documentation/assets/14607273/fbba5714-c818-4edb-91fc-96b0ad8c8434)

