### PR TITLE
fix(trashbin): Add missing size/expire commands to occ commmand list

### DIFF
--- a/admin_manual/occ_command.rst
+++ b/admin_manual/occ_command.rst
@@ -1303,14 +1303,16 @@ units.
 Trashbin
 --------
 
-::
+These commands allow for manually managing various aspects of the trash bin (deleted files)::
 
  trashbin
-  trashbin:cleanup  [--all-users] [--] [<user_id>...]  Permanently remove deleted files
-  trashbin:restore  [--all-users] [--scope[=SCOPE]] [--since[=SINCE]] [--until[=UNTIL]] [--dry-run] [--] [<user_id>...]  Restore deleted files according to the given filters
+  trashbin:cleanup      Permanently remove deleted files
+  trashbin:expire       Expires the users trashbin
+  trashbin:size         Configure the target trashbin size
+  trashbin:restore      Restore all deleted files according to the given filters
 
 .. note::
-  This command is only available when the "Deleted files" app
+  These commands are only available when the "Deleted files" app
   (``files_trashbin``) is enabled.
 
 The ``trashbin:cleanup  [--all-users] [--] [<user_id>...]`` command removes the deleted files of the specified


### PR DESCRIPTION
### ☑️ Resolves

Adds to the list of commands:
- nextcloud/server#21658
- nextcloud/server#1138

Doesn't actually show their usage, but at least they're listed now. I didn't even realize `occ trashbin:size` was a command. Kind of handy for setting a size when you aren't using quotas.

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1731941/179347ad-2dae-441b-989f-1f4c24932fe9)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
