### PR TITLE
[stable27] chore: Overwrite PHP platform version for composer

### DIFF
--- a/build/composer.json
+++ b/build/composer.json
@@ -13,6 +13,9 @@
         "leafo/scssphp": "dev-master"
     },
     "config": {
-        "github-protocols": ["https"]
+        "github-protocols": ["https"],
+        "platform": {
+            "php": "7.4"
+        }
     }
 }


### PR DESCRIPTION
### ☑️ Resolves

Allows dependency installation with PHP8. Any breaking changes of PHP7->PHP8 will cause an error, though.

@mgallien please test this patch on the docs host. Run the PHP process required to build docs.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
