### PR TITLE
fix(dev): Add missing imagick extension to make psalm work

### DIFF
--- a/developer_manual/server/static-analysis.rst
+++ b/developer_manual/server/static-analysis.rst
@@ -19,6 +19,7 @@ The following PHP extensions are required to be installed and enabled to make ps
 * ftp
 * gd
 * iconv
+* imagick
 * json
 * ldap
 * libxml


### PR DESCRIPTION
### ☑️ Resolves

My local psalm suddenly started to complain about the missing imagick types because I didn't have the extension installed and enabled.