### PR TITLE
fix(admin): Update supported database support

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -23,9 +23,9 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - openSUSE Leap 15.5                                                  |
 |                  | - CentOS Stream                                                       |
 +------------------+-----------------------------------------------------------------------+
-| Database         | - **MySQL 8.0+** or MariaDB 10.3/10.4/10.5/**10.6** (recommended)     |
+| Database         | - **MySQL 8.0+** or MariaDB 10.3/10.5/**10.6** (recommended)/10.11    |
 |                  | - Oracle Database 11g (*only as part of an enterprise subscription*)  |
-|                  | - PostgreSQL 10/11/12/13/14/15                                        |
+|                  | - PostgreSQL 12/13/14/15/16                                           |
 |                  | - SQLite (*only recommended for testing and minimal-instances*)       |
 +------------------+-----------------------------------------------------------------------+
 | Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |


### PR DESCRIPTION
### ☑️ Resolves

* Resolves https://github.com/nextcloud-gmbh/server/issues/721
  * We need support for mariadb 10.11 as this is the only version provided by our supported Debian 12 version
  * mariadb 10.4 is not used by any supported or used distribution and EOL with Nextcloud 29
  * mariadb 10.3 is EOL but we need to keep support as long as we support Ubuntu 20.04
  * Postgres 10 and 11 are EOL and not used by any distribution we support or is used, all distributions also provide at least Postgres 12

BTW mariadb 10.11 is the current LTS version.