### PR TITLE
fix(occ): Add `user:auth-tokens` to command listing

### DIFF
--- a/admin_manual/occ_command.rst
+++ b/admin_manual/occ_command.rst
@@ -1362,16 +1362,21 @@ The ``--dry-run`` option can be used to simulate the restore without actually re
 User commands
 -------------
 
-The ``user`` commands create and remove users, reset passwords, display a simple
+The ``user`` commands create and remove users, reset passwords, manage authentication tokens / sessions, display a simple
 report showing how many users you have, and when a user was last logged in::
 
  user
   user:add                            adds a user
-  user:add-app-password               adds a app password named "cli"
+  user:add-app-password               adds a app password named "cli" (deprecated: alias for user:auth-tokens:add)
+  user:auth-tokens:add                Add app password for the named account
+  user:auth-tokens:delete             Deletes an authentication token
+  user:auth-tokens:list               List authentication tokens of an user
+  user:clear-avatar-cache             clear avatar cache
   user:delete                         deletes the specified user
   user:disable                        disables the specified user
   user:enable                         enables the specified user
   user:info                           shows information about the specific user
+  user:keys:verify                    Verify if the stored public key matches the stored private key
   user:lastseen                       shows when the user was logged in last time
   user:list                           shows list of all registered users
   user:report                         shows how many users have access


### PR DESCRIPTION
These were implemented in nextcloud/server#40026 but never documented.

No usage examples, but at least the commands are now listed.

### ☑️ Resolves

* Fixes nextcloud/server#30918
* https://github.com/nextcloud/server/pull/40026#issuecomment-2011755402
* https://github.com/nextcloud/server/issues/44170#issuecomment-1998305551
* nextcloud/server#29001

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
