### PR TITLE
feat: Document removal of OC version of background job classes

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
@@ -68,6 +68,7 @@ Removed APIs
 * ``OCP\Log\ILogFactory::getCustomLogger``: use ``\OCP\Log\ILogFactory::getCustomPsrLogger`` to get a customized :ref:`PSR3 <psr3>` logger
 * ``oc_share`` table: Due to massive performance impact on queries when selecting additionally for ``item_type``,
   it is no longer allowed, to use the ``oc_share`` table for any other types than ``file`` and ``folder``.
+* ``OC\BackgroundJob\Job``, ``OC\BackgroundJob\QueuedJob`` and ``OC\BackgroundJob\TimedJob``: use the ``OCP`` versions.
 
 Added events
 ^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

See https://github.com/nextcloud/server/pull/43387

### 🖼️ Screenshots

![Screenshot_20240220_090922](https://github.com/nextcloud/documentation/assets/91878298/4afde656-6152-445d-a989-564801dd9a76)

