### PR TITLE
Specify the type for $header

### DIFF
--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -124,7 +124,7 @@ Let's assume that we need to override the email header::
 
    class MyClass extends EMailTemplate
    {
-      protected $header = <<<EOF
+      protected string $header = <<<EOF
          <table align="center" class="wrapper">
                // your theme email header modification
          </table>


### PR DESCRIPTION
When we would like to extend our class for the EMailTemplate, we have a PHP error about the type of the `$header` variable.

Because, the `$header` property is typed : https://github.com/nextcloud/server/blob/db3c731b0e4f623af264b854e9e54e5f7263e513/lib/private/Mail/EMailTemplate.php#L97 .

Please, can you change on this documentation too : https://portal.nextcloud.com/article/customized-email-templates-29.html
