### PR TITLE
chore(developer): Add documentation about new WebDAV endpoint for downloading folders

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_31.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_31.rst
@@ -68,6 +68,8 @@ Back-end changes
 Added APIs
 ^^^^^^^^^^
 
+- It is now possible to download folders as zip or tar archives using the WebDAV backend using :code:`GET` requests.
+  See the relevant :ref:`endpoint documentation<webdav-download-folders>`.
 - ``OCP\SetupCheck\CheckServerResponseTrait`` was added to ease implementing custom :ref:`setup checks<setup-checks>` which need to check HTTP calls to the the server itself.
 
 Changed APIs
@@ -79,12 +81,17 @@ Changed APIs
 Deprecated APIs
 ^^^^^^^^^^^^^^^
 
-- TBD
+- The ``/s/{token}/download`` endpoint for downloading public shares is deprecated.
+  Instead use the Nextcloud provided :ref:`WebDAV endpoint<webdav-download-folders>`.
 
 Removed APIs
 ^^^^^^^^^^^^
 
 - Legacy, non functional, ``OC_App::getForms`` was removed.
+- The private and legacy ``OC_Files`` class was removed.
+  Instead use ``OCP\AppFramework\Http\StreamResponse`` or ``OCP\AppFramework\Http\ZipResponse``.
+- The private and legacy Ajax endpoint for downloading file archives (``/apps/files/ajax/download.php``) was removed.
+  Instead use the Nextcloud provided :ref:`WebDAV endpoint<webdav-download-folders>`.
 - All ``OCP\ILogger`` logging methods, deprecated since Nextcloud 20, are removed.
     - The interface now only holds the Nextcloud internal logging level constants.
       For all logging ``Psr\Log\LoggerInterface`` should be used.


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/pull/48098
  * Add WebDAV folder-download endpoint documentation
  * Add changelog entry for new endpoint
  * Add changelog entry for deprecated and removed legacy endpoints

### 🖼️ Screenshots

![Screenshot 2024-09-28 at 19-01-55 Basic APIs — Nextcloud latest Developer Manual latest documentation](https://github.com/user-attachments/assets/b7752b30-735c-4f7e-8b58-eb76a560b3a9)
![Screenshot 2024-09-28 at 19-03-26 Basic APIs — Nextcloud latest Developer Manual latest documentation](https://github.com/user-attachments/assets/dfdfbe15-3b87-4d91-ae6e-babb7cb355a7)
![Screenshot 2024-09-28 at 19-08-45 Upgrade to Nextcloud 31 — Nextcloud latest Developer Manual latest documentation](https://github.com/user-attachments/assets/91a7148c-b031-4258-87f8-8d33980ac59b)