### PR TITLE
fix: Ubuntu 22.04 installation instructions archive location

### DIFF
--- a/admin_manual/installation/example_ubuntu.rst
+++ b/admin_manual/installation/example_ubuntu.rst
@@ -44,7 +44,7 @@ You can quit the prompt by entering::
 Now download the archive of the latest Nextcloud version:
 
 * Go to the `Nextcloud Install Page <https://nextcloud.com/install>`_.
-* Go to **Download Nextcloud Server > Download Server > Community Projects** and download either the tar.bz2 or .zip archive.
+* Go to **Download Server > Community Projects** and download either the tar.bz2 or .zip archive.
 * This downloads a file named nextcloud-x.y.z.tar.bz2 or nextcloud-x.y.z.zip
   (where x.y.z is the version number).
 * Download its corresponding checksum file, e.g. nextcloud-x.y.z.tar.bz2.md5,

--- a/admin_manual/installation/example_ubuntu.rst
+++ b/admin_manual/installation/example_ubuntu.rst
@@ -43,9 +43,8 @@ You can quit the prompt by entering::
 
 Now download the archive of the latest Nextcloud version:
 
-* Go to the `Nextcloud Download Page <https://nextcloud.com/install>`_.
-* Go to **Download Nextcloud Server > Download > Archive file for
-  server owners** and download either the tar.bz2 or .zip archive.
+* Go to the `Nextcloud Install Page <https://nextcloud.com/install>`_.
+* Go to **Download Nextcloud Server > Download Server > Community Projects** and download either the tar.bz2 or .zip archive.
 * This downloads a file named nextcloud-x.y.z.tar.bz2 or nextcloud-x.y.z.zip
   (where x.y.z is the version number).
 * Download its corresponding checksum file, e.g. nextcloud-x.y.z.tar.bz2.md5,


### PR DESCRIPTION
### ☑️ Resolves

No issue number. Installation instructions describe steps that do not match the updated "Install" page, making it hard for users to find archive files. This PR updates the steps, making it clear where the user can find archives.

https://docs.nextcloud.com/server/latest/admin_manual/installation/example_ubuntu.html

### 🖼️ Screenshots
![image](https://github.com/nextcloud/documentation/assets/1692600/fd3b0e9d-552c-4895-9d60-ca66db107997)

**NOTE:** This is my first PR updating docs. If I did anything wrong, please do let me know. Thanks.