### PR TITLE
[stable29] Fix wrong german translation for 'sharing' in user manual

### DIFF
--- a/user_manual/locale/de/LC_MESSAGES/files/transfer_ownership.pot
+++ b/user_manual/locale/de/LC_MESSAGES/files/transfer_ownership.pot
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 Nextcloud GmbH
 # This file is distributed under the same license as the Nextcloud latest User Manual package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Joachim Sokolowski, 2020
 # Niklas <baeren987@gmail.com>, 2021
@@ -10,7 +10,7 @@
 # Mark Ziegler <mark.ziegler@rakekniven.de>, 2021
 # kaekimaster, 2023
 # Mario Siegmann <mario_siegmann@web.de>, 2023
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -41,7 +41,7 @@ msgstr ""
 
 #: ../../files/transfer_ownership.rst:8
 msgid "Navigate to *Settings* (top-right menu) > *Sharing*."
-msgstr "Navigieren Sie zu *Einstellungen* (Menü oben rechts) > *Freigabe*."
+msgstr "Navigieren Sie zu *Einstellungen* (Menü oben rechts) > *Teilen*."
 
 #: ../../files/transfer_ownership.rst:9
 msgid ""


### PR DESCRIPTION
There's a mismatch between the user manual and the actual navigation menu entry in the personal settings.
In the navigation in Nextcloud, "Sharing" is translated as "Teilen":

![image](https://github.com/user-attachments/assets/c965168a-2a58-43eb-b77c-771b17b17e9d)
 
but in the doc it is translated as "Freigabe".

This has been fixed in Transifex so it will be synced with the master branch of the docs.

Is this the right way to fix the translation issue for the stable29 branch of the docs?

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/a4523363-b79b-4579-adff-8cf72dfb1587)