### PR TITLE
fix: Adjust system requirement for upcoming Nextcloud 30

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -23,7 +23,7 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - openSUSE Leap 15.5                                                  |
 |                  | - CentOS Stream                                                       |
 +------------------+-----------------------------------------------------------------------+
-| Database         | - **MySQL 8.0+** or MariaDB 10.3/10.5/**10.6** (recommended)/10.11    |
+| Database         | - MySQL 8.0 / **8.4** or MariaDB 10.6/ **10.11** (recommended) / 11.4 |
 |                  | - Oracle Database 11g (*only as part of an enterprise subscription*)  |
 |                  | - PostgreSQL 12/13/14/15/16                                           |
 |                  | - SQLite (*only recommended for testing and minimal-instances*)       |


### PR DESCRIPTION
### ☑️ Resolves

Clarify which versions we are testing and thus can support:
* MySQL 8.0 LTS + 8.4 LTS
* MariaDB 10.6 LTS, 10.11 LTS and 11.4 LTS
* *(other databases unchanged)*

See also https://github.com/nextcloud/server/pull/46121
