### PR TITLE
feat(admin): Add information about `forbidden_filename_basenames` in Nextcloud 30

### DIFF
--- a/admin_manual/release_notes/upgrade_to_30.rst
+++ b/admin_manual/release_notes/upgrade_to_30.rst
@@ -16,4 +16,5 @@ Changes to the available options in ``config.php``.
 
 * The option ``blacklisted_files`` is now deprecated and replaced with ``forbidden_filenames``
 * The option ``forbidden_chars`` is now deprecated and replaced with ``forbidden_filename_characters``
+* The option ``forbidden_filename_basenames`` was added to allow bocking files with specific basenames (the filename without extension (before the first dot))
 * The option ``forbidden_filename_extensions`` was added to allow blocking extensions from being used on filenames


### PR DESCRIPTION
### ☑️ Resolves
* for https://github.com/nextcloud/server/pull/46545

### 🖼️ Screenshots
![Screenshot 2024-07-17 at 13-45-25 Upgrade to Nextcloud 30 — Nextcloud latest Administration Manual latest documentation](https://github.com/user-attachments/assets/b2ab1343-e156-47bf-9381-7ed91f159e91)

