### PR TITLE
docs(admin/external_storage): Specify that `Region` is a required field

### DIFF
--- a/admin_manual/configuration_files/external_storage/amazons3.rst
+++ b/admin_manual/configuration_files/external_storage/amazons3.rst
@@ -30,7 +30,7 @@ rarely required with Amazon, but some legacy Amazon datacenters may require it. 
 :code:`Legacy (v2) authentication` unselected.
 
 **If you using a non-Amazon hosted S3 store:** you will need to set the :code:`Hostname` 
-parameter (and can ignore the :code:`Region` parameter). You may need to enable :code:`Enable Path Style` 
+parameter. If your non-Amazon S3 store has a region code, enter it in :code:`Region`. You may need to enable :code:`Enable Path Style` 
 if your non-Amazon S3 store does *not* support requests like :code:`https://bucket.hostname.domain/`.
 Setting :code:`Enable Path Style` to true configures the S3 client to make requests like 
 :code:`https://hostname.domain/bucket` instead. It's rare to need :code:`Legacy (v2) authentication`, but


### PR DESCRIPTION
Nextcloud always sends `eu-west-1` as the region. For S3 store providers that support the region field, this can cause external storage to not work.

Removes wording that says `Region` is optional. Clarifies that for providers that use `Region`, the user must provide it because the Nextcloud default will always be incorrect.

### ☑️ Resolves

* Fix #9507

### 🖼️ Screenshots

Changes the following text since `Region` is required for some providers, such as Cloudflare R2.

![image](https://github.com/user-attachments/assets/a7ad1d49-216a-4187-a582-6647e4701bfb)
