### PR TITLE
Update2 issues#11549

### DIFF
--- a/admin_manual/apps_management.rst
+++ b/admin_manual/apps_management.rst
@@ -81,6 +81,38 @@ By default guest users, when using the guests app, are not notified, to enable n
 
   occ config:app:set --type boolean --value="true" updatenotification app_updated.notify_guests
 
+Enabling apps via occ command
+-----------------------------
+
+In addition to managing apps via the web interface, administrators can also enable or disable apps using the `occ` command.
+
+To enable an app, use the following command:
+
+::
+
+  occ app:enable <app-id>
+
+For example, to enable the "files" app, run:
+
+::
+
+  occ app:enable files
+
+To enable the app for specific groups, use the `--groups` option:
+
+::
+  
+  occ app:enable files --groups=admin
+
+
+This command enables the "files" app only for the "admin" group.
+
+To disable an app, use:
+
+::
+
+  occ app:disable <app-id>
+
 Using private API
 -----------------
 

--- a/admin_manual/occ_command.rst
+++ b/admin_manual/occ_command.rst
@@ -268,6 +268,13 @@ Enable an app for specific groups of users::
  sudo -u www-data php occ app:enable --groups admin --groups sales files_external
  files_external enabled for groups: admin, sales
 
+Enable multiple apps simultaneously::
+
+ sudo -u www-data php occ app:enable app1 app2 app3
+ app1 enabled
+ app2 enabled
+ app3 enabled
+
 Disable an app::
 
  sudo -u www-data php occ app:disable files_external


### PR DESCRIPTION
### ☑️ Resolves
Updated occ_command.rst to provide additional examples on enabling multiple apps simultaneously.
Updated apps_management.rst to include new usage examples, ensuring consistency in presenting the occ command for managing multiple apps at once.

![occ_command rst updated](https://github.com/user-attachments/assets/0af64ecc-6f9b-4097-994a-244b0b75fee4)
![apps_management rst updated](https://github.com/user-attachments/assets/41800abe-a0e0-43a9-a2b3-ca723c42a17a)

This PR enhances the documentation by adding examples of enabling multiple apps simultaneously (occ_command.rst) and ensuring consistency in apps_management.rst by expanding the explanation for occ commands.In apps_management.rst, the example for enabling multiple apps is added to improve clarity for users managing applications through the command line, streamlining their setup processes.