### PR TITLE
Update Minimum Android Version for Nextcloud Talk

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -123,7 +123,7 @@ Talk App
 ^^^^^^^^
 
 - **iOS** 15.0+
-- **Android** 7.0+
+- **Android** 8.0+
 - **Nextcloud Server** 14.0+
 - **Nextcloud Talk** 4.0+
 


### PR DESCRIPTION
The minimum supported Android version for Nextcloud Talk app is Android 8.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
