### PR TITLE
docs(tuning): add warning for Imaginary+HEIC

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -168,6 +168,11 @@ external microservice: `Imaginary <https://github.com/h2non/imaginary>`_.
    Imaginary is currently incompatible with server-side-encryption. 
    See https://github.com/nextcloud/server/issues/34262
 
+.. warning::
+
+   Imaginary is currently known to have issues with HEIC images.
+   See https://github.com/nextcloud/server/issues/35643
+
 We strongly recommend running our custom docker image that is more up to date than the official image.
 You can find the image at `docker.io/nextcloud/aio-imaginary:latest`.
 


### PR DESCRIPTION
Autorotation is (still) broken [and disabled](https://github.com/nextcloud/server/blob/b5c1766d336e376319ac77289cbc8f6f299e3f20/lib/private/Preview/Imaginary.php#L92-L93
) on HEIC for Imaginary (it just stalls on certain images); this leads to unexpectedly rotated previews scattered around which is hard to debug (e.g. https://github.com/pulsejet/memories/issues/1120).

While this PR just documents the issue, is there still any point recommending Imaginary? I ran some tests and found no evidence to suggest it did any better than Imagick or GD for preview generation in terms of performance (I understand vips is likely better for image manipulation, but that's not really what we're doing here). Actually it's worse for HEIC at least (funny considering IIRC both Imagick and Imaginary use libheif).

Either way it seems counterproductive to recommend something that has known serious issues with a format used by half the mobile devices in the world (at least; even my Samsung shoots HEIC now).