### PR TITLE
fix(client): Fix Out-of-office endpoint and response data

### DIFF
--- a/developer_manual/client_apis/OCS/ocs-out-of-office-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-out-of-office-api.rst
@@ -8,8 +8,7 @@ OCS Out-of-office API
 
 The OCS Out-of-office API allows you to access and modify out-of-office data of users.
 
-The base URL for all calls to the share API is:
-*<nextcloud_base_url>/ocs/v2.php/apps/dav/api/v1/outOfOffice*
+The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/dav/api/v1/outOfOffice``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 
@@ -20,7 +19,7 @@ Fetch ongoing data
 Fetch data of the ongoing out-of-office period of a user.
 
 * Method: ``GET``
-* Endpoint: ``/{userId}``
+* Endpoint: ``/{userId}/now``
 * Response:
     - Status code:
         + ``200 OK`` Out-of-office data
@@ -30,15 +29,15 @@ Fetch data of the ongoing out-of-office period of a user.
 +---------------------------------+-------------+---------------------------------------------------------------------+
 | field                           | type        | Description                                                         |
 +---------------------------------+-------------+---------------------------------------------------------------------+
-| ``id``                          | int         | Database ID of the absence data entity                              |
+| ``id``                          | string      | Database ID of the absence data entity                              |
 +---------------------------------+-------------+---------------------------------------------------------------------+
 | ``userId``                      | string      | ID of the user which the data belongs to                            |
 +---------------------------------+-------------+---------------------------------------------------------------------+
-| ``firstDay``                    | string      | First day of the absence in format ``YYYY-MM-DD``                   |
+| ``startDate``                   | int         | Timestamp of the start date (respecting the userId's timezone)      |
 +---------------------------------+-------------+---------------------------------------------------------------------+
-| ``lastDay``                     | string      | Last day of the absence in format ``YYYY-MM-DD``                    |
+| ``endDate``                     | int         | Timestamp of the end date (respecting the userId's timezone)        |
 +---------------------------------+-------------+---------------------------------------------------------------------+
-| ``status``                      | string      | Short text that is set as user status during the absence            |
+| ``shortMessage``                | string      | Short text that is set as user status during the absence            |
 +---------------------------------+-------------+---------------------------------------------------------------------+
 | ``message``                     | string      | Longer multiline message that is shown to others during the absence |
 +---------------------------------+-------------+---------------------------------------------------------------------+

--- a/developer_manual/client_apis/OCS/ocs-recommendations-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-recommendations-api.rst
@@ -6,7 +6,7 @@ The OCS Recommendations API allows you to get a list of recommended files and fo
 
 .. note:: This API requires the Recommendations app to be enabled.
 
-The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v2.php/apps/recommendations/api/v1/*
+The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/recommendations/api/v1/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-share-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-share-api.rst
@@ -5,7 +5,7 @@ OCS Share API
 The OCS Share API allows you to access the sharing API from outside over
 pre-defined OCS calls.
 
-The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v2.php/apps/files_sharing/api/v1*
+The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/files_sharing/api/v1``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-sharee-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-sharee-api.rst
@@ -5,7 +5,7 @@ OCS Sharee API
 The OCS Sharee API allows you to access the sharing API from outside over
 pre-defined OCS calls.
 
-The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v1.php/apps/files_sharing/api/v1*
+The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v1.php/apps/files_sharing/api/v1``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-status-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-status-api.rst
@@ -4,7 +4,7 @@ OCS Status API
 
 The OCS Status API allows you to access and modify status API from outside over pre-defined OCS calls.
 
-The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v2.php/apps/user_status/api/v1/user_status*
+The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/user_status/api/v1/user_status``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-text2image-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-text2image-api.rst
@@ -8,7 +8,7 @@ OCS Text-To-Image API
 
 The OCS Text-To-Image API allows you to run image generation tasks implemented by apps using  :ref:`the backend Text-To-Image API<text2image>`.
 
-The base URL for all calls to this API is: *<nextcloud_base_url>/ocs/v2.php/text2image/*
+The base URL for all calls to this API is: ``<nextcloud_base_url>/ocs/v2.php/text2image/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-textprocessing-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-textprocessing-api.rst
@@ -11,7 +11,7 @@ OCS TextProcessing API
 
 The OCS Text processing API allows you to run text processing tasks, like prompting large language models implemented by apps using  :ref:`the backend Text Processing API<text_processing>`.
 
-The base URL for all calls to this API is: *<nextcloud_base_url>/ocs/v2.php/textprocessing/*
+The base URL for all calls to this API is: ``<nextcloud_base_url>/ocs/v2.php/textprocessing/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-translation-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-translation-api.rst
@@ -8,7 +8,7 @@ OCS Translation API
 
 The OCS Translation API allows you to translate strings from a language to another.
 
-The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v2.php/translation/*
+The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/translation/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-user-preferences-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-user-preferences-api.rst
@@ -4,7 +4,7 @@ OCS user preferences API
 
 The OCS user preferences API allows you to set and delete preferences from outside over pre-defined OCS calls.
 
-The base URL for all calls to the share API is: *<nextcloud_base_url>/ocs/v2.php/apps/provisioning_api/api/v1/config/users/*
+The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/provisioning_api/api/v1/config/users/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 


### PR DESCRIPTION
### ☑️ Resolves

* Endpoint was missing the `/now` and was duplicating the second documented endpoint
* Data was wrong, see https://github.com/nextcloud/server/blob/370a9d77ea0aadd736d42741623cf98729797d8b/apps/dav/lib/ResponseDefinitions.php#L22-L35

### 🖼️ Screenshots

![grafik](https://github.com/user-attachments/assets/69ec22d7-0379-440a-80e0-b6c5cea69df9)
