### PR TITLE
(general_troubleshooting) Add Tideways as a problematic PHP extensions

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -230,6 +230,7 @@ these modules:
 
 3. PHP
 
+* Tideways
 * eAccelerator
 
 .. _trouble-webdav-label:


### PR DESCRIPTION
Tideways come up twice in the last couple weeks with the same impact: Files pane is completely blank in the Web UI and minimal to no indication of the cause.

It's also had some other [interactions with different PHP versions](https://support.tideways.com/documentation/setup/troubleshooting/debugging-segfaults-in-php.html) specifically involving Symfony.

This adds it to the (existing) list of potentially problematic PHP extensions in the Admin Manual for admins to check for if they're experiencing problems. 


### ☑️ Resolves

* Fix nextcloud/server#39535
* https://help.nextcloud.com/t/fyi-on-php-8-2-the-php-module-tideways-can-break-nextcloud/168198

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
