### PR TITLE
chore: remove documentation for user_external

### DIFF
--- a/admin_manual/configuration_user/index.rst
+++ b/admin_manual/configuration_user/index.rst
@@ -10,7 +10,6 @@ User management
     reset_user_password
     user_password_policy
     two_factor-auth
-    user_auth_ftp_smb_imap
     user_auth_ldap
     user_auth_ldap_cleanup
     user_auth_ldap_api

--- a/admin_manual/configuration_user/user_auth_ftp_smb_imap.rst
+++ b/admin_manual/configuration_user/user_auth_ftp_smb_imap.rst
@@ -1,9 +1,0 @@
-==================================================
-User authentication with IMAP, SMB, FTP and others
-==================================================
-
-You may configure additional user backends with the 
-External User Backends (user_external) app.
-
-See https://github.com/nextcloud/user_external#readme 
-for an up to date documentation.


### PR DESCRIPTION
### ☑️ Resolves

Users expect, because the app is mentioned in our admin documentation, that there should be a compatible release and are disappointed if not.

We do not maintain or support user_external, and therefore the mention in our documention should go.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
