### PR TITLE
Clarify the use of a master key during setup of encryption

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -79,6 +79,14 @@ the Nextcloud Web interface. If you lose your encryption keys your files are not
 recoverable. Always have backups of your encryption keys stored in a safe 
 location, and consider enabling all recovery options.
 
+Please be aware that a `master key` is generated during enabling the encryption.
+This ensures that admin(s) can recover passwords and installed Nextcloud apps can
+function properly.
+If you do not want to use a master key setup, but wish to use user key encryption
+instead, please run the following command before enabling the encryption::
+
+ occ encryption:disable-master-key
+
 You have more options via the ``occ`` command (see :ref:`occ_encryption_label`)
 
 .. _enable_encryption_label:


### PR DESCRIPTION
Add notice about encryption having a master key setup, since it has been the default since Nextcloud 13 without any notice.

### ☑️ Resolves

Kinda resolves discussion in this issue: https://github.com/nextcloud/server/issues/8283

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
