### PR TITLE
(admin) email cfg - NC `loglevel` `0` required for Mailer debugging

### DIFF
--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -395,11 +395,20 @@ Enabling debug mode
 -------------------
 
 If you are unable to send email, it might be useful to activate further debug
-messages by enabling the ``mail_smtpdebug`` parameter:
+messages by enabling the ``mail_smtpdebug`` parameter and temporarily setting your NC loglevel to DEBUG:
 
 ::
 
     "mail_smtpdebug" => true,
+    "loglevel" => 0,
+
+Be cautious setting your ``loglevel`` to DEBUG (``0``) since it'll apply to everything occurring on your NC instance, not just email. 
+And don't forget to set it back to a more reasonable level when you're done troubleshooting:
+
+::
+
+    "mail_smtpdebug" => false,
+    "loglevel" => 2,
 
 .. note:: Immediately after pressing the **Send email** button, as described
    before, several **SMTP -> get_lines(): ...** messages appear on the screen.


### PR DESCRIPTION
### ☑️ Resolves

* Fixes #11082 

It also arose in nextcloud/server#40073 (and anytime anyone has email config problems) that the documentation doesn't make clear that enabling `mail_smtpdebug` alone doesn't provide the debug output. This is because the output it generates is still sent to the debug level of the NC logger. So global `loglevel` also has to be set to `0` during troubleshooting. This just adds a note about that as well as how to turn it back off.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
