### PR TITLE
fix(admin): Revise opcache revalidation tuning section

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -128,13 +128,31 @@ more processes to run in parallel to handle the requests.
 Enable PHP OPcache
 ------------------
 
-The `OPcache <https://php.net/manual/en/intro.opcache.php>`_ improves the performance of PHP applications by caching precompiled bytecode. The default OPcache settings are usually sufficient for Nextcloud code to be fully cached. If any cache size limit is reached by more than 90%, the admin panel will show a related warning. Nextcloud strictly requires code comments to be preserved in opcode, which is the default. But in case PHP settings are changed on your system, you may need set the following:
+The `OPcache <https://php.net/manual/en/intro.opcache.php>`_ improves the performance of PHP applications by caching precompiled bytecode.
 
-.. code:: ini
+Revalidation
+^^^^^^^^^^^^
 
-  opcache.save_comments = 1
+OPcache revalidation in PHP handles changes made to PHP application code stored on disk. Code changes occur whenever:
 
-By default, cached scripts are revalidated on access to ensure that changes on disk take effect after at most ``2`` seconds. Since Nextcloud handles cache revalidation internally when required, the revalidation frequency can be reduced or completely disabled to enhance performance. Note, however, that it affects manual changes to scripts, including ``config.php``. To check for changes at most every ``60`` seconds, use the following setting:
+- Nextcloud or a Nextcloud app is upgraded 
+- a configuration change is made (e.g. ``config.php`` is modified) 
+
+Nextcloud, as much as possible, handles cache revalidation internally when required. However this is not foolproof. In a default PHP environment, revalidation is 
+enabled and cached scripts are revalidated to ensure that changes (on disk) take effect every ``2`` seconds. In many environments, these default 
+values are reasonable (and may never need to be changed). 
+
+However, the revalidation frequency can be adjusted and may *potentially* enhance performance. We make no recommendations here about appropriate values for revalidation (other than the PHP defaults).
+
+.. danger::
+    Lengthening the time between revalidation (or disabling it completely) means that manual changes to scripts, including ``config.php``, will take longer before they become active (or will never do so, if
+    revalidation is disabled completely). Lengthening also increases the likelihood of transient Server and application upgrade problems. It also prevents the proper toggling of maintenance mode.
+    
+.. warning::
+    If you adjust these parameters, you are more likely to need to restart/reload your web server (mod_php) or fpm after making configuration changes or performing upgrades. If you forget to do so, you 
+    will likely experience unusual behavior due to a mismatch between what is on disk and is in memory. These may appear to be bugs, but will go away as soon as you restart/reload mod_php/fpm.
+
+To change the default from ``2`` and check for changes on disk at most every ``60`` seconds, use the following setting:
 
 .. code:: ini
 
@@ -146,9 +164,30 @@ To disable the revalidation completely:
 
   opcache.validate_timestamps = 0
 
-Any change to ``config.php`` will then require either restarting PHP, manually clearing the cache, or invalidating this particular script.
+Any Server/app upgrades or changes to ``config.php`` will then require restarting PHP (or otherwise manually clearing the cache or invalidating this particular script).
 
-For more details check out the `official documentation <https://php.net/manual/en/opcache.configuration.php>`_. To monitor OPcache usage, clear individual or all cache entries, `opcache-gui <https://github.com/amnuts/opcache-gui>`_ can be used.
+.. warning::
+   To avoid false reports, if your environment isn't using the PHP default revalidation values, please do not report bugs/odd behavior after upgrading Nextcloud or Nextcloud apps until after you've 
+   restarted mod_php/fpm (to confirm they are not simply caused by local revalidation configuration).
+
+Sizing
+^^^^^^
+
+If any cache size limit is reached by more than 90%, the admin panel will show a related warning and suggested changes.
+
+For more details check out the `official PHP documentation <https://php.net/manual/en/opcache.configuration.php>`_. To monitor OPcache usage, clear individual or all cache entries, `opcache-gui <https://github.com/amnuts/opcache-gui>`_ can be used.
+
+Comments
+^^^^^^^^
+
+Nextcloud strictly requires code comments to be preserved in opcode, which is the default. But in case PHP settings are changed on your system, you may need set the following:
+
+.. code:: ini
+
+  opcache.save_comments = 1
+
+JIT
+^^^
 
 PHP 8.0 and above ship with a JIT compiler that can be enabled to benefit any CPU intensive apps you might be running. To enable a tracing JIT with all optimizations:
 
@@ -202,8 +241,8 @@ Nextcloud to use Imaginary by editing your `config.php`:
 
     For large instance, you should follow `Imaginary's scalability recommendation <https://github.com/h2non/imaginary#scalability>`.
 
-Settings:
-^^^^^^^^^
+Settings
+^^^^^^^^
 
 If you want set the preview format for imaginary.  
 You can change between jpeg and webp, the default is jpeg:


### PR DESCRIPTION
### ☑️ Resolves

- Try to make PHP revalidation values, suggestions, and trade-offs more apparent (main focus of this PR)
- Add big warnings about impact of lengthening frequency of revalidations and/or disabling outright 
- Try to make the opcache tuning section a bit more organized (move things around more logically, add sub-headings)

Also, related to pending enhancement: nextcloud/server#45498

Note: The main thing that is perhaps controversial here is the PHP default of `2` versus `60` (not so much because we ever formally recommended changing it to `60`, but because `60` is already being used in both the AIO and micro-services/community Docker image). I'm of the camp that PHP's default of `2` should be emphasized. And any deviation from that is fine, but the operator making that change is on their own (and expected to restart/etc if needed). Fortunately with the Docker images (at least ours), at least for Server itself, it's less of an issue since the code upgrades only happen through a container restart (but still a factor for `config.php` + potentially for app updates).

Historical (most relevant):

- nextcloud/docker#1718
- nextcloud/docker#93
- nextcloud/documentation#1439
- nextcloud/all-in-one#192
- nextcloud/all-in-one#199

### 🖼️ Screenshots

![image](https://github.com/nextcloud/documentation/assets/1731941/616b9e80-34fe-4035-8f3b-7f1165ea11e3)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
