### PR TITLE
fix(upgrade_to_30): Note the drop of MariaDB 10.5 support

### DIFF
--- a/admin_manual/release_notes/upgrade_to_30.rst
+++ b/admin_manual/release_notes/upgrade_to_30.rst
@@ -8,6 +8,7 @@ System requirements
 * PHP 8.1 is now deprecated but still supported.
 * PHP 8.0 is no longer supported.
 * PostgreSQL 9.4 is no longer supported.
+* MariaDB 10.5 is no longer supported.
 
 Web server configuration
 ------------------------

--- a/admin_manual/release_notes/upgrade_to_30.rst
+++ b/admin_manual/release_notes/upgrade_to_30.rst
@@ -8,7 +8,7 @@ System requirements
 * PHP 8.1 is now deprecated but still supported.
 * PHP 8.0 is no longer supported.
 * PostgreSQL 9.4 is no longer supported.
-* MariaDB 10.5 is no longer supported.
+* MariaDB 10.3 and 10.5 are no longer supported.
 
 Web server configuration
 ------------------------


### PR DESCRIPTION
### ☑️ Resolves

* Fix nextcloud/server#48271

So apparently we dropped official support for MariaDB 10.5 (which is an LTS and still supported thru 5/2025 per https://mariadb.org/about/#maintenance-policy) in v30. Earlier in the v30 dev cycle I'd kept 10.5 in (for nextcloud/server#45241). Not sure if it was an oversight or deliberate, but looks like it got dropped outright in nextcloud/server#46121. The new cut-off became 10.6.

Anyhow, adding a note to the release notes section to further call it out (the system requirements are accurate/up-to-date with nextcloud/server#46121; this is just to call it out more prominently since this is a notable change).

I'd personally still vote for keeping 10.5 in, but either way let's keep the docs clear.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
