### PR TITLE
Make digging deeper category an alphabetic list

### DIFF
--- a/developer_manual/digging_deeper/index.rst
+++ b/developer_manual/digging_deeper/index.rst
@@ -7,43 +7,43 @@ Digging deeper
 
    api
    config/index
-   debugging
    classloader
    continuous_integration
+   dashboard
+   deadlock
+   debugging
    email
    files-metadata
-   flow
+   groupware/index
    http_client
    javascript-apis
+   translation
+   flow
    npm
    notifications
+   out_of_office
    performance
+   phonenumberutil
    psr
+   profile
+   profiler
+   projects
    publicpage
+   reference
    repair
    rest_apis
    search
+   security
    settings
+   setup_checks
    speech-to-text
    talk
-   translation
-   text_processing
    task_processing
+   text_processing
    text2image
    two-factor-provider
-   users
-   dashboard
-   reference
-   projects
-   groupware/index
-   web_host_metadata
    status
-   security
-   setup_checks
-   profile
    user_migration
-   profiler
-   deadlock
-   phonenumberutil
-   out_of_office
+   users    
+   web_host_metadata
    time


### PR DESCRIPTION
### ☑️ Resolves

This should render the section *digging deeper* a alphabetical list. There is also a [topic on the forum](https://help.nextcloud.com/t/reorder-digging-deeper-developer-documentation/206332) where no concerns were spoken out.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

![grafik](https://github.com/user-attachments/assets/400f6261-6181-4fbd-9ad8-bd01eb010755)
