### PR TITLE
feat(developers): Document trash item deleted by method

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
@@ -80,6 +80,7 @@ Added APIs
 - ``OCP\Notification\IncompleteParsedNotificationException`` is thrown by ``OCP\Notification\IManager::prepare()`` when no ``OCP\Notification\INotifier`` handled the ``OCP\Notification\INotification`` object
 - ``OCP\Notification\InvalidValueException`` is thrown by ``OCP\Notification\IAction::set*()`` and ``OCP\Notification\INotification::set*()`` when the value did not match the required criteria
 - ``OCP\Notification\UnknownNotificationException`` should be thrown by ``OCP\Notification\INotifier::prepare()`` when they didn't handle the notification
+- ``OCA\Files_Trashbin\Trash\ITrashItem::getDeletedBy`` should return the user who deleted the item or null if unknown
 
 Changed APIs
 ^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

- Resolve https://github.com/nextcloud/server/pull/44643#pullrequestreview-2016418149

- The custom trash backends in groupfolders and collectives will need to be updated to support this API (technically non-public) to not break anything

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/24800714/179449da-c853-4b1e-a008-6bcfb070230b)