### PR TITLE
Update user_2fa.rst with link to current Nitrokey

### DIFF
--- a/user_manual/user_2fa.rst
+++ b/user_manual/user_2fa.rst
@@ -82,9 +82,9 @@ You can use two-factor authentication based on hardware tokens. The following de
      *    `Nitrokey Pro <https://shop.nitrokey.com/shop/product/nitrokey-pro-2-3>`_
      *    `Nitrokey Storage <https://shop.nitrokey.com/shop>`_
 
-*    FIDO U2F based:
+*    FIDO2 based:
 
-     *    `Nitrokey FIDO U2F <https://shop.nitrokey.com/shop/product/nitrokey-fido-u2f-20>`_
+     *    `Nitrokey FIDO2 <https://shop.nitrokey.com/shop/product/nkfi2-nitrokey-fido2-55>`_
 
 Using client applications with two-factor authentication
 --------------------------------------------------------

--- a/user_manual/user_2fa.rst
+++ b/user_manual/user_2fa.rst
@@ -85,6 +85,7 @@ You can use two-factor authentication based on hardware tokens. The following de
 *    FIDO2 based:
 
      *    `Nitrokey FIDO2 <https://shop.nitrokey.com/shop/product/nkfi2-nitrokey-fido2-55>`_
+     *    `Nitrokey FIDO U2F <https://shop.nitrokey.com/shop/product/nitrokey-fido-u2f-20>`_
 
 Using client applications with two-factor authentication
 --------------------------------------------------------


### PR DESCRIPTION
Nitrokey doesn't support the FIDO U2F anymore. Instead it's now the Nitrokey FIDO2. I updated the link accordingly.