### PR TITLE
Mark the Projects feature as deprecated 

### DIFF
--- a/user_manual/files/projects.rst
+++ b/user_manual/files/projects.rst
@@ -2,12 +2,15 @@
 Projects
 ========
 
+.. deprecated:: 25
+    This feature was replaced by the shipped related resources app.
+
 Users can associate files, chats and other items with each other in projects. The various apps will present these items in a list, allowing users to immediately jump to them. Projects are Nextcloud wide. When a user shares a file that is part of a project, the share recipient can see that project, too. A click on any of the items in a project leads right to it, be it a chat, a file or a task.
 
 Create a new project
 --------------------
 
-A new project can be created by linking two items together. Start off by opening a file or folders sharing sidebar. 
+A new project can be created by linking two items together. Start off by opening a file or folders sharing sidebar.
 
 .. figure:: ../images/projects1.png
 


### PR DESCRIPTION
and replaced by related resources.

Is it correct that it was announced deprecated from NC 25?

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/b552950c-0b69-49da-b8f7-75da04846b9c)

This could be backported down to stable25.