### PR TITLE
[stable29] fix: add minimum sqlite version to system requirements

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -26,7 +26,7 @@ For best performance, stability and functionality we have documented some recomm
 | Database         | - **MySQL 8.0+** or MariaDB 10.3/10.5/**10.6** (recommended)/10.11    |
 |                  | - Oracle Database 11g (*only as part of an enterprise subscription*)  |
 |                  | - PostgreSQL 10/11/12/13/14/15/16                                     |
-|                  | - SQLite (*only recommended for testing and minimal-instances*)       |
+|                  | - SQLite 3.16+ (*only recommended for testing and minimal-instances*) |
 +------------------+-----------------------------------------------------------------------+
 | Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |
 |                  | - nginx with ``php-fpm``                                              |


### PR DESCRIPTION
Manual backport of #12209 (why? whatever)
