### PR TITLE
fix(info): update default discussion URL

### DIFF
--- a/developer_manual/app_development/info.rst
+++ b/developer_manual/app_development/info.rst
@@ -225,7 +225,7 @@ discussion
     * optional
     * must contain a URL to the project's discussion page/forum
     * will be rendered on the app detail page as the "ask question or discuss" button
-    * if absent, it will default to our forum at https://help.nextcloud.com/ and create a new category in the apps category
+    * if absent, it will default to our forum at https://help.nextcloud.com/
 bugs
     * required
     * must contain a URL to the project's bug tracker


### PR DESCRIPTION
### ☑️ Resolves

This change is to coincide with https://github.com/nextcloud/appstore/pull/1496

### 🖼️ Screenshots

![Screenshot 2024-09-26 at 09-44-34 App metadata — Nextcloud latest Developer Manual latest documentation](https://github.com/user-attachments/assets/a1436ef3-36cc-49f9-8157-e159a043428c)
