### PR TITLE
Add option to db indices to occ_command.rst

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -632,6 +632,8 @@ following command::
 
  sudo -u www-data php occ db:add-missing-indices
 
+Use option ``--dry-run`` to output the SQL queries without running them.
+
 .. _encryption_label:
 
 Encryption


### PR DESCRIPTION
An option `--dry-run` for the adding db-indices seems to be available but not documented (https://github.com/nextcloud/server/blob/2c059dd606f923e5fd689815a09a263bed1c25fd/core/Command/Db/AddMissingIndices.php#L65C17-L65C24)

### ☑️ Resolves

* Fix #11767

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
