### PR TITLE
fix(admin/migration): Updates NC version required for oC migration

### DIFF
--- a/admin_manual/maintenance/migrating_owncloud.rst
+++ b/admin_manual/maintenance/migrating_owncloud.rst
@@ -15,9 +15,7 @@ See the table below for a version map, where migrating is easily possible:
 +-------------------+------------------------------+
 | ownCloud          | Nextcloud                    |
 +===================+==============================+
-| 10.13.x           | 25.0.x (but at least 25.0.2) |
-+-------------------+------------------------------+
-| 10.5.x            | 20.0.x (but at least 20.0.5) |
+| 10.13.x           | 25.0.x (but at least 25.0.13) |
 +-------------------+------------------------------+
 
 .. note:: Since ownCloud does not and will not support PHP 8.0 or higher, you


### PR DESCRIPTION
### ☑️ Resolves

After confirming with Marcel Scherello, documentation has outdated information on oC/NC versions required for migration.

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/b4f5aa81-3717-4b14-8484-842fc1dc4cad)
