### PR TITLE
Update reverse_proxy_configuration.rst, fixing traefik-v2 example

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -95,10 +95,10 @@ Traefik 2
 Using Docker labels:
 ::
 
-  traefik.http.routers.nextcloud.middlewares: 'nextcloud_redirectregex'
-  traefik.http.middlewares.nextcloud_redirectregex.redirectregex.permanent: true
-  traefik.http.middlewares.nextcloud_redirectregex.redirectregex.regex: 'https://(.*)/.well-known/(?:card|cal)dav'
-  traefik.http.middlewares.nextcloud_redirectregex.redirectregex.replacement: 'https://$${1}/remote.php/dav'
+  - "traefik.http.routers.nextcloud.middlewares=nextcloud_redirectregex@docker"
+  - "traefik.http.middlewares.nextcloud_redirectregex.redirectregex.permanent=true"
+  - "traefik.http.middlewares.nextcloud_redirectregex.redirectregex.regex=https://(.*)/.well-known/(?:card|cal)dav"
+  - "traefik.http.middlewares.nextcloud_redirectregex.redirectregex.replacement=https://$${1}/remote.php/dav"
 
 Using a TOML file:
 ::


### PR DESCRIPTION
For me the original documentation examples did not work because of false formatting.

### ☑️ Resolves

- I updated the formatting for the traefik v2.x example so it actually works.

### 🖼️ Screenshots

<img width="1118" alt="Bildschirmfoto 2024-09-18 um 10 06 07" src="https://github.com/user-attachments/assets/6508825f-78d1-4c1d-bcbe-c6d275612913">
