### PR TITLE
fix(admin): remove mentions of apc.enable_cli

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -117,8 +117,6 @@ Which returns::
 
 .. note:: On some systems it might be required to call **php-cli** instead of **php**.
 
-.. note:: For some configurations, it might be necessary to append ``--define apc.enable_cli=1`` to the cron command. Please refer to :doc:`./caching_configuration` (section APCu).
-
 .. note:: Please refer to the crontab man page for the exact command syntax.
 
 .. _easyCron: https://www.easycron.com/

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -116,11 +116,6 @@ After restarting your Web server, add this line to your ``config.php`` file::
  
 Refresh your Nextcloud admin page, and the cache warning should disappear.  
 
-.. warning:: APCu is disabled by default on CLI which could cause issues with nextcloud's
-   cron jobs. Please make sure you set the ``apc.enable_cli`` to ``1`` on your ``php.ini``
-   config file or append ``--define apc.enable_cli=1`` to the cron job call.
-
-
 Depending on your installation size and the number of users and interactions
 with the system you may want to adapt the ``apc.shm_size`` setting in your
 ``php.ini``. The default value is 32M which is usually too low for Nextcloud. A
@@ -129,7 +124,7 @@ installed you may want to increase this value further. Keep in mind that this
 memory needs to be available in your system's memory and kept in mind when
 sizing the amount of workers on your server.
 
-A frequenly resetting cache can lead to unexpected slow downs when the cache is
+A frequently resetting cache can lead to unexpected slow downs when the cache is
 being cleared and refilled.
 
 There is an admin check trying to detect too low memory sizing, but make sure to

--- a/admin_manual/installation/example_openbsd.rst
+++ b/admin_manual/installation/example_openbsd.rst
@@ -114,7 +114,6 @@ It is recommended to add opcache to it::
 
   [opcache]
   opcache.enable=1
-  opcache.enable_cli=1
   opcache.memory_consumption=512
   opcache.interned_strings_buffer=8
   opcache.max_accelerated_files=10000

--- a/admin_manual/installation/php_configuration.rst
+++ b/admin_manual/installation/php_configuration.rst
@@ -98,7 +98,6 @@ ini values
 
 The following ini settings should be adapted if needed for Nextcloud:
 
-* ``apc.enable_cli``: see :doc:`../configuration_server/caching_configuration`
 * ``disable_functions``: avoid disabling functions unless you know exactly what you are doing
 * ``max_execution_time``: see :doc:`../configuration_files/big_file_upload_configuration`
 * ``memory_limit``: should be at least 512MB. See also :doc:`../configuration_files/big_file_upload_configuration`

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -163,11 +163,6 @@ Using the command line based updater
 The command line based updater works in the exact same way the web based
 updater works. The steps and checks are the very same.
 
-.. warning:: APCu is disabled by default on CLI which could cause issues with nextcloud's
-   command line based updater. Please make sure you set the ``apc.enable_cli`` to ``1`` on your ``php.ini``
-   config file or append ``--define apc.enable_cli=1`` to the command line based updater call
-   (like ``sudo -u www-data php --define apc.enable_cli=1 /var/www/nextcloud/updater/updater.phar``).
-
 The steps are basically the same as for the web based updater:
 
 1.  You should see a notification at the top of any Nextcloud page when there is


### PR DESCRIPTION
After https://github.com/nextcloud/server/pull/46151, Nextcloud does not require `apc.enable_cli` to be enabled anymore, but will fallback to the dummy NullCache instead for CLI calls. All mentions of this PHP configuration option are hence removed.

Additionally, one left mention of `opcache.enable_cli` is removed, which was never required.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
