### PR TITLE
Clarify username for postgresql's peer authentication method

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -221,13 +221,13 @@ To start the postgres command line mode use::
 
   sudo -u postgres psql -d template1
 
-Then a **template1=#** prompt will appear. Now enter the following lines and confirm them with the enter key:
+Then a **template1=#** prompt will appear. Now enter the following lines, making sure to replace "www-data" with the name of the user of the PHP process, and confirm them with the enter key:
 
 ::
 
-  CREATE USER username CREATEDB;
-  CREATE DATABASE nextcloud OWNER username TEMPLATE template0 ENCODING 'UTF8';
-  GRANT CREATE ON SCHEMA public TO username;
+  CREATE USER "www-data" CREATEDB;
+  CREATE DATABASE nextcloud OWNER "www-data" TEMPLATE template0 ENCODING 'UTF8';
+  GRANT CREATE ON SCHEMA public TO "www-data";
 
 You can quit the prompt by entering::
 
@@ -245,7 +245,7 @@ this:
 
     "dbtype"        => "pgsql",
     "dbname"        => "nextcloud",
-    "dbuser"        => "username",
+    "dbuser"        => "www-data",
     "dbpassword"    => "",
     "dbhost"        => "/var/run/postgresql",
     "dbtableprefix" => "oc_",


### PR DESCRIPTION
The documentation is not clear that the database user name should be the name of the PHP process when using PostgreSQL's peer authentication method. This was only hinted at in a subsequent paragraph, after I had run the PSQL commands with the user name `username`.

I also updated the example to use the common `www-data` user name, which will probably familiar to most users.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
