### PR TITLE
fix(Files): mention enabledPreviewProviders parameter in Previews chapter

### DIFF
--- a/admin_manual/configuration_files/previews_configuration.rst
+++ b/admin_manual/configuration_files/previews_configuration.rst
@@ -16,12 +16,13 @@ By default, Nextcloud can generate previews for the following filetypes:
 * Cover of MP3 files
 * Text documents
 
-.. note:: Technically Nextcloud can also generate the previews
-          of other file types such as PDF, SVG or various office documents.
-          Due to security concerns those providers have been disabled by
-          default and are considered unsupported.
-          While those providers are still available, we discourage enabling 
-          them, and they are not documented.
+.. note:: Nextcloud can also generate previews of other file types (such as PDF, SVG,
+   various Office document formats, and various video formats). Due to security and
+   performance concerns those providers are disabled by default. While those providers 
+   are still available, we discourage enabling them and they are considered unsupported. 
+   The full list of the preview providers that are enabled by default (as well as those 
+   disabled by default) can be found under the ``enabledPreviewProviders`` 
+   :doc:`configuration parameter </configuration_server/config_sample_php_parameters>`.
 
 Parameters
 ----------


### PR DESCRIPTION
### ☑️ Resolves

This parameter *is* documented in our config sample and people routinely use it (or ask questions that lead to it). We should mention it in the Previews section. Also mildly tidied up the overall language of the note.

P.S. Can't add direct link labels into config sample sections currently because of how we generate that section of the docs. That's out of scope for this PR.

### 🖼️ Screenshots

Now: 

![image](https://github.com/user-attachments/assets/f2c970c6-2224-4351-b306-fc92a743905b)

Before:

![image](https://github.com/user-attachments/assets/d1521b25-d10b-4288-8102-9802a6ec8877)

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
