### PR TITLE
docs(admin): Update Android system requirements to 7

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -111,13 +111,13 @@ Files App
 ^^^^^^^^^
 
 - **iOS** 15.0+
-- **Android** 6.0+
+- **Android** 7.0+
 
 Talk App
 ^^^^^^^^
 
 - **iOS** 15.0+
-- **Android** 6.0+
+- **Android** 7.0+
 - **Nextcloud Server** 14.0+
 - **Nextcloud Talk** 4.0+
 


### PR DESCRIPTION
### ☑️ Resolves

* Fixes nextcloud/android#12758
* Documents nextcloud/talk-android#2886 & nextcloud/android#11474

Already documented/required in the Play Store entries for both Files and Talk apps. So not a policy change; just documenting what's already reality.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
