### PR TITLE
Fixed webhook equals operator from $eq to $e

### DIFF
--- a/admin_manual/webhook_listeners/index.rst
+++ b/admin_manual/webhook_listeners/index.rst
@@ -31,7 +31,7 @@ If you would like to match events fired by a specific user, you can pass ``{ "us
 
 If you would like to enforce multiple criteria, you can simply pass multiple properties ``{ "event.tableId": 42, "event.rowId": 3 }``
 
-You can also use additional comparison operators (``$eq, $ne, $gt, $gte, $lt, $lte, $in, $nin``) as well as logical operators (``$and, $or, $not, $nor``). For example use ``{ "time" : { "$lt": 1711971024 } }`` to accept only events prior to April 1st 2024 and ``{ "time" : { "$not": { "$lt": 1711971024 } } }`` to accept events after April 1st 2024.
+You can also use additional comparison operators (``$e, $ne, $gt, $gte, $lt, $lte, $in, $nin``) as well as logical operators (``$and, $or, $not, $nor``). For example use ``{ "time" : { "$lt": 1711971024 } }`` to accept only events prior to April 1st 2024 and ``{ "time" : { "$not": { "$lt": 1711971024 } } }`` to accept events after April 1st 2024.
 
 Speeding up webhook dispatch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In the webhook listeners [source code](https://github.com/nextcloud/server/blob/4febe107e65927d9be298e2b45869343b7073874/apps/webhook_listeners/lib/Service/PHPMongoQuery.php#L252), the `equals` function is called by the `$e` operator, but not by `$eq`