### PR TITLE
fix(developer): Deprecate `OC.dialogs`

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
@@ -32,6 +32,16 @@ Deprecated APIs
 
 * ``OC.dialogs.fileexists`` was already deprecated in Nextcloud 29, but is now also marked as such.
   Use ``openConflictPicker`` from `@nextcloud/upload <https://nextcloud-libraries.github.io/nextcloud-upload/functions/openConflictPicker.html>`_ instead.
+* Most ``OC.dialogs`` API is now deprecated and will be removed in the future. For generic dialogs use the ``DialogBuilder`` from the :ref:`js-library_nextcloud-dialogs`.
+  A list of the now deprecated methods:
+
+  * ``OC.dialogs.alert``
+  * ``OC.dialogs.info``
+  * ``OC.dialogs.confirm``
+  * ``OC.dialogs.confirmDestructive``
+  * ``OC.dialogs.confirmHtml``
+  * ``OC.dialogs.prompt``
+  * ``OC.dialogs.message``
 
 Back-end changes
 ----------------

--- a/developer_manual/digging_deeper/javascript-apis.rst
+++ b/developer_manual/digging_deeper/javascript-apis.rst
@@ -57,6 +57,8 @@ This package provides an `Axios <https://www.npmjs.com/package/axios>`_ HTTP cli
 
 This package provides a simple event bus implementation that integrates with server and other apps. Thus it is one of the recommended ways of inter-app communication. Documentation: https://nextcloud-libraries.github.io/nextcloud-event-bus/
 
+.. _js-library_nextcloud-dialogs:
+
 ``@nextcloud/dialogs``
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### ☑️ Resolves

* For: https://github.com/nextcloud/server/pull/44755

### 🖼️ Screenshots

![Screenshot 2024-04-09 at 20-28-35 Upgrade to Nextcloud 30 — Nextcloud latest Developer Manual latest documentation](https://github.com/nextcloud/documentation/assets/1855448/918d5959-0215-4224-af62-b558c4349a22)
