### PR TITLE
feat: Add documentation for app-updated notifications for Nextcloud 29

### DIFF
--- a/admin_manual/apps_management.rst
+++ b/admin_manual/apps_management.rst
@@ -62,6 +62,25 @@ update all apps.
 .. note:: **Beta releases**: You can also install beta releases of apps directly from here by 
           switching your Nextcloud to the beta channel in the admin overview.
 
+Update notifications
+^^^^^^^^^^^^^^^^^^^^
+
+The always installed ``updatenotification`` app allows administrators to be notified on available app and Nextcloud updates.
+Moreover, since Nextcloud 29, this app also allows to notify users about updated apps and the changes that are included in the update.
+This notification is enabled by default if the app provides a changelog.
+
+To disable user notifications use:
+
+::
+
+  occ config:app:set --type boolean --value="false" updatenotification app_updated.enabled
+
+By default guest users, when using the guests app, are not notified, to enable notifications also for them use:
+
+::
+
+  occ config:app:set --type boolean --value="true" updatenotification app_updated.notify_guests
+
 Using private API
 -----------------
 

--- a/developer_manual/app_development/info.rst
+++ b/developer_manual/app_development/info.rst
@@ -378,3 +378,15 @@ The following elements are either deprecated or for internal use only and will f
 * **remote**
 * **requiremin**
 * **requiremax**
+
+.. _app changelog:
+
+Changelog
+---------
+
+Apps can provide a changelog. This should be written in the `keep a changelog <https://keepachangelog.com/>`_.
+
+If the apps provide a ``CHANGELOG.md`` file in the project root, this file will be used to show changes for the released version in the app store and for administrators in the app settings.
+
+Moreover, since Nextcloud 29, if the ``updatenotification`` app is enabled, apps can also provide a changelog for the users.
+The app will notify users about after the app update if either a ``CHANGELOG.language.md`` (where ``language`` is the language code of that user) or a fallback ``CHANGELOG.en.md`` is available.

--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
@@ -6,6 +6,8 @@ General
 -------
 
 * The Circles app will be renamed to Teams. Apps that use the terms Circle/Circles need to get adjusted to use Team/Teams instead. For example ``share to circle`` would become ``share to team``.
+* The ``updatenotification`` app now also supports notifications for apps that were updated.
+  If the updated app provides a ``CHANGELOG.language.md`` or ``CHANGELOG.en.md`` file, it will create notifications for users about these changes. See also the :ref:`app changelog<app changelog>` section.
 
 info.xml
 ^^^^^^^^


### PR DESCRIPTION
## ☑️ Resolves

* For https://github.com/nextcloud/server/pull/43967

## 🖼️ Screenshots

### Admin
![Screenshot 2024-03-08 at 00-50-04 Apps management — Nextcloud latest Administration Manual latest documentation](https://github.com/nextcloud/documentation/assets/1855448/33ef81ff-31e8-407e-9dea-93562896610b)


### Developer
![Screenshot 2024-03-08 at 00-49-23 Upgrade to Nextcloud 29 — Nextcloud latest Developer Manual latest documentation](https://github.com/nextcloud/documentation/assets/1855448/0e40ce2c-6131-49bc-97af-770fa421031f)
![Screenshot 2024-03-08 at 00-49-10 App metadata — Nextcloud latest Developer Manual latest documentation](https://github.com/nextcloud/documentation/assets/1855448/ec50173b-8e29-452a-bae4-ffa0900e927c)
