### PR TITLE
Remove legacy header X-Download-Options

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -71,7 +71,6 @@ server {
     # HTTP response headers borrowed from Nextcloud `.htaccess`
     add_header Referrer-Policy                   "no-referrer"       always;
     add_header X-Content-Type-Options            "nosniff"           always;
-    add_header X-Download-Options                "noopen"            always;
     add_header X-Frame-Options                   "SAMEORIGIN"        always;
     add_header X-Permitted-Cross-Domain-Policies "none"              always;
     add_header X-Robots-Tag                      "noindex, nofollow" always;

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -103,7 +103,6 @@ server {
         # HTTP response headers borrowed from Nextcloud `.htaccess`
         add_header Referrer-Policy                   "no-referrer"       always;
         add_header X-Content-Type-Options            "nosniff"           always;
-        add_header X-Download-Options                "noopen"            always;
         add_header X-Frame-Options                   "SAMEORIGIN"        always;
         add_header X-Permitted-Cross-Domain-Policies "none"              always;
         add_header X-Robots-Tag                      "noindex, nofollow" always;


### PR DESCRIPTION
The header has been removed from the nextcloud/server code: https://github.com/nextcloud/server/commit/ea0e45d81e6963dab8c89981538f9d5fe2d51472
