### PR TITLE
Update upgrade.rst - update grammar on upgrading to minor version before major version

### DIFF
--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -41,7 +41,7 @@ Approaching Upgrades
 --------------------
 
 Nextcloud must be upgraded step by step: 
-  * Before you can upgrade to the next major release, Nextcloud upgrades to the latest point release.
+  * Before you can upgrade to the next major release, you need to upgrade to the latest minor version for your current major version.
   * Then run the upgrade again to upgrade to the next major release's latest point release.
   * **You cannot skip major releases.** Please re-run the upgrade until you have reached the highest available (or applicable) release.
   * Example: 18.0.5 -> 18.0.11 -> 19.0.5 -> 20.0.2

--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -41,7 +41,7 @@ Approaching Upgrades
 --------------------
 
 Nextcloud must be upgraded step by step: 
-  * Before you can upgrade to the next major release, you need to upgrade to the latest minor version for your current major version.
+  * Before you can upgrade to the next major release, you need to upgrade to the latest point release of your current major version.
   * Then run the upgrade again to upgrade to the next major release's latest point release.
   * **You cannot skip major releases.** Please re-run the upgrade until you have reached the highest available (or applicable) release.
   * Example: 18.0.5 -> 18.0.11 -> 19.0.5 -> 20.0.2


### PR DESCRIPTION
### ☑️ Resolves

* no known issues for this to my knowledge

This just fixes a grammar issue on the upgrades page that was a little confusing.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
<img width="770" alt="Screenshot of the nextcloud admin manual showing an updated bullet point about updating to a latest minor before upgrading a major version" src="https://github.com/user-attachments/assets/2fe9ac8f-e723-4b6b-b638-9bd8ad0f2764">
