### PR TITLE
(admin-general troubleshooting) Enabling phpinfo access via the serverinfo (System) app

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -76,7 +76,24 @@ usually access them by pressing F12.
 PHP version and information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You will need to know your PHP version and configurations. To do this, create a
+You will need to know the PHP version and configuration that is in-use on your 
+Nextcloud server. This will not necessarily be the same version and configuration as 
+can be reached from the command-line. The simplest way to gather this information is 
+by using what's commonly referenced as ``phpinfo()``.
+
+The most accurate - and easiest - way to access ``phpinfo`` is by checking it from 
+within Nextcloud itself. Of course, this requires that Nextcloud is functioning 
+enough that you can log in as an administrator and access the 
+**Administration settings -> System** menu. If so, you can enable the exposure of 
+``phpinfo`` data by toggling it on via ``occ``:
+
+``./occ config:app:set --value=yes serverinfo phpinfo``
+
+From then on a new button labeled **Show phpinfo** will be visible in the web 
+interface under **Administration settings -> System**. Clicking it will expose 
+just about everything you may want to know about your PHP environment.
+
+If accessing the Nextcloud web interface is not an option, you may create a
 plain-text file named **phpinfo.php** and place it in your Web root, for
 example ``/var/www/html/phpinfo.php``. (Your Web root may be in a different
 location; your Linux distribution documentation will tell you where.) This file


### PR DESCRIPTION
nextcloud/serverinfo#469 added `phpinfo()` details that can be accessed by an administrator via the shipped `serverinfo` (System) app. The feature is currently opt-in so it must be enabled before it can be accessed.

This adds a couple paragraphs to the existing `phpinfo` section in the general troubleshooting chapter that describe this new functionality and how to enable it within the `serverinfo` app.

### ☑️ Resolves

* Fix nextcloud/serverinfo#362
* Fix nextcloud/serverinfo#107

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
![image](https://github.com/nextcloud/documentation/assets/1731941/67c6d419-c10c-4415-92e9-9b52df0b9812)
