### PR TITLE
chore(github): Update groupware code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,10 @@
-/*/groupware/                                               @ChristophWurst
-/*/groupware/calendar.rst                                   @miaulalala
-/*/groupware/contacts.rst                                   @hamza221
-/*/groupware/mail.rst                                       @GretaD
+/*/groupware/calendar.rst                                   @SebastianKrupinski @st3iny @tcitworld
+/*/groupware/contacts.rst                                   @GVodyanov @hamza221 @SebastianKrupinski
+/*/groupware/mail.rst                                       @ChristophWurst @GretaD @kesselb
 /*/security.rst                                             @nickvergessen
 /admin_manual/configuration_database                        @nickvergessen
 /admin_manual/file_workflows                                @nickvergessen
 /developer_manual/client_apis/OCS/ocs-status-api.rst        @Antreesy @nickvergessen
-/developer_manual/digging_deeper/groupware/                 @ChristophWurst
-/developer_manual/digging_deeper/groupware/calendar.rst     @miaulalala
+/developer_manual/digging_deeper/groupware/calendar.rst     @SebastianKrupinski @st3iny @tcitworld
 /developer_manual/digging_deeper/talk.rst                   @nickvergessen
 /user_manual/talk/                                          @Antreesy @DorraJaouad @nickvergessen


### PR DESCRIPTION
### ☑️ Resolves

* Update repo code owners to https://github.com/nextcloud/groupware/blob/8f662c09e9c6784ae297e0b8186eac961862b6f2/README.md

### 🖼️ Screenshots

n/a
