### PR TITLE
Fix(email_configuration): Fix conflicting debug mode sections

### DIFF
--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -259,12 +259,24 @@ of the Admin settings page.
 Troubleshooting
 ---------------
 
-If you are unable to send email, try turning on debugging. Do this by enabling
-the ``mail_smtpdebug`` parameter in ``config/config.php``.
+Enabling debug mode
+"""""""""""""""""""
+
+If you are unable to send email, it might be useful to activate further debug
+messages by enabling the ``mail_smtpdebug`` parameter and temporarily setting your NC loglevel to DEBUG:
 
 ::
 
-    "mail_smtpdebug" => true;
+    "mail_smtpdebug" => true,
+    "loglevel" => 0,
+
+Be cautious setting your ``loglevel`` to DEBUG (``0``) since it'll apply to everything occurring on your NC instance, not just email. 
+And don't forget to set it back to a more reasonable level when you're done troubleshooting:
+
+::
+
+    "mail_smtpdebug" => false,
+    "loglevel" => 2,
 
 .. note:: Immediately after pressing the **Send email** button, as described
    before, several **SMTP -> get_lines(): ...** messages appear on the screen.
@@ -395,25 +407,6 @@ All emails keep getting rejected even though only one email address is invalid.
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Partial sending, i. e. sending to all but the faulty email address is not possible.
-
-Enabling debug mode
--------------------
-
-If you are unable to send email, it might be useful to activate further debug
-messages by enabling the ``mail_smtpdebug`` parameter and temporarily setting your NC loglevel to DEBUG:
-
-::
-
-    "mail_smtpdebug" => true,
-    "loglevel" => 0,
-
-Be cautious setting your ``loglevel`` to DEBUG (``0``) since it'll apply to everything occurring on your NC instance, not just email. 
-And don't forget to set it back to a more reasonable level when you're done troubleshooting:
-
-::
-
-    "mail_smtpdebug" => false,
-    "loglevel" => 2,
 
 .. note:: Immediately after pressing the **Send email** button, as described
    before, several **SMTP -> get_lines(): ...** messages appear on the screen.


### PR DESCRIPTION
`mail_smtpdebug` was being described in two places, one of which was incomplete (it didn't note the requirement to also change `loglevel` to `0`... leading to confusion).

* Removes the inaccurate spot and moves the accurate one into its place so there are no longer two debug logging sections
* Existing language/links retained 

### ☑️ Resolves

* Fix nextcloud/server#42946

### 🖼️ Screenshots

(On mobile sorry)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
