### PR TITLE
docs(admin): Fix name of Collabora Nextcloud integration app

### DIFF
--- a/admin_manual/office/example-docker.rst
+++ b/admin_manual/office/example-docker.rst
@@ -92,9 +92,10 @@ After configuring these do restart your apache using ``systemctl restart apache2
 Configure the app in Nextcloud
 *********************************
 
-Go to the Apps section and choose "Office & text"
-Install the "Collabora Online app"
-Admin -> Office -> Specify the server you have setup before (e.g. "https://office.example.com")
+- Go to the Apps section and choose "Office & text"
+- Install the "Nextcloud Office" app
+- Go to Admin -> Office -> Specify the server you have setup before (e.g. "https://office.example.com")
+
 Congratulations, your Nextcloud has Collabora Online Office integrated!
 
 


### PR DESCRIPTION
Updates the Collabora integration app to the current name ("Nextcloud Office").

### ☑️ Resolves

* Fix #11559 

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
