### PR TITLE
fix(nginx): adjust config to changed ocm-provider

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -96,7 +96,7 @@ server {
     # that file is correctly served; if it doesn't, then the request is passed to
     # the front-end controller. This consistent behaviour means that we don't need
     # to specify custom rules for certain paths (e.g. images and other assets,
-    # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+    # `/updater`, `/ocs-provider`), and thus
     # `try_files $uri $uri/ /index.php$request_uri`
     # always provides the desired behaviour.
     index index.php index.html /index.php$request_uri;
@@ -143,7 +143,7 @@ server {
     # to the URI, resulting in a HTTP 500 error response.
     location ~ \.php(?:$|/) {
         # Required for legacy support
-        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
 
         fastcgi_split_path_info ^(.+?\.php)(/.*)$;
         set $path_info $fastcgi_path_info;

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -119,7 +119,7 @@ server {
         # that file is correctly served; if it doesn't, then the request is passed to
         # the front-end controller. This consistent behaviour means that we don't need
         # to specify custom rules for certain paths (e.g. images and other assets,
-        # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+        # `/updater`, `/ocs-provider`), and thus
         # `try_files $uri $uri/ /nextcloud/index.php$request_uri`
         # always provides the desired behaviour.
         index index.php index.html /nextcloud/index.php$request_uri;
@@ -141,7 +141,7 @@ server {
         # `/nextcloud/index.php` to the URI, resulting in a HTTP 500 error response.
         location ~ \.php(?:$|/) {
             # Required for legacy support
-            rewrite ^/nextcloud/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /nextcloud/index.php$request_uri;
+            rewrite ^/nextcloud/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+|.+\/richdocumentscode\/proxy) /nextcloud/index.php$request_uri;
 
             fastcgi_split_path_info ^(.+?\.php)(/.*)$;
             set $path_info $fastcgi_path_info;


### PR DESCRIPTION
- Since 27.1.2 and 26.0.8 ocm-provider is not a dir anymore, but implemented in a usual Controller. Nginx webserver config requires adjustments.

As noted in https://github.com/nextcloud/server/pull/40745, for https://github.com/nextcloud/server/pull/39574

