### PR TITLE
Fix speech to text typo

### DIFF
--- a/developer_manual/digging_deeper/speech-to-text.rst
+++ b/developer_manual/digging_deeper/speech-to-text.rst
@@ -56,13 +56,13 @@ The corresponding ``MyReferenceListener`` class can look like:
             }
 
             if ($event instanceof TranscriptionSuccessfulEvent) {
-                $transcript = $event->getTranscript()
+                $transcript = $event->getTranscript();
                 // store $transcript somewhere
             }
 
-            if ($event instanceof TranscriptionSuccessfulEvent) {
-                $error = $event->getErrorMessage()
-                $userId = $event->getUserId()
+            if ($event instanceof TranscriptionFailedEvent) {
+                $error = $event->getErrorMessage();
+                $userId = $event->getUserId();
                 // Notify relevant user about failure
             }
         }


### PR DESCRIPTION
### ☑️ Resolves

* Fix `TranscriptionFailedEvent` typo and add a few semicolons.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/20724224/c8b7627a-1ef5-4e24-a34f-1a45710a67f9)
