### PR TITLE
fix(Requirements): Memory constrained environments

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -55,6 +55,11 @@ depending on the numbers of users, apps, files and volume of server activity.
 
 Nextcloud needs a minimum of **128MB** RAM per process, and we recommend a minimum of **512MB** RAM per process.
 
+In low memory environments, some features or apps may require adjustments to their default 
+settings in order to function (or, in some cases, may need to be disabled outright).
+
+.. warning:: To use the built-in Updater, at least 256MB is required.
+
 Database requirements for MySQL / MariaDB
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### ☑️ Resolves

* various apps/features/configurations require more than the minimum so let's make it clearer that only meeting the minimum does come with trade-offs
* the built-in Updater requires PHP memory_limit (and/or available RAM) equal to the current size of the downloaded Archive package (see nextcloud/updater#505). Otherwise it will always fail on step 5 (integrity check). Let's mention that so people aren't surprised. They can of course do a manual update still.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1731941/1618d16b-1821-4637-9af2-0130b64da656)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
