### PR TITLE
Update NGINX example to the recommended PHP version

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -1,6 +1,6 @@
 upstream php-handler {
     server 127.0.0.1:9000;
-    #server unix:/var/run/php/php7.4-fpm.sock;
+    #server unix:/run/php/php8.2-fpm.sock;
 }
 
 # Set the `immutable` cache control options only for assets with a cache busting `v` argument

--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -63,9 +63,9 @@ server {
     # with the `ngx_pagespeed` module, uncomment this line to disable it.
     #pagespeed off;
 
-    # The settings allows you to optimize the HTTP2 bandwitdth.
+    # The settings allows you to optimize the HTTP2 bandwidth.
     # See https://blog.cloudflare.com/delivering-http-2-upload-speed-improvements/
-    # for tunning hints
+    # for tuning hints
     client_body_buffer_size 512k;
 
     # HTTP response headers borrowed from Nextcloud `.htaccess`

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -1,6 +1,6 @@
 upstream php-handler {
     server 127.0.0.1:9000;
-    #server unix:/var/run/php/php7.4-fpm.sock;
+    #server unix:/run/php/php8.2-fpm.sock;
 }
 
 # Set the `immutable` cache control options only for assets with a cache busting `v` argument

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -87,9 +87,9 @@ server {
         # with the `ngx_pagespeed` module, uncomment this line to disable it.
         #pagespeed off;
 
-        # The settings allows you to optimize the HTTP2 bandwitdth.
+        # The settings allows you to optimize the HTTP2 bandwidth.
         # See https://blog.cloudflare.com/delivering-http-2-upload-speed-improvements/
-        # for tunning hints
+        # for tuning hints
         client_body_buffer_size 512k;
 
         # HSTS settings


### PR DESCRIPTION
### ☑️ Resolves

* the Nginx example was still referencing the deprecated PHP 7.4.
* 2 typos in the descriptive comment of  `client_body_buffer_size`

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
