### PR TITLE
profiler docs: add version detection

### DIFF
--- a/developer_manual/digging_deeper/profiler.rst
+++ b/developer_manual/digging_deeper/profiler.rst
@@ -13,9 +13,9 @@ using the latest development version of Nextcloud.
 
 .. code-block:: bash
 
+   major_version=$(php occ version 2>&1 | awk -F'[. ]' '{print $2;exit}')
    cd apps/
-   git clone --branch stableX https://github.com/nextcloud/profiler.git
-   # adapt X to your Nextcloud version: sudo -E -u www-data php occ version | grep -oP 'Nextcloud \K\d+'
+   git clone --branch stable$major_version https://github.com/nextcloud/profiler.git
    cd profiler
    cd ../..
 

--- a/developer_manual/digging_deeper/profiler.rst
+++ b/developer_manual/digging_deeper/profiler.rst
@@ -13,7 +13,7 @@ using the latest development version of Nextcloud.
 
 .. code-block:: bash
 
-   major_version=$(php occ version 2>&1 | awk -F'[. ]' '{print $2;exit}')
+   major_version=$(sudo -E -u www-data php occ version 2>&1 | awk -F'[. ]' '{print $2;exit}')
    cd apps/
    git clone --branch stable$major_version https://github.com/nextcloud/profiler.git
    cd profiler


### PR DESCRIPTION
In the previous command, the `|&` was not a typo but intentional. Was removed outside of github AFAIK.

The output of `php occ version` is on `STDERR`.

Anyway, now this is a POSIX way to detect version.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
