### PR TITLE
fix(background_jobs_configuration) Add example

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -31,7 +31,17 @@ for this config, the background jobs which advertise themselves as not time-sens
 will be delayed during the "working" hours and only run in the 4 hours after the given
 time. This is e.g. used for activity expiration, suspicious login training, and update checks.
 
-A value of 1 e.g. will only run these background jobs between 01:00am UTC and 05:00am UTC.
+A value of 1 e.g. will only run these background jobs between 01:00am UTC and 05:00am UTC::
+
+  'maintenance_window_start' => 1,
+
+If you don't care when these jobs run, you can set the value to ``100``, but beware that 
+resource intensive jobs may then run unnecessarily during high usage periods. This may lead to
+slower performance and a lower quality user experience.
+
+This setting may also be set directly via ``occ`` just like any other configuration parameter::
+
+  occ config:system:set maintenance_window_start --type=integer --value=1
 
 Cron jobs
 ---------


### PR DESCRIPTION
### ☑️ Resolves

Since this parameter hit the setup checks in NC28, the link goes here but there isn't a full config example. This adds:

- a working example
- an additional sentence about using `100` to disable this feature and the impact of doing so
- a quick `occ` command to set as well

Addresses queries that keep popping up in the Help Forums.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1731941/271ff786-d2ba-4af4-b2bc-8abfe4683422)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
