### PR TITLE
enh(userstatus): set user status to 'In a meeting' if calendar is busy

### DIFF
--- a/user_manual/groupware/calendar.rst
+++ b/user_manual/groupware/calendar.rst
@@ -265,6 +265,13 @@ The ``Empty trash bin`` buttons will wipe all trash bin contents in one step.
 
 .. _calendar-working-hours:
 
+Automated User Status
+~~~~~~~~~~~~~~~~~~~~~
+
+When you have a calendar event scheduled that has a "BUSY" status, your user status will be automatically set to "In a meeting" unless you have set yourself to "Do Not Disturb" or "Invisible".
+You can overwrite the status with a custom message any time, or set your calendar events to "FREE".
+Calendars that are transparent will be ignored.
+
 Responding to invitations
 -------------------------
 


### PR DESCRIPTION
### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/7427347/0bfb6f0b-6158-4a38-bb02-0713203605a0)



<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
