### PR TITLE
feat(developer): Add attribute routing to 29 upgrade guide

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
@@ -36,6 +36,11 @@ Removed globals
 Back-end changes
 ----------------
 
+Added APIs
+^^^^^^^^^^
+
+* The Attributes ``OCP\AppFramework\Http\Attribute\ApiRoute`` and ``OCP\AppFramework\Http\Attribute\FrontpageRoute`` can be used for routing registering routes. See :doc:`/basics/routing` for documentation.
+
 Changed APIs
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
Should have been added in https://github.com/nextcloud/documentation/pull/11442 already.