### PR TITLE
fix(admin_manual): Explicitly specify which versions of MySQL

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -11,30 +11,30 @@ For best performance, stability and functionality we have documented some recomm
           reliable scaling) and support, we strongly recommend you to check out our `enterprise support
           <https://nextcloud.com/enterprise/>`_.
 
-+------------------+-----------------------------------------------------------------------+
-| Platform         | Options                                                               |
-+==================+=======================================================================+
-| Operating System | - **Ubuntu 22.04 LTS** (recommended)                                  |
-| (64-bit)         | - Ubuntu 20.04 LTS                                                    |
-|                  | - **Red Hat Enterprise Linux 9** (recommended)                        |
-|                  | - Red Hat Enterprise Linux 8                                          |
-|                  | - Debian 12 (Bookworm)                                                |
-|                  | - SUSE Linux Enterprise Server 15                                     |
-|                  | - openSUSE Leap 15.5                                                  |
-|                  | - CentOS Stream                                                       |
-+------------------+-----------------------------------------------------------------------+
-| Database         | - **MySQL 8.0+** or MariaDB 10.3/10.5/**10.6** (recommended)/10.11    |
-|                  | - Oracle Database 11g (*only as part of an enterprise subscription*)  |
-|                  | - PostgreSQL 12/13/14/15/16                                           |
-|                  | - SQLite (*only recommended for testing and minimal-instances*)       |
-+------------------+-----------------------------------------------------------------------+
-| Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |
-|                  | - nginx with ``php-fpm``                                              |
-+------------------+-----------------------------------------------------------------------+
-| PHP Runtime      | - 8.1 (*deprecated*)                                                  |
-|                  | - 8.2                                                                 |
-|                  | - **8.3** (*recommended*)                                             |
-+------------------+-----------------------------------------------------------------------+
++------------------+------------------------------------------------------------------------------------+
+| Platform         | Options                                                                            |
++==================+====================================================================================+
+| Operating System | - **Ubuntu 22.04 LTS** (recommended)                                               |
+| (64-bit)         | - Ubuntu 20.04 LTS                                                                 |
+|                  | - **Red Hat Enterprise Linux 9** (recommended)                                     |
+|                  | - Red Hat Enterprise Linux 8                                                       |
+|                  | - Debian 12 (Bookworm)                                                             |
+|                  | - SUSE Linux Enterprise Server 15                                                  |
+|                  | - openSUSE Leap 15.5                                                               |
+|                  | - CentOS Stream                                                                    |
++------------------+------------------------------------------------------------------------------------+
+| Database         | - **MySQL** **8.0**/8.2/8.3 or MariaDB 10.3/10.5/**10.6**/10.11 (recommended)      |
+|                  | - Oracle Database 11g (*only as part of an enterprise subscription*)               |
+|                  | - PostgreSQL 12/13/14/15/16                                                        |
+|                  | - SQLite (*only recommended for testing and minimal-instances*)                    |
++------------------+------------------------------------------------------------------------------------+
+| Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)                 |
+|                  | - nginx with ``php-fpm``                                                           |
++------------------+------------------------------------------------------------------------------------+
+| PHP Runtime      | - 8.1 (*deprecated*)                                                               |
+|                  | - 8.2                                                                              |
+|                  | - **8.3** (*recommended*)                                                          |
++------------------+------------------------------------------------------------------------------------+
 
 See :doc:`source_installation` for minimum PHP-modules and additional software for installing Nextcloud.
 


### PR DESCRIPTION
### ☑️ Resolves

Rather than say "8.0+" (which could lead to problems with deployments using untested versions of MySQL with Nextcloud) let's stick to the actual versions we test against. 

Currently (in `master`) that is, technically 8.0 and 8.3, but not the recently published 8.4. We are explicit with our other recommended databases so let's be consistent here too. 

Included 8.2 since, like for PostgreSQL, our automated test matrix skips it for efficiency (presumably) since it *likely* is covered by our 8.0 and 8.3 tests (it's out of scope to debate the pros/cons of that here).

### 🖼️ Screenshots

New:
![image](https://github.com/nextcloud/documentation/assets/1731941/d389cf67-4c75-409c-8a5b-fa4b0ef54007)

Existing:
![image](https://github.com/nextcloud/documentation/assets/1731941/a503273e-bb74-473d-85ac-5dc618e21c7b)


<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
