### PR TITLE
(big_file_upload_configuration) Note new Apache LimitRequestBody default

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -65,7 +65,7 @@ for how to configure those values correctly:
 
 Apache
 ^^^^^^
-* `LimitRequestBody <https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody>`_
+* `LimitRequestBody <https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody>`_ (In Apache HTTP Server <=2.4.53 this defaulted to unlimited, but now defaults to 1 GiB. The new default limits uploads from non-chunking clients to 1 GiB. If this is a concern in your environment, override the new default by either manually setting it to ``0`` or to a value similar to that used for your local environment's PHP ``upload_max_filesize / post_max_size / memory_limit`` parameters.)
 * `SSLRenegBufferSize <https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslrenegbuffersize>`_
 * `Timeout <https://httpd.apache.org/docs/current/mod/core.html#timeout>`_
 


### PR DESCRIPTION
* Context:
  - Apache's default for `LimitRequestBody` changed from 0 (unlimited) to 1 GiB in v2.4.53 which was released on June 08, 2022. This is becoming a more widely deployed version (e.g. Debian 12 currently ships with v2.4.57 and Ubuntu kinentic/22.10 ships with v2.4.54)
  - See https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody where this change in behavior is documented
  - Impacts non-chunking client transactions (effectively restricting them to <1GB)
* Documents this in the Admin Manual in the *Uploading big files > 512MB* section were this parameter is already mentioned
* Gives the reader some guidance so that they may decide what value makes the most sense in their local environment

### ☑️ Resolves

* Fixes #9601
  - Also nextcloud/server#35778
  - Also nextcloud/server#37695
* Documents potential adjustments so that Apache-based downstreams can decide what (if anything) to do in their default setups or own documentation - e.g. 
  - nextcloud/docker#1796
  - nextcloud/docker#1830. 
  - Some already have overridden the default since Apache changed it - e.g. nextcloud/all-in-one#1178

### Follow-up Notes

* Since this parameter can be used in `.htaccess` it may make sense to explore whether overriding Apache's new default makes sense to do in `server`, but that's outside the scope of documentation

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

![image](https://github.com/nextcloud/documentation/assets/1731941/63340ade-e081-4057-8635-780a95099235)

(Ignore black background; just by browser config)