### PR TITLE
Update Debian version in system_requirements.rst

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -17,7 +17,7 @@ For best performance, stability and functionality we have documented some recomm
 | Operating System | - **Ubuntu 22.04 LTS** (recommended)                                  |
 | (64-bit)         | - Ubuntu 20.04 LTS                                                    |
 |                  | - **Red Hat Enterprise Linux 8** (recommended)                        |
-|                  | - Debian 11 (Bullseye)                                                |
+|                  | - Debian 12 (Bookworm)                                                |
 |                  | - SUSE Linux Enterprise Server 15                                     |
 |                  | - openSUSE Leap 15.4                                                  |
 |                  | - CentOS Stream                                                       |


### PR DESCRIPTION
If we recommend a Debian operating system, it would be better to use a version that already ships a php version that is supported by NC.

https://wiki.debian.org/PHP#Available_versions

Not sure if you do some specific tests on a Debian setup and to claim to support it, you would need to adjust the version as well.

Perhaps back-port to NC26 as well (first version to support php 8.2).