### PR TITLE
fix: EoL 27 from index + move EoL desktop versions to dedicated section

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
 
 							<div class="section" id="nextcloud-28">
 								<h2>Nextcloud 28<a class="headerlink" href="#nextcloud-28" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>previous</em> version of Nextcloud.</p>
+								<p>This documents the <em>last supported</em> version of Nextcloud.</p>
 								<ul class="simple">
 									<li><a class="reference external" href="https://docs.nextcloud.com/server/28/user_manual/">User Manual</a>
 										(<a class="reference external" href="https://docs.nextcloud.com/server/28/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
@@ -275,6 +275,14 @@
 									<p>This documents the <em>latest stable</em> version of the Nextcloud desktop client.</p>
 									<ul class="simple">
 										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.12">Manual</a>
+									</ul>
+								</div>
+
+								<div class="section" id="desktop-311">
+									<h2>Desktop 3.11<a class="headerlink" href="#desktop-311" title="Permalink to this headline">¶</a></h2>
+									<p>This documents the <em>previous</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+									<ul class="simple">
+										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.11">Manual</a>
 									</ul>
 								</div>
 							</div> <!-- desktop -->
@@ -475,14 +483,6 @@
 							publicly maintained and users are strongly encouraged to upgrade to a maintained
 							release or get access to long term security and stability updates with
 							<a href="https://nextcloud.com/enterprise">Nextcloud Enterprise.</a></p>
-
-							<div class="section" id="desktop-311">
-								<h2>Desktop 3.11<a class="headerlink" href="#desktop-311" title="Permalink to this headline">¶</a></h2>
-								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-								<ul class="simple">
-									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.11">Manual</a>
-								</ul>
-							</div>
 
 							<div class="section" id="desktop-310">
 								<h2>Desktop 3.10<a class="headerlink" href="#desktop-310" title="Permalink to this headline">¶</a></h2>

--- a/index.html
+++ b/index.html
@@ -217,6 +217,8 @@
 								machine images, or sign up for hosted Nextcloud services. See the
 								<a class="reference external" href="https://nextcloud.com/install/">Get Started</a>
 								page for more information.</p>
+								<p>The below are the <a href="https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule">currently maintained</a>
+								versions of Nextcloud Server.</p>
 							</div>
 
 							<div class="section" id="nextcloud-latest">
@@ -255,18 +257,6 @@
 								</ul>
 							</div>
 
-							<div class="section" id="nextcloud-27">
-								<h2>Nextcloud 27<a class="headerlink" href="#nextcloud-27" title="Permalink to this headline">¶</a></h2>
-								<p>This documents the <em>last supported</em> version of Nextcloud.</p>
-								<ul class="simple">
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/27/user_manual/">User Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/27/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/27/admin_manual/">Administration Manual</a>
-										(<a class="reference external" href="https://docs.nextcloud.com/server/27/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-									<li><a class="reference external" href="https://docs.nextcloud.com/server/27/developer_manual/">Developer Manual</a>
-								</ul>
-							</div>
-
 							<div class="section" id="desktop">
 								<h1>Nextcloud Desktop Client<a class="headerlink" href="#desktop" title="Permalink to this headline">¶</a></h1>
 								<p>Once you have a Nextcloud Server running, you can connect to it with various <a class="reference external" href="https://nextcloud.com/install/#install-clients">clients like our mobile and desktop client.</a>
@@ -287,92 +277,27 @@
 										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.12">Manual</a>
 									</ul>
 								</div>
-
-								<div class="section" id="desktop-311">
-									<h2>Desktop 3.11<a class="headerlink" href="#desktop-311" title="Permalink to this headline">¶</a></h2>
-									<p>This documents the <em>previous</em> version of the Nextcloud desktop client.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.11">Manual</a>
-									</ul>
-								</div>
-
-								<div class="section" id="desktop-310">
-									<h2>Desktop 3.10<a class="headerlink" href="#desktop-310" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.10">Manual</a>
-									</ul>
-								</div>
-
-								<div class="section" id="desktop-39">
-									<h2>Desktop 3.9<a class="headerlink" href="#desktop-39" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.9">Manual</a>
-									</ul>
-								</div>
-
-								<div class="section" id="desktop-38">
-									<h2>Desktop 3.8<a class="headerlink" href="#desktop-38" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.8">Manual</a>
-									</ul>
-								</div>
-
-								<div class="section" id="desktop-37">
-									<h2>Desktop 3.7<a class="headerlink" href="#desktop-37" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.7">Manual</a>
-									</ul>
-								</div>
-
-								<div class="section" id="desktop-36">
-									<h2>Desktop 3.6<a class="headerlink" href="#desktop-36" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.6">Manual</a>
-									</ul>
-								</div>
-
-								<div class="section" id="desktop-35">
-									<h2>Desktop 3.5<a class="headerlink" href="#desktop-35" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.5">Manual</a>
-									</ul>
-								</div>
-								<div class="section" id="desktop-34">
-									<h2>Desktop 3.4<a class="headerlink" href="#desktop-34" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.4">Manual</a>
-									</ul>
-								</div>
-								<div class="section" id="desktop-33">
-									<h2>Desktop 3.3<a class="headerlink" href="#desktop-33" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.3">Manual</a>
-									</ul>
-								</div>
-								<div class="section" id="desktop-32">
-									<h2>Desktop 3.2<a class="headerlink" href="#desktop-32" title="Permalink to this headline">¶</a></h2>
-									<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
-									<ul class="simple">
-										<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.2">Manual</a>
-									</ul>
-								</div>
-							</div>
+							</div> <!-- desktop -->
 
 							<div class="section" id="nextcloud-older">
-								<h1>Older Nextcloud server releases<a class="headerlink" href="#nextcloud-older" title="Permalink to this headline">¶</a></h1>
+								<h1>Older Nextcloud Server releases<a class="headerlink" href="#nextcloud-older" title="Permalink to this headline">¶</a></h1>
 								<p>This documents the <em>older</em> versions of Nextcloud. These releases are no longer
 								publicly maintained and users are strongly encouraged to upgrade to a maintained
 								release or get access to long term security and stability updates with
 								<a href="https://nextcloud.com/enterprise">Nextcloud Enterprise.</a></p>
+								
+								<div class="section" id="nextcloud-27">
+									<h2>Nextcloud 27<a class="headerlink" href="#nextcloud-27" title="Permalink to this headline">¶</a></h2>
+									<ul class="simple">
+										<li><a class="reference external" href="https://docs.nextcloud.com/server/27/user_manual/">User Manual</a>
+											(<a class="reference external" href="https://docs.nextcloud.com/server/27/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
+										<li><a class="reference external" href="https://docs.nextcloud.com/server/27/admin_manual/">Administration Manual</a>
+											(<a class="reference external" href="https://docs.nextcloud.com/server/27/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
+										<li><a class="reference external" href="https://docs.nextcloud.com/server/27/developer_manual/">Developer Manual</a>
+									</ul>
+								</div>
 
+								
 								<div class="section" id="nextcloud-26">
 									<h2>Nextcloud 26<a class="headerlink" href="#nextcloud-26" title="Permalink to this headline">¶</a></h2>
 									<ul class="simple">
@@ -541,7 +466,92 @@
 									</ul>
 								</div>
 							</div>
-						</div><!-- server -->
+						</div><!-- nextcloud(server)-older -->
+
+						<!-- desktop-older -->
+						<div class="section" id="desktop-older">
+							<h1>Older Nextcloud Desktop releases<a class="headerlink" href="#desktop-older" title="Permalink to this headline">¶</a></h1>
+							<p>This documents the <em>older</em> versions of Nextcloud Desktop Client. These releases are no longer
+							publicly maintained and users are strongly encouraged to upgrade to a maintained
+							release or get access to long term security and stability updates with
+							<a href="https://nextcloud.com/enterprise">Nextcloud Enterprise.</a></p>
+
+							<div class="section" id="desktop-311">
+								<h2>Desktop 3.11<a class="headerlink" href="#desktop-311" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.11">Manual</a>
+								</ul>
+							</div>
+
+							<div class="section" id="desktop-310">
+								<h2>Desktop 3.10<a class="headerlink" href="#desktop-310" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.10">Manual</a>
+								</ul>
+							</div>
+
+							<div class="section" id="desktop-39">
+								<h2>Desktop 3.9<a class="headerlink" href="#desktop-39" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.9">Manual</a>
+								</ul>
+							</div>
+
+							<div class="section" id="desktop-38">
+								<h2>Desktop 3.8<a class="headerlink" href="#desktop-38" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.8">Manual</a>
+								</ul>
+							</div>
+
+							<div class="section" id="desktop-37">
+								<h2>Desktop 3.7<a class="headerlink" href="#desktop-37" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.7">Manual</a>									</ul>
+								</div>
+
+							<div class="section" id="desktop-36">
+								<h2>Desktop 3.6<a class="headerlink" href="#desktop-36" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.6">Manual</a>
+								</ul>
+							</div>
+
+							<div class="section" id="desktop-35">
+								<h2>Desktop 3.5<a class="headerlink" href="#desktop-35" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.5">Manual</a>
+								</ul>
+							</div>
+							<div class="section" id="desktop-34">
+								<h2>Desktop 3.4<a class="headerlink" href="#desktop-34" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.4">Manual</a>
+								</ul>
+							</div>
+							<div class="section" id="desktop-33">
+								<h2>Desktop 3.3<a class="headerlink" href="#desktop-33" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.3">Manual</a>
+								</ul>
+							</div>
+							<div class="section" id="desktop-32">
+								<h2>Desktop 3.2<a class="headerlink" href="#desktop-32" title="Permalink to this headline">¶</a></h2>
+								<p>This documents an <em>older</em> version of the Nextcloud desktop client. Users are strongly encouraged to upgrade to benefit from security and stability improvements.</p>
+								<ul class="simple">
+									<li><a class="reference external" href="https://docs.nextcloud.com/desktop/3.2">Manual</a>
+								</ul>
+							</div>
+						</div> <!-- desktop-older -->
 
 						<div class="section" id="reporting-documentation-bugs-how-to-contribute">
 							<h1>Reporting Documentation Bugs &amp; How to Contribute<a class="headerlink" href="#reporting-documentation-bugs-how-to-contribute" title="Permalink to this headline">¶</a></h1>


### PR DESCRIPTION
### ☑️ Resolves

* Drop Server 27 as *last supported*
* Moves EoL Desktop versions to their own section, just as we do with EoL Server versions
* Adds a link to the *Maintenance and Release Schedule* at the top of the Server section

P.S. (desktop) I believe it's time to bump Desktop 3.13 to *latest* stable and 3.12 to *previous* stable. I don't believe there is an *upcoming* doc base deployed yet, but might be time for that too.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
