### PR TITLE
docs(admin): Emphasize recommended versions in db chapter

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -10,14 +10,14 @@ Nextcloud requires a database in which administrative data is stored. The follow
 
 The MySQL or MariaDB databases are the recommended database engines.
 
-.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`System Requirements`<../installation/system_requirements>`
+.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`System Requirements`<../installation/system_requirements>
    before settling on a particular version.
 
 Requirements
 ------------
 
 * Decide whether you wish to use MySQL / MariaDB, PostgreSQL, or Oracle as your database
-* Pick a recommendeded version of your database by checking the Nextcloud :doc:`System Requirements`<../installation/system_requirements>`
+* Pick a recommendeded version of your database by checking the Nextcloud :doc:`System Requirements`<../installation/system_requirements>
 * Install and set up the chosen database server software (and preferrred version) before deploying Nextcloud Server
 
 .. note:: The steps for configuring a third party database are beyond the

--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -10,13 +10,13 @@ Nextcloud requires a database in which administrative data is stored. The follow
 
 The MySQL or MariaDB databases are the recommended database engines.
 
-.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :ref:`system_requirements`
+.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`system_requirements`
 
 Requirements
 ------------
 
 * Decide whether you wish to use MySQL / MariaDB, PostgreSQL, or Oracle as your database
-* Pick a recommendeded version of your database by checking the Nextcloud :ref:`system_requirements`
+* Pick a recommendeded version of your database by checking the Nextcloud :doc:`system_requirements`
 * Install and set up the chosen database server software (and preferrred version) before deploying Nextcloud Server
 
 .. note:: The steps for configuring a third party database are beyond the

--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -10,13 +10,13 @@ Nextcloud requires a database in which administrative data is stored. The follow
 
 The MySQL or MariaDB databases are the recommended database engines.
 
-.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`system_requirements`
+.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`../installation/system_requirements`
 
 Requirements
 ------------
 
 * Decide whether you wish to use MySQL / MariaDB, PostgreSQL, or Oracle as your database
-* Pick a recommendeded version of your database by checking the Nextcloud :doc:`system_requirements`
+* Pick a recommendeded version of your database by checking the Nextcloud :doc:`../installation/system_requirements`
 * Install and set up the chosen database server software (and preferrred version) before deploying Nextcloud Server
 
 .. note:: The steps for configuring a third party database are beyond the

--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -10,13 +10,14 @@ Nextcloud requires a database in which administrative data is stored. The follow
 
 The MySQL or MariaDB databases are the recommended database engines.
 
-.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`../installation/system_requirements`
+.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`System Requirements`<../installation/system_requirements>`
+   before settling on a particular version.
 
 Requirements
 ------------
 
 * Decide whether you wish to use MySQL / MariaDB, PostgreSQL, or Oracle as your database
-* Pick a recommendeded version of your database by checking the Nextcloud :doc:`../installation/system_requirements`
+* Pick a recommendeded version of your database by checking the Nextcloud :doc:`System Requirements`<../installation/system_requirements>`
 * Install and set up the chosen database server software (and preferrred version) before deploying Nextcloud Server
 
 .. note:: The steps for configuring a third party database are beyond the

--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -10,11 +10,14 @@ Nextcloud requires a database in which administrative data is stored. The follow
 
 The MySQL or MariaDB databases are the recommended database engines.
 
+.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :ref:`system_requirements`
+
 Requirements
 ------------
 
-Choosing to use MySQL / MariaDB, PostgreSQL, or Oracle as your database
-requires that you install and set up the server software first.
+* Decide whether you wish to use MySQL / MariaDB, PostgreSQL, or Oracle as your database
+* Pick a recommendeded version of your database by checking the Nextcloud :ref:`system_requirements`
+* Install and set up the chosen database server software (and preferrred version) before deploying Nextcloud Server
 
 .. note:: The steps for configuring a third party database are beyond the
   scope of this document.  Please refer to the documentation for your specific

--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -10,14 +10,14 @@ Nextcloud requires a database in which administrative data is stored. The follow
 
 The MySQL or MariaDB databases are the recommended database engines.
 
-.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`System Requirements`<../installation/system_requirements>
+.. tip:: Not all versions of every supported database are recommended. Please review the Nextcloud :doc:`System Requirements <../installation/system_requirements>`
    before settling on a particular version.
 
 Requirements
 ------------
 
 * Decide whether you wish to use MySQL / MariaDB, PostgreSQL, or Oracle as your database
-* Pick a recommendeded version of your database by checking the Nextcloud :doc:`System Requirements`<../installation/system_requirements>
+* Pick a recommendeded version of your database by checking the Nextcloud :doc:`System Requirements <../installation/system_requirements>`
 * Install and set up the chosen database server software (and preferrred version) before deploying Nextcloud Server
 
 .. note:: The steps for configuring a third party database are beyond the


### PR DESCRIPTION
### ☑️ Resolves

More strongly emphasize that picking the *version* of your preferred database is also important. 

- Mention it
- Link to system requirements
- Add a note call-out
- Clarify the steps for db deployment as bullet points for the reader

Context: Some people merely use the `latest` tags their MariaDB Docker stacks or install the latest from vendor repositories without paying attention to the versions recommended by us. Not surprisingly they run into problems from time to time (like the latest breaking changes that were in MariaDB 11.3.x images -- which we don't even support since it's a short-term release). 

Every little nudge in the right direction helps.

Side note: Anyone know why the Database config section isn't just a chapter under *Installation and server configuration*? It's kind of weird that it's arbitrarily near the end of the Admin Manual, since it's a prerequisite to any deployment.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1731941/d331d39f-1b9d-4b26-b9a0-1d6a12275c1b)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
