### PR TITLE
fix(docs): Fix occ example for dashboard layout

### DIFF
--- a/admin_manual/configuration_server/dashboard_configuration.rst
+++ b/admin_manual/configuration_server/dashboard_configuration.rst
@@ -21,7 +21,7 @@ The layout of an existing user can be read with the following command::
 
 The layout of the dashboard for a specific user can be set with the following command::
 
-  occ user:setting admin dashboard layout --value="calendar,files,activity"
+  occ user:setting admin dashboard layout "calendar,files,activity"
 
 The default layout of the dashboard for all users can be set with the following command::
 


### PR DESCRIPTION
### ☑️ Resolves

The `occ` command for `user:setting` does not have a `--value` option:

```
The "--value" option does not exist.

user:setting [--output [OUTPUT]] [--ignore-missing-user] [--default-value DEFAULT-VALUE] [--update-only] [--delete] [--error-if-not-exists] [--] <uid> [<app> [<key> [<value>]]]
```

<img width="736" alt="image" src="https://github.com/nextcloud/documentation/assets/1580193/15b69b22-a2e3-48da-bf73-2947d974d020">

