### PR TITLE
feat: Support postgres 17 but drop postgres 12

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -26,7 +26,7 @@ For best performance, stability and functionality we have documented some recomm
 | Database         | - MySQL 8.0 / **8.4** or MariaDB 10.6/ **10.11** (recommended) / 11.4 |
 |                  | - Oracle Database 11g, 18, 21, 23                                     |
 |                  |   (*only as part of an enterprise subscription*)                      |
-|                  | - PostgreSQL 12/13/14/15/16                                           |
+|                  | - PostgreSQL 13/14/15/16/17                                           |
 |                  | - SQLite 3.16+ (*only recommended for testing and minimal-instances*) |
 +------------------+-----------------------------------------------------------------------+
 | Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |


### PR DESCRIPTION
### ☑️ Resolves

* 17 is the latest release we should support
* 12 is now (as of 2024-11-15) end-of-life.
