### PR TITLE
enh(admin): explain data fingerprint in more detail

### DIFF
--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -13,10 +13,6 @@ restore:
 .. note:: You must have both the database and data directory. You cannot
    complete restoration unless you have both of these.
 
-When you have completed your restoration, also make sure to run the
-:ref:`maintenance:data-fingerprint <maintenance_commands_label>` command
-afterwards, to ensure your sync clients can recover from the restored backup.
-
 Restore folders
 ---------------
 
@@ -82,3 +78,28 @@ PostgreSQL
 ::
 
     PGPASSWORD="password" psql -h [server] -U [username] -d nextcloud -f nextcloud-sqlbkp.bak
+
+Synchronising with clients after data recovery
+----------------------------------------------
+
+By default the Nextcloud server is considered the authorative source for the data.
+If the data on the server and the client differs
+clients will default to fetching the data from the server.
+
+If the recovered backup is outdated
+the state of the clients may be more up to date than the state of the server.
+In this case also make sure to run the
+:ref:`maintenance:data-fingerprint <maintenance_commands_label>` command
+afterwards. 
+It changes the logic of the synchronisation algorithm
+to try an recover as much data as possible.
+Files missing on the server are therefore recovered from the clients
+and in case of different content the users will be asked.
+
+.. note:: The usage of `maintenance:data-fingerprint` can cause conflict dialogues
+   and difficulties deleting files on the client.
+   Therefore it's only recommended to prevent dataloss if the backup was outdated.
+
+If you are running multiple application servers you will need to make sure
+the config files are synced between them so that the updated `data-fingerprint`
+is applied on all instances.


### PR DESCRIPTION
There are downsides to changing `data-fingerprint` after recovering from a backup:
* Conflicts are shown to the user rather than automatically resolved.
* Files will be kept even if they were deleted on one side.

Explain those so the admin can make an informed decision.

### 🖼️ Screenshots

Removed info about `data-fingerprint` on top:
![grafik](https://github.com/nextcloud/documentation/assets/97337118/3ceda8eb-b95e-4ec1-afe5-ac8199866dc5)

Added separate section with more detailed info:
![grafik](https://github.com/nextcloud/documentation/assets/97337118/02137e27-5c29-486c-913f-68d0bdcb686f)

