### PR TITLE
fix(developer): Document the change of the _route parameter

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
@@ -46,6 +46,7 @@ Changed APIs
 
 * ``OCP\IURLGenerator::URL_REGEX_NO_MODIFIERS``: Changed to match localhost and hostnames with ports.
 * ``OCP\Files\IMimeTypeLoader``: Every method from this interface now has type declarations. Make sure to update your implementation if you have one.
+* ``OCP\IRequest::getParam('_route')`` and ``OCP\IRequest::getParams()['_route']``: The route name (consisting of app ID, controller name and controller method) is now all lower case
 
 Removed APIs
 ^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

* Breaking change from https://github.com/nextcloud/server/pull/42801/files#diff-e9bf496c8b197d60a7640f88f6fc4b5ff13cd41657c4e14f225ede16797e721eR139-R145
* Created an issue in talk https://github.com/nextcloud/spreed/pull/11863
* I saw the method being used in multiple apps and just by luck all of them had a "single word namespace" (photos, profiler, ...) and all of them only checked for the app id or controller name. But I think it still makes sense to document this.

### 🖼️ Screenshots

![grafik](https://github.com/nextcloud/documentation/assets/213943/84d82431-fe4a-49fc-9099-7bdca05e9430)
