### PR TITLE
chore(git): ignore ack config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ venv
 
 Pipfile
 Pipfile.lock
+
+# ack-grep
+.ackrc


### PR DESCRIPTION
Avoid `.ackrc` showing up in *Untracked files* (provided you use ack and directory specific settings).