### PR TITLE
rename Core to Server development

### DIFF
--- a/developer_manual/core/index.rst
+++ b/developer_manual/core/index.rst
@@ -1,8 +1,8 @@
 .. _coreindex:
 
-=================
-Core development
-=================
+==================
+Server development
+==================
 
 Please make sure you have set up a :ref:`devenv`.
 


### PR DESCRIPTION
### ☑️ Resolves

Currently in the `Developer Manual` on both the sidebar and page is the title:

- [Core development](https://docs.nextcloud.com/server/latest/developer_manual/core/index.html)

My understanding is this is an artifact from Owncloud when the `server` was called `core`

My pull request is a simple 6 character change which resolves this.

### 🖼️ Screenshots

![nextcloud-docs-core-to-server](https://github.com/nextcloud/documentation/assets/49612519/6d19e5bd-e30f-40a9-9fe5-f3bb46bcbff5)
