### PR TITLE
fix: add minimum sqlite version to system requirements

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -27,7 +27,7 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - Oracle Database 11g, 18, 21, 23                                     |
 |                  |   (*only as part of an enterprise subscription*)                      |
 |                  | - PostgreSQL 12/13/14/15/16                                           |
-|                  | - SQLite (*only recommended for testing and minimal-instances*)       |
+|                  | - SQLite 3.16+ (*only recommended for testing and minimal-instances*) |
 +------------------+-----------------------------------------------------------------------+
 | Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |
 |                  | - nginx with ``php-fpm``                                              |


### PR DESCRIPTION
Fixes nextcloud/server#37649

Also see:

-  https://github.com/doctrine/dbal/issues/5133#issuecomment-1034068059
- https://www.sqlite.org/chronology.html
- https://packages.debian.org/search?keywords=sqlite3