### PR TITLE
Fix warning for data-directory troubleshooting

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -386,7 +386,7 @@ Unofficially moving the data directory can be done as follows:
 6. Ensure permissions are still correct
 7. Restart apache
 
-.. warning
+.. warning::
    However this is not supported and you risk breaking your database.
 
 For a safe moving of data directory, supported by Nextcloud, recommended actions are:
@@ -398,7 +398,7 @@ For a safe moving of data directory, supported by Nextcloud, recommended actions
 5. Ensure permissions are still correct
 6. Restart apache
 
-.. warning
+.. warning::
    Note, you may need to configure your webserver to support symlinks.
 
 Troubleshooting quota or size issues


### PR DESCRIPTION
Noticed that the warning is in the files, but not rendered currently.

### 🖼️ Screenshots

Before:
<img width="769" alt="Bildschirmfoto 2024-02-27 um 23 28 06" src="https://github.com/nextcloud/documentation/assets/1580193/f1658bf5-62aa-41a5-a5fe-5024796e18c6">

After:
<img width="764" alt="image" src="https://github.com/nextcloud/documentation/assets/1580193/73959c25-059d-4258-a823-daee58c9a05f">
