### PR TITLE
Change example for setting correct permissions.

### DIFF
--- a/admin_manual/maintenance/manual_upgrade.rst
+++ b/admin_manual/maintenance/manual_upgrade.rst
@@ -94,8 +94,8 @@ Step-by-Step Manual Upgrade
 13. Adjust file ownership and permissions::
 
      chown -R www-data:www-data nextcloud
-     find nextcloud/ -type d -exec chmod 750 {} \;
-     find nextcloud/ -type f -exec chmod 640 {} \;
+     find nextcloud/ -type d -exec chmod 750 {} +
+     find nextcloud/ -type f -exec chmod 640 {} +
 
 14. Restart your Web server.
 


### PR DESCRIPTION
Using `find -exec chmod … {} \;`  executes one process of chmod for every file/directory, whereas `find -exec chmod … {} +` collects files into a large list and invocates chmod much less.

### ☑️ Resolves



### 🖼️ Screenshots
