### PR TITLE
Add section for desktop clients

### DIFF
--- a/user_manual/contents.rst
+++ b/user_manual/contents.rst
@@ -13,6 +13,7 @@ Table of contents
     files/index
     groupware/index
     talk/index 
+    desktop/index
     userpreferences
     universal_access
     user_2fa

--- a/user_manual/desktop/index.rst
+++ b/user_manual/desktop/index.rst
@@ -1,0 +1,13 @@
+===============
+Desktop Clients
+===============
+
+You can share one or more files and folders on your computer, and synchronize
+them with your Nextcloud server. Place files in your local shared directories,
+and those files are immediately synchronized to the server and to other devices
+using the Nextcloud Desktop Sync Client, Android app, or iOS app. To
+learn more about the Nextcloud desktop client, please refer to:
+
+* `Nextcloud Desktop Client`_
+
+.. _`Nextcloud Desktop Client`: https://docs.nextcloud.com/desktop/latest/

--- a/user_manual/index.rst
+++ b/user_manual/index.rst
@@ -15,11 +15,6 @@ file synchronization and sharing solution on servers that you control.
 You can share one or more files and folders on your computer, and synchronize
 them with your Nextcloud server. Place files in your local shared directories,
 and those files are immediately synchronized to the server and to other devices
-using the Nextcloud Desktop Sync Client, Android app, or iOS app. To
-learn more about the Nextcloud desktop client, please refer to:
-
-* `Nextcloud Desktop Client`_
-
-.. _`Nextcloud Desktop Client`: https://docs.nextcloud.com/desktop/latest/
+using the Nextcloud Desktop Sync Client, Android app, or iOS app.
 
 `Help translate <https://www.transifex.com/nextcloud/nextcloud-user-documentation/>`_.


### PR DESCRIPTION
The desktop client documentation will be migrated here.
It is currently located here and is neither integrated not matching from theme point of view

https://docs.nextcloud.com/desktop/latest/

This PR is a preparation for the migration of the doc itself