### PR TITLE
docs(admin): Document MultipartUpload for uploading chunks to s3

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -174,6 +174,8 @@ to the actual file on the Nextcloud servers temporary directory. It is recommend
 the size of your temp directory accordingly and also ensure that request timeouts are high
 enough for PHP, webservers or any load balancers involved.
 
+.. tip:: In more recent versions of Nextcloud Server, when uploading to S3 in *Primary Storage* mode, we use S3 `MultipartUpload`. This allows chunked upload streaming of the chunks directly to S3 so that the final MOVE request no longer needs to assemble the final file on the Nextcloud server. This requires your ``memcache.distributed`` to be set to use Redis (or Memcached), otherwise we fall back on the prior behavior which consumes space on the Nextcloud Server for file assembly (as described above).
+
 Federated Cloud Sharing
 -----------------------
 


### PR DESCRIPTION

### ☑️ Resolves

Adds a clarifying note to the "Large file upload on object storage" section about MultipartUpload support that was added awhile back in nextcloud/server#27034.

Aside: *This entire chapter could use some love to make it more cohesive and approachable - due to all the additions made over time - but I don't have time to edit the entire chapter right now. :) So, for now, just wanted to at least get this in there so it's covered.*

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
