### PR TITLE
feat(build): add unicode support to Latex for PDF

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,3 +73,5 @@ edit_on_github_branch = 'master'
 
 # user starts in light mode
 default_dark_mode = False
+
+latex_engine = "xelatex"


### PR DESCRIPTION
Currently, master fails to build because we have another unicode character (⋮). According to https://docs.readthedocs.io/en/stable/guides/pdf-non-ascii-languages.html we should use xelatex for building the PDF. It succeeded locally:

![Screenshot_20230831_151539](https://github.com/nextcloud/documentation/assets/2184312/e98fa6cd-b70a-4f81-a271-ad96bb36c8db)



