### PR TITLE
add 'Working with ... code' docs from server/README

### DIFF
--- a/developer_manual/core/code-back-end.rst
+++ b/developer_manual/core/code-back-end.rst
@@ -1,0 +1,13 @@
+=============
+Back-end code
+=============
+
+When changing back-end PHP code, in general, no additional steps are needed before checking in.
+
+However, if new files were created, you will need to run the following command to update the autoloader files:
+
+.. code-block:: console
+    
+   build/autoloaderchecker.sh
+
+After that, please also include the autoloader file changes in your commits.

--- a/developer_manual/core/code-front-end.rst
+++ b/developer_manual/core/code-front-end.rst
@@ -1,0 +1,76 @@
+==============
+Front-end code
+==============
+
+Building Vue components and scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We are moving more and more toward using Vue.js in the front-end, starting with Settings. For building the code on changes, use these terminal commands in the root folder:
+
+.. code-block:: console
+
+    # install dependencies
+    make dev-setup
+
+    # build for development
+    make build-js
+
+    # build for development and watch edits
+    make watch-js
+
+    # build for production with minification
+    make build-js-production
+
+
+Building styles
+^^^^^^^^^^^^^^^
+
+Styles are written in SCSS and compiled to css.
+
+.. code-block:: console
+
+    # install dependencies
+    make dev-setup
+
+    # compile style sheets
+    npm run sass
+
+    # compile style sheets and watch edits
+    npm run sass:watch
+
+
+Committing changes
+^^^^^^^^^^^^^^^^^^
+
+**When making changes, also commit the compiled files!**
+
+We still use Handlebars templates in some places in Files and Settings. We will replace these step-by-step with Vue.js, but in the meantime, you need to compile them separately.
+
+If you don’t have Handlebars installed yet, you can do it with this terminal command:
+
+.. code-block:: console
+    
+   sudo npm install -g handlebars
+
+Then inside the root folder of your local Nextcloud development installation, run this command in the terminal every time you changed a ``.handlebars`` file to compile it:
+
+.. code-block:: console
+    
+   ./build/compile-handlebars-templates.sh
+
+Before checking in JS changes, make sure to also build for production:
+
+.. code-block:: console
+
+    make build-js-production
+
+
+Then add the compiled files for committing.
+
+To save some time, to only rebuild for a specific app, use the following and replace the module with the app name:
+
+.. code-block:: console
+
+    MODULE=user_status make build-js-production
+
+Please note that if you used ``make build-js`` or ``make watch-js`` before, you'll notice that a lot of files were marked as changed, so might need to clear the workspace first.

--- a/developer_manual/core/code-front-end.rst
+++ b/developer_manual/core/code-front-end.rst
@@ -10,16 +10,16 @@ We are moving more and more toward using Vue.js in the front-end, starting with 
 .. code-block:: console
 
     # install dependencies
-    make dev-setup
+    npm install
 
     # build for development
-    make build-js
+    npm run dev
 
     # build for development and watch edits
-    make watch-js
+    npm run watch
 
     # build for production with minification
-    make build-js-production
+    npm run build
 
 
 Building styles

--- a/developer_manual/core/index.rst
+++ b/developer_manual/core/index.rst
@@ -9,6 +9,8 @@ Please make sure you have set up a :ref:`devenv`.
 .. toctree::
    :maxdepth: 2
 
+   code-front-end
+   code-back-end
    static-analysis
    unit-testing
    externalapi


### PR DESCRIPTION
### ☑️ Resolves

Currently the `server/README.md` file has two sections which seem to be better placed in the **Developer Manual's** [Core development](https://docs.nextcloud.com/server/latest/developer_manual/core/index.html) section.

- [Working with front-end code](https://github.com/nextcloud/server/#working-with-front-end-code-)
- [Working with back-end code](https://github.com/nextcloud/server/#working-with-back-end-code-)

This pull-request incorporates those sections from the `README.md` converted to the `.rst`  format for Sphinx.


### 🖼️ Screenshots

![nextcloud-docs-front-end-code](https://github.com/nextcloud/documentation/assets/49612519/dbdc2b6c-e5ef-446d-b0d5-3b8f69a5cc48)

![nextcloud-docs-back-end-code](https://github.com/nextcloud/documentation/assets/49612519/c12de4f3-6221-424d-9de7-6e1015e9cefb)
