### PR TITLE
Correct the version of owncloud allowing migration

### DIFF
--- a/admin_manual/maintenance/migrating_owncloud.rst
+++ b/admin_manual/maintenance/migrating_owncloud.rst
@@ -17,7 +17,7 @@ See the table below for a version map, where migrating is easily possible:
 +===================+==============================+
 | 10.13.x           | 25.0.x (but at least 25.0.2) |
 +-------------------+------------------------------+
-| 10.0.5 or later   | 20.0.x (but at least 20.0.5) |
+| 10.5.x            | 20.0.x (but at least 20.0.5) |
 +-------------------+------------------------------+
 
 .. note:: Since ownCloud does not and will not support PHP 8.0 or higher, you


### PR DESCRIPTION
### ☑️ Resolves

Upgrading from owncloud is only supported from 10.5, and not from 10.0.5 as stated in the documentation. See https://github.com/nextcloud/server/blob/stable20/version.php#L43 for reference.

### 🖼️ Screenshots

<img width="749" alt="image" src="https://github.com/nextcloud/documentation/assets/1580193/a92d73f3-900b-4919-85b6-53345712cbe4">