### PR TITLE
fix(developer)!: oc_share table is now only for files and folders

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
@@ -66,6 +66,8 @@ Removed APIs
 ^^^^^^^^^^^^
 
 * ``OCP\Log\ILogFactory::getCustomLogger``: use ``\OCP\Log\ILogFactory::getCustomPsrLogger`` to get a customized :ref:`PSR3 <psr3>` logger
+* ``oc_share`` table: Due to massive performance impact on queries when selecting additionally for ``item_type``,
+  it is no longer allowed, to use the ``oc_share`` table for any other types than ``file`` and ``folder``.
 
 Added events
 ^^^^^^^^^^^^


### PR DESCRIPTION
### 🖼️ Screenshots
![Bildschirmfoto vom 2024-02-08 14-47-00](https://github.com/nextcloud/documentation/assets/213943/f93a06d2-e89e-4712-b436-c934574a5e36)


