### PR TITLE
Document occ encryption drop legacy filekey and fix obsolete statement

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -28,10 +28,8 @@ Encryption and decryption are performed on the Nextcloud server. All files sent
 to remote storage will be encrypted by the Nextcloud server, and upon retrieval, 
 decrypted before serving them to you and anyone you have shared them with.
 
-.. note:: Encrypting files increases their size by roughly 35%, so you must 
-   take this into account when you are provisioning storage and setting 
-   storage quotas. User's quotas are based on the unencrypted file size, and 
-   not the encrypted file size.
+.. note:: Encryption files generate a slight overhead in size by ~1% (35% before Nextcloud 25).
+   User's quotas are based on the unencrypted file size, and not the encrypted file size.
 
 When files on external storage are encrypted in Nextcloud, you cannot share them 
 directly from the external storage services, but only through Nextcloud sharing 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -641,6 +641,7 @@ Encryption
   encryption:decrypt-all               Disable server-side encryption and
                                        decrypt all files
   encryption:disable                   Disable encryption
+  encryption:drop-legacy-filekey       Drop legacy filekey for files still using it
   encryption:enable                    Enable encryption
   encryption:enable-master-key         Enable the master key. Only available
                                        for fresh installations with no existing
@@ -702,6 +703,13 @@ user data instead of individual user keys. This is especially useful to enable
 single-sign on. Use this only on fresh installations with no existing data, or
 on systems where encryption has not already been enabled. It is not possible to
 disable it.
+
+``encryption:drop-legacy-filekey`` scans the files for the legacy filekey
+format using RC4 and get rid of it (if master key is enabled). The operation can
+be quite slow as it needs to rewrite each encrypted file. If you do not do it files
+will be migrated to drop their legacy filekey on the first modification. If you have
+old files from Nextcloud<25 still using base64 encoding this will migrate them to the
+binary format and save about 33% disk space.
 
 See :doc:`../configuration_files/encryption_configuration` to learn more.
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11539 

### 🖼️ Screenshots

![Copie d'écran_20240308_144314](https://github.com/nextcloud/documentation/assets/91878298/3e23020d-8a5a-4702-b684-436a98408c29)
![Copie d'écran_20240308_144457](https://github.com/nextcloud/documentation/assets/91878298/58858500-11a5-4773-8cd9-8f1dc2304e34)
