### PR TITLE
fix(developer): Add deprecation of `OC.dialogs.fileexists` to upgrade…

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_29.rst
@@ -33,6 +33,11 @@ Removed globals
 
 * Global ``autosize`` is removed, it was deprecated for over 4 years and scheduled for removal with Nextcloud 20. If you still need it you should ship your own version.
 
+Deprecated APIs
+^^^^^^^^^^^^^^^
+
+* ``OC.dialogs.fileexists`` is deprecated. Use ``openConflictPicker`` from `@nextcloud/upload <https://nextcloud-libraries.github.io/nextcloud-upload/functions/openConflictPicker.html>`_ instead.
+
 Back-end changes
 ----------------
 

--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
@@ -20,6 +20,12 @@ Removed APIs
 Removed globals
 ^^^^^^^^^^^^^^^
 
+Deprecated APIs
+^^^^^^^^^^^^^^^
+
+* ``OC.dialogs.fileexists`` was already deprecated in Nextcloud 29, but is now also marked as such.
+  Use ``openConflictPicker`` from `@nextcloud/upload <https://nextcloud-libraries.github.io/nextcloud-upload/functions/openConflictPicker.html>`_ instead.
+
 Back-end changes
 ----------------
 


### PR DESCRIPTION
… guide

### ☑️ Resolves

* For https://github.com/nextcloud/server/pull/44756

### 🖼️ Screenshots

![Screenshot 2024-04-09 at 20-14-44 Upgrade to Nextcloud 30 — Nextcloud latest Developer Manual latest documentation](https://github.com/nextcloud/documentation/assets/1855448/44f01331-b2c9-4e8c-bc1f-d1877186ac11)

