### PR TITLE
docs(admin): Adjust + automate ordering of Configuration chapter

### DIFF
--- a/admin_manual/configuration_server/index.rst
+++ b/admin_manual/configuration_server/index.rst
@@ -4,26 +4,9 @@ Nextcloud configuration
 
 .. toctree::
    :maxdepth: 2
+   :glob:
 
    security_setup_warnings
    occ_command
-   activity_configuration
-   caching_configuration
-   background_jobs_configuration
    config_sample_php_parameters
-   email_configuration
-   external_sites
-   language_configuration
-   logging_configuration
-   antivirus_configuration
-   dashboard_configuration
-   reverse_proxy_configuration
-   bruteforce_configuration
-   automatic_configuration
-   text_configuration
-   theming
-   oauth2
-   admin_delegation_configuration
-   domain_change
-
-.. Intentional disabled antivirus_configuration
+   *


### PR DESCRIPTION
Make sure the following are always first:

- "Warnings on admin page"
- "Using the occ command"
- "Configuration Parameters"

Then:

- Include everything else automatically using glob (i.e. without require this index.rst be updated when adding new sections)
- Automatically alphabetize glob included sections

Note: At the moment it alphabetizes based on the underlying filename so some of the glob added ones will still have a funny order, but my primary motivation for this change was to pull *Configuration Parameters* out of hiding. The auto-adding and alphabetizing was more a bonus.

### ☑️ Resolves

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1731941/52940d6b-e96f-4f1a-8117-781a31a4e017)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
