### PR TITLE
fix(devmanual): Move cached data out of database performance section

### DIFF
--- a/developer_manual/digging_deeper/performance.rst
+++ b/developer_manual/digging_deeper/performance.rst
@@ -106,17 +106,17 @@ Transactions are crucial for changes that belong together but they can cause pro
 
   Look out for messages like ``Transaction took longer than 1s: 7.1270351409912`` and ``Transaction rollback took longer than 1s: 1.2153599501``.
 
-Cached data
-^^^^^^^^^^^
-
-Starting from Nextcloud 26, user and group display names now are cached. Use the ``IUserManager::getDisplayName`` or ``IGroupManager::getDisplayName`` functions to avoid roundtrips to the database.
-
 Measuring performance
 ^^^^^^^^^^^^^^^^^^^^^
 
 If you do bigger changes in the architecture or the database structure you should always double check the positive or negative performance impact.
 
 The recommendation is to automatically do 10000 PROPFINDs or file uploads, measure the time and compare the time before and after the change.
+
+Cached data
+-----------
+
+Starting from Nextcloud 26, user and group display names now are cached. Use the ``IUserManager::getDisplayName`` or ``IGroupManager::getDisplayName`` functions to avoid roundtrips to the database.
 
 Getting help
 ------------


### PR DESCRIPTION
Cached data is not specific to db access. Moving it out.

### 🖼️ Screenshots

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2024-02-01 18-32-26](https://github.com/nextcloud/documentation/assets/1374172/8ca75ec9-327c-489a-9bb3-0a46c9772f48) | ![Bildschirmfoto vom 2024-02-01 18-31-39](https://github.com/nextcloud/documentation/assets/1374172/d9233e48-c523-478a-8443-99841745839a) | 

Ref https://github.com/nextcloud/documentation/pull/10026


