### PR TITLE
Fix OpenAPI illegal character error

### DIFF
--- a/developer_manual/_static/openapi.html
+++ b/developer_manual/_static/openapi.html
@@ -3,6 +3,7 @@
         <title>OCS API</title>
         <script src="stoplight-elements.js"></script>
         <link rel="stylesheet" href="stoplight-elements.css">
+        <meta charset="utf-8">
     </head>
     <body>
         <elements-api apiDescriptionUrl="openapi.json" router="hash" hideTryIt="true" logo="logo-blue.png"></elements-api>


### PR DESCRIPTION
### ☑️ Resolves

Fixes the illegal character errors seen in https://github.com/nextcloud/documentation/pull/10006. On some web servers it worked just fine, on others it didn't.
