### PR TITLE
(Object Storage) S3 performance gain from disabling verify_bucket_exists

### DIFF
--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -196,7 +196,7 @@ Optional parameters less commonly needing adjustment:
 * :code:`putSizeLimit` defaults to :code:`104857600`
 * :code:`legacy_auth` has no default
 * :code:`version` defaults to :code:`latest`
-* :code:`verify_bucket_exists` defaults to :code:`true`
+* :code:`verify_bucket_exists` defaults to :code:`true` [Note: Setting this to :code:`false` *after* confirming the bucket has been created may provide a performance benefit, but may not be possible in multibucket scenarios.]
 
 **If you are using Amazon S3:** the :code:`region` parameter is required unless you're happy with 
 the default of :code:`eu-west-1`. There is no need to override the :code:`hostname` or :code:`port`. 


### PR DESCRIPTION
There is a performance gain from disabling the check for the need to create the target bucket. But the bucket must exist already (obviously) and there are some scenarios where it's not possible (e.g. multibuckets). Adds a note about this benefit next to where this parameter is already documented.

- Documents performance gain from `verify_bucket_exists` for S3 as developed in nextcloud/server#23932
- Also includes caveat language re: multibucket scenarios

### ☑️ Resolves

* Fix nextcloud/server#23932 (Resolves: pending documentation)

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
