### PR TITLE
Remove old redis installation hints

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -307,31 +307,6 @@ More information on configuration of phpredis session handler can be found on th
 
 ..  _install_redis_label:
 
-Additional Redis installation help
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If your version of **Mint** or **Ubuntu** does not package the required version of 
-``php-redis``, then try `this Redis guide on Tech and Me
-<https://www.techandme.se/install-redis-cache-on-ubuntu-server-with-php-7-and-nextcloud/>`_
-for a complete Redis installation on Ubuntu 14.04 using PECL. 
-These instructions are adaptable for **any distro** that does not package the 
-supported version, or that does not package Redis at all, such as **SUSE Linux 
-Enterprise Server** and **Red Hat Enterprise Linux**.
-
-For PHP 7.0 and PHP 7.1 use Redis PHP module 3.1.x or later.
-  
-See `<https://pecl.php.net/package/redis>`_
-
-On Debian/Mint/Ubuntu, use ``apt-cache`` to see the available 
-``php-redis`` version, or the version of your installed package::
-
- apt-cache policy php-redis
- 
-On CentOS and Fedora, the ``yum`` command shows available and installed version 
-information::
-
- yum search php-pecl-redis
-
 
 Memcached
 ---------


### PR DESCRIPTION
Follow up on https://github.com/nextcloud/documentation/pull/11264.

There is more outdated documentation regarding redis:
- instruction to retired Ubuntu 14.04 manual
-  php-redis packages are now included in Ubuntu (since 20.04 LTS), older onces are or are about to expire by now (18.04 + 5 years)
- info about redis suppot for php7.1/2 compatibility is not relevant, these versions are not supported for quite some time.

Not sure about the fedora/CentOS part, but there is just an information how to retrieve package information on a setup, that does not really help.

We can probably backport these changes to all supported versions.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
