### PR TITLE
Update nginx-subdir.conf.sample &  nginx-root.conf.sample

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -186,6 +186,12 @@ server {
     location /remote {
         return 301 /remote.php$request_uri;
     }
+    # fix 405 error on posts that are passwd as pritty URL
+    error_page 405 =200 @post_static ;   #/index.php/$request_uri;
+    location @post_static {
+         proxy_pass https://$server_name/index.php/$request_uri ;
+         proxy_redirect off;
+    }
 
     location / {
         try_files $uri $uri/ /index.php$request_uri;

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -185,6 +185,13 @@ server {
             return 301 /nextcloud/remote.php$request_uri;
         }
 
+        # fix 405 error on posts that are passwd as pritty URL
+        error_page 405 =200 @post_static ;   #/index.php/$request_uri;
+        location @post_static {
+            proxy_pass https://$server_name/nextcloud/index.php/$request_uri ;
+            proxy_redirect off;
+        }
+
         location /nextcloud {
             try_files $uri $uri/ /nextcloud/index.php$request_uri;
         }


### PR DESCRIPTION
prevent 405 error combined with pretty URL's

### ☑️ Resolves

* Issue with f.e. shifts (shiftplan)  that uses URL:
https://server/admin/settings     with PUT
location /   (without proxy_pass) returns error 405 on PUT/POST...

Solution a redirect in case of 405 errors.

Example patched.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
