### PR TITLE
feat: more specific Apache recommendations

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -27,7 +27,8 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - PostgreSQL 10/11/12/13/14/15                                        |
 |                  | - SQLite (*only recommended for testing and minimal-instances*)       |
 +------------------+-----------------------------------------------------------------------+
-| Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |
+| Webserver        | - **Apache >= 2.4.54 with** ``mod_php`` **or** ``php-fpm``            |
+|                  |   (recommended)                                                       |
 |                  | - nginx with ``php-fpm``                                              |
 +------------------+-----------------------------------------------------------------------+
 | PHP Runtime      | - 8.0 (*deprecated*)                                                  |


### PR DESCRIPTION
Due to https://httpd.apache.org/security/vulnerabilities_24.html#CVE-2022-22720 recommend versions higher than 2.4.53.

| Before | After |
|--------|--------|
| ![image](https://github.com/nextcloud/documentation/assets/7427347/57f850b0-e6d1-4283-8e92-c1ab49bfdf4a)| ![image](https://github.com/nextcloud/documentation/assets/7427347/824690ed-becc-4cbd-a521-0a24d5fa6d58) |