### PR TITLE
fix: remove mention of legacy `filelocking.enabled` toggle

### DIFF
--- a/admin_manual/configuration_files/files_locking_transactional.rst
+++ b/admin_manual/configuration_files/files_locking_transactional.rst
@@ -22,8 +22,8 @@ the same document. Multiple users can open and edit a file at the same time and
 Transactional File locking does not prevent this. Rather, it prevents
 simultaneous file saving.
 
-File locking is enabled by default, using the database locking backend. This
-places a significant load on your database. Using ``memcache.locking`` relieves
+Transactional File locking will use the database locking backend by default. This
+places a significant load on your database. Setting ``memcache.locking`` relieves
 the database load and improves performance. Admins of Nextcloud servers with
 heavy workloads should install a memcache. (See
 :doc:`../configuration_server/caching_configuration`.)
@@ -32,7 +32,6 @@ To use a memcache with Transactional File Locking, you must install the Redis
 server and corresponding PHP module. After installing Redis you must enter a
 configuration in your ``config.php`` file like this example::
 
-  'filelocking.enabled' => true,
   'memcache.locking' => '\OC\Memcache\Redis',
   'redis' => array(
        'host' => 'localhost',
@@ -48,7 +47,6 @@ If you want to configure Redis to listen on an Unix socket (which is
 recommended if Redis is running on the same system as Nextcloud) use this example
 ``config.php`` configuration::
 
-  'filelocking.enabled' => true,
   'memcache.locking' => '\OC\Memcache\Redis',
   'redis' => array(
        'host' => '/var/run/redis/redis.sock',


### PR DESCRIPTION
No longer relevant today since it's not an experimental feature (hasn't been for nearly a decade) and is now on by default. There is no good reason to disable it. The toggle only exists to be able to *enable* it, when it was still experimental.

See nextcloud/server#45330 & https://github.com/nextcloud/server/pull/45330#discussion_r1608291623 + nextcloud/server#45471

### ☑️ Resolves

### 🖼️ Screenshots
![image](https://github.com/nextcloud/documentation/assets/1731941/d0fe55db-616d-49ff-b23a-90c099415f09)
<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
