### PR TITLE
docs: pqsql 9.4 is no longer supported

### DIFF
--- a/admin_manual/release_notes/upgrade_to_30.rst
+++ b/admin_manual/release_notes/upgrade_to_30.rst
@@ -7,3 +7,4 @@ System requirements
 
 * PHP 8.1 is now deprecated but still supported.
 * PHP 8.0 is no longer supported.
+* PostgreSQL 9.4 is no longer supported.


### PR DESCRIPTION
### ☑️ Resolves

Document that pqsql 9.4 is no longer supported.

Nextcloud 30 removed a workaround for the missing upsert in pqsql 9.4.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
