### PR TITLE
chore: add trailing comma for allowed_admin_ranges

### DIFF
--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -188,7 +188,7 @@ This can be achieved with this kind of setting, usually using private IP ranges:
     '127.0.0.1/8',
     '192.168.0.0/16',
     'fd00::/8',
-  ]
+  ],
 
 All requests originating from IP addresses outside of these ranges will not be able to execute admin actions.
 


### PR DESCRIPTION
### ☑️ Resolves

For https://help.nextcloud.com/t/allowed-admin-ranges-stanza-in-config-php-results-in-black-screen-of-death/202944

Most of our examples have a trailing comma to easier copy and paste.


### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
