### PR TITLE
correct variable name

### DIFF
--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -99,7 +99,7 @@ You can use simple callback to react on events. They will receive the event obje
     class Application extends App {
         public function __construct() {
             parent::__construct('myapp');
-                /* @var IEventDispatcher $eventDispatcher */
+                /* @var IEventDispatcher $dispatcher */
                 $dispatcher = $this->getContainer()->query(IEventDispatcher::class);
                 $dispatcher->addListener(AddEvent::class, function(AddEvent $event) {
                     // ...


### PR DESCRIPTION
It seems the type-hinting comment should be about the `$dispatcher` variable on the line below it.
