### PR TITLE
Add missing trailing slashes in Caddy redirects

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -140,8 +140,8 @@ Caddy
 ::
 
     subdomain.example.com {
-        redir /.well-known/carddav /remote.php/dav 301
-        redir /.well-known/caldav /remote.php/dav 301
+        redir /.well-known/carddav /remote.php/dav/ 301
+        redir /.well-known/caldav /remote.php/dav/ 301
 
         reverse_proxy {$NEXTCLOUD_HOST:localhost}
     }


### PR DESCRIPTION
### ☑️ Resolves

The caddy redirects in the documentation don't have the needed trailing slash, making a warning show in the administration page

