### PR TITLE
in text: "bruteforce" > "brute force"

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -606,7 +606,7 @@ auth.bruteforce.protection.enabled
 
 	'auth.bruteforce.protection.enabled' => true,
 
-Whether the bruteforce protection shipped with Nextcloud should be enabled or not.
+Whether the brute force protection shipped with Nextcloud should be enabled or not.
 
 Disabling this is discouraged for security reasons.
 
@@ -620,9 +620,9 @@ auth.bruteforce.protection.testing
 
 	'auth.bruteforce.protection.testing' => false,
 
-Whether the bruteforce protection shipped with Nextcloud should be set to testing mode.
+Whether the brute force protection shipped with Nextcloud should be set to testing mode.
 
-In testing mode bruteforce attempts are still recorded, but the requests do
+In testing mode brute force attempts are still recorded, but the requests do
 not sleep/wait for the specified time. They will still abort with
 "429 Too Many Requests" when the maximum delay is reached.
 Enabling this is discouraged for security reasons


### PR DESCRIPTION
In description text we should use correct spelling which is "brute force" or "brute-force", not "bruteforce". 

In other parts of the documentation, "brute force" is used: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/bruteforce_configuration.html

See also https://en.wikipedia.org/wiki/Brute-force_attack

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
