### PR TITLE
docs: add repair-filecache when mimetype has been updated

### DIFF
--- a/admin_manual/configuration_mimetypes/index.rst
+++ b/admin_manual/configuration_mimetypes/index.rst
@@ -21,6 +21,9 @@ command to propagate the changes through the system. This example is for
 Ubuntu Linux::
 
   $ sudo -u www-data php occ maintenance:mimetype:update-js
+
+  # you may also need to update the mimetype for existing files, see nextcloud/server#30566
+  $ sudo -u www-data php occ maintenance:mimetype:update-db --repair-filecache
   
 See :doc:`../configuration_server/occ_command` to learn more about ``occ``.
 


### PR DESCRIPTION
### ☑️ Resolves
reflect the discussion at nextcloud/server#30566 that shows the need to repair the filecache after updating the mimetype
(e.g., to open files with a customized extension in text editor instead of downloading them)

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
