### PR TITLE
chore: Add notes for `noExpirationDate` flag addition to share API

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.rst
@@ -210,6 +210,8 @@ Changed APIs
 - ``OCP\IGroupManager::isAdmin()`` should be used instead of checking is current user is part of admin group manually.
 - ``IAttributes`` ``enabled`` key have bee renamed to ``value`` and supports more than boolean.
 - ``OCP\DB\Exception`` uses the reason code ``REASON_LOCK_WAIT_TIMEOUT`` now, instead of ``REASON_SERVER`` for a LockWaitTimeoutException.
+- ``OCP\Share\IShare::setNoExpirationDate()`` now sets an overwrite flag for falsy expiry date values, this flag is used to determine whether the system should overwrite falsy expiry date values before creating a share.
+- ``OCP\Share\IShare::getNoExpirationDate()`` retrieves the value of the ``noExpirationDate`` flag.
 
 Deprecated APIs
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

Document share API updates in : https://github.com/nextcloud/server/pull/44485

### 🖼️ Screenshots
![Screenshot from 2024-07-21 14-24-48](https://github.com/user-attachments/assets/292087eb-5fb6-4ce9-9f25-bdb3c681d742)

