### PR TITLE
Database installation - MariaDB use mariadb / no FLUSH PRIVILEGES

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -127,6 +127,10 @@ To start the MySQL command line mode use::
 
   mysql -uroot -p
 
+When using MariaDB use::
+
+  mariadb -uroot -p
+
 Then a **mysql>** or **MariaDB [root]>** prompt will appear. Now enter the following lines and confirm them with the enter key:
 
 ::
@@ -134,7 +138,6 @@ Then a **mysql>** or **MariaDB [root]>** prompt will appear. Now enter the follo
   CREATE USER 'username'@'localhost' IDENTIFIED BY 'password';
   CREATE DATABASE IF NOT EXISTS nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
   GRANT ALL PRIVILEGES on nextcloud.* to 'username'@'localhost';
-  FLUSH privileges;
 
 You can quit the prompt by entering::
 


### PR DESCRIPTION
MariaDB is deprecating off its mysql client usage (has been a symlink for a very long time).

FLUSH PRIVILEGES aren't required after any creation of users or grants. It has only two very specific meenings that aren't the case here; when credentials are directly changes in underlying tables using DML, or the server was started with --skip-grant-tables and this is ending that lack of priv scheme.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
