### PR TITLE
chore(devmanual): Deprecate `--color-text-light` and `--color-text-lighter` CSS variables

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_28.rst
@@ -49,7 +49,8 @@ Changed APIs
 Deprecated APIs
 ^^^^^^^^^^^^^^^
 
-* tbd
+* The CSS variables ``--color-text-light`` and  ``--color-text-lighter`` were made aliases of ``--color-main-text`` and ``--color-text-maxcontrast``
+  in `Nextcloud 20 <https://github.com/nextcloud/server/pull/21117>`_ and are now officially deprecated and will be removed in the near future.
 
 Removed APIs
 ^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/pull/40773#discussion_r1372941254

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1855448/b421441c-0894-4cc3-b2ad-a152a75dbfcc)

