### PR TITLE
docs(developer): Document since and deprecation periods

### DIFF
--- a/developer_manual/server/code-back-end.rst
+++ b/developer_manual/server/code-back-end.rst
@@ -11,3 +11,10 @@ However, if new files were created, you will need to run the following command t
    build/autoloaderchecker.sh
 
 After that, please also include the autoloader file changes in your commits.
+
+Compatibility documentation
+---------------------------
+
+- New APIs (interfaces, constants, methods, classes, traits, enums) added to the public namespace ``OCP`` have to be annotated with a ``@since X.Y.Z`` attribute of the version it was added in.
+- When it is backported the version should be adjusted to the X.Y.Z of the stable version it was backported in only in that stable branch. The master branch should still contain the newest Major version shipping the API.
+- Once an API was shipped, unless it is marked as experimental, it has to be deprecated in similar fashion using ``@deprecated X.Y.Z`` for 3 years (9 Nextcloud releases) before it can be removed. Deprecations have to be clearly documented in the :ref:`app-upgrade-guide` for the upcoming Major version.

--- a/developer_manual/server/externalapi.rst
+++ b/developer_manual/server/externalapi.rst
@@ -123,7 +123,7 @@ Changing API and backwards compatibility
 
 We aim to keep our API as stable as possible to avoid breaking third-party apps.
 Before an API is allowed to be removed, it should be marked as deprecated for at
-least 2 years (6 Nextcloud releases) before it gets removed.
+least 3 years (9 Nextcloud releases) before it gets removed.
 
 Changing the API `should be discussed in a github issue in our server repo
 <https://github.com/nextcloud/server/issues>`_. A pull request is most welcome.


### PR DESCRIPTION
### 🖼️ Screenshots

![grafik](https://github.com/user-attachments/assets/4afd66c2-41e5-4389-91a2-d4658a9e8a3f)