### PR TITLE
Update config_sample_php_parameters.rst

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -3302,13 +3302,13 @@ specifications. For those, have an opt-out.
 
 WARNING: only use this if you know what you are doing
 
-simpleSignUpLink.shown
+simpleSignUpLink
 ^^^^^^^^^^^^^^^^^^^^^^
 
 
 ::
 
-	'simpleSignUpLink.shown' => true,
+	'simpleSignUpLink' => true,
 
 By default, there is on public pages a link shown that allows users to
 learn about the "simple sign up" - see https://nextcloud.com/signup/


### PR DESCRIPTION
update to docs for config.php as the system does not check  `simpleSignUpLink.shown`, rather it checks `simpleSignUpLink` (with no sub property) to control this functionality.

### ☑️ Resolves

* unexplained confusion from forums because the docs are just out of sync with the current version.

### 🖼️ Screenshots

N/A
