### PR TITLE
fix(encryption): Link to current version of recovery tools

### DIFF
--- a/admin_manual/configuration_files/encryption_details.rst
+++ b/admin_manual/configuration_files/encryption_details.rst
@@ -345,7 +345,7 @@ Each block is (by default) AES-256-CTR decrypted with the ``$iv[$position]`` and
 Sources
 -------
 
-- `nextcloud-tools repository on GitHub <https://github.com/syseleven/nextcloud-tools>`_
+- `encryption-recovery-tools repository on GitHub <https://github.com/nextcloud/encryption-recovery-tools>`_
 - `Nextcloud Encryption Configuration documentation <https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html>`_
 - `Nextcloud Help response concerning the usage of version information <https://help.nextcloud.com/t/allow-file-decryption-with-only-the-files-keys-and-passwords/436/12>`_
 - `Sourcecode: Creation of the Message Authentication Code <https://github.com/nextcloud/server/blob/a374d8837d6de459500e619cf608e0721ea14574/apps/encryption/lib/Crypto/Crypt.php#L504>`_


### PR DESCRIPTION
### ☑️ Resolves

* Fix nextcloud/server#47594

We were still linking to the archived version that isn't up-to-date with our current encryption implementation.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
