### PR TITLE
fix(configuration): [reverse proxy] Correct errors in `Multiple domains reverse SSL proxy` example

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -167,7 +167,7 @@ you can set the following parameters inside the :file:`config/config.php`.
     'overwriteprotocol' => 'https',
     'overwritewebroot'  => '/domain.tld/nextcloud',
     'overwritecondaddr' => '^10\.0\.0\.1$',
-    'overwrite.cli.url' => 'https://domain.tld/,
+    'overwrite.cli.url' => 'https://ssl-proxy.tld/domain.tld/',
   );
 
 .. note:: If you want to use the SSL proxy during installation you have to


### PR DESCRIPTION
The ' was missing. Maybe the url off the ssl proxy also?

