### PR TITLE
change Nextcloud to Interface & interaction design

### DIFF
--- a/developer_manual/design/index.rst
+++ b/developer_manual/design/index.rst
@@ -1,12 +1,12 @@
-===========================
-Nextcloud design guidelines
-===========================
+==============================
+Interface & interaction design
+==============================
 
 .. toctree:: 
-		:maxdepth: 2
+	:maxdepth: 2
 
-		introduction
-		foundations
-		layout
-		layoutcomponents
-		atomiccomponents
+	introduction
+	foundations
+	layout
+	layoutcomponents
+	atomiccomponents


### PR DESCRIPTION
### ☑️ Resolves

The current wording `Nextcloud design guidelines` is:

- Redundant, as this is obviously about Nextcloud
- Vague as it's not obviously about visual UI / UX design 

![documentation-nextcloud-design](https://github.com/nextcloud/documentation/assets/49612519/fd57ed43-504b-42e3-ad31-c1ed943e42f4)

This two word change addresses both issues. It also is easier to identify the section in search results.

![documentation-interface-design](https://github.com/nextcloud/documentation/assets/49612519/a06e6279-79fe-4fa9-8bfc-7a5bdfdb6897)
 
![documentation-interface-design-search](https://github.com/nextcloud/documentation/assets/49612519/fcab5cf5-bb4b-4c3d-9c89-d5b5ac25232f)



