### PR TITLE
feat: `addScript` and `addInitScript` docs

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
@@ -22,6 +22,13 @@ Front-end changes
 Added APIs
 ^^^^^^^^^^
 
+* The new Files initialising much faster than the old one, you will face some
+  race conditions if you register some custom properties loading your scripts
+  by using the ``Util::addScript`` method.
+  We recommend you use the new ``Util::addInitScript`` method instead, your script
+  will be loaded right after the common core scripts and right before the Files app.
+  See :ref:`ApplicationJs` for more information.
+
 * File actions: to register file actions, please use the dedicated API from https://npmjs.org/@nextcloud/files or
   https://nextcloud-libraries.github.io/nextcloud-files/functions/registerFileAction.html
 * New file menu: to register entries in the new file menu, please use the dedicated API from https://npmjs.org/@nextcloud/files or 

--- a/developer_manual/basics/front-end/templates.rst
+++ b/developer_manual/basics/front-end/templates.rst
@@ -49,6 +49,9 @@ The parent variables will also be available in the included templates, but shoul
 Including CSS and JavaScript
 ----------------------------
 
+.. warning:: This is deprecated, please use ``addScript`` and ``addStyle`` in your controller instead.
+   See :ref:`ApplicationJs` for more information.
+
 To include CSS or JavaScript use the **style** and **script** functions:
 
 .. code-block:: php


### PR DESCRIPTION
Add documentation for the `addInitScript` feature and deprecate the old ways.
Also document the long time overdue `addScript` feature.
Ref: https://github.com/nextcloud/server/pull/40323

| 1 | 2 |
|:---------:|:------:|
|![2023-10-19_15-11](https://github.com/nextcloud/documentation/assets/14975046/99413f2a-14c5-4c71-9386-5e40fc448c03)|![2023-10-19_15-11_1](https://github.com/nextcloud/documentation/assets/14975046/51c5170f-ba3f-40d8-ba87-eb853e16a240)|
|![2023-10-19_15-11_2](https://github.com/nextcloud/documentation/assets/14975046/7269f1ea-ee62-45a9-8079-55ccebd3b468)|![image](https://github.com/nextcloud/documentation/assets/14975046/919dec3e-b65b-4b6b-8583-a8503d0ecf51)|