### PR TITLE
reverse_proxy_configuration.rst: IPv6 CIDR is supported

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -18,16 +18,14 @@ configured in :file:`config/config.php`
 
 Set the :file:`trusted_proxies` parameter as an array of:
 
-* IPv4 addresses, 
+* IPv4 addresses 
 * IPv4 ranges in CIDR notation
 * IPv6 addresses
+* IPv6 ranges in CIDR notation
 
 to define the servers Nextcloud should trust as proxies. This parameter
 provides protection against client spoofing, and you should secure those
 servers as you would your Nextcloud server.
-
-.. note:: CIDR notation for IPv6 is currently work in progress and thus not
-  available as of yet.
 
 A reverse proxy can define HTTP headers with the original client IP address,
 and Nextcloud can use those headers to retrieve that IP address. Nextcloud uses


### PR DESCRIPTION
Confirmed that IPv6 CIDR notation works on server v27.0.0. Apparently, this has been supported since v25.0.0-beta1; see  https://github.com/nextcloud/server/pull/32615