### PR TITLE
Update sync_ios.rst

### DIFF
--- a/user_manual/groupware/sync_ios.rst
+++ b/user_manual/groupware/sync_ios.rst
@@ -12,6 +12,9 @@ Calendar
 #. Select Other as account type.
 #. Select Add CalDAV account.
 #. For server, type the domain name of your server i.e. ``example.com``.
+#. Open Advanced Settings
+#. For server, type the domain name of your server and username i.e. ``example.com/remote.php/dav/principals/users/username/``
+#. Close Advanced Settings
 #. Enter your user name and password.
 #. Select Next.
 


### PR DESCRIPTION
The current documentation does not work. Based on https://help.nextcloud.com/t/why-doesnt-calendar-sync-to-ios-work/30446, the changes are necessary to connect an IPhone to the caldav system, using an IPhone 13 with IOS 17.6.1

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
