### PR TITLE
Update server_tuning.rst to include example Imaginary Docker run command

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -246,6 +246,10 @@ Nextcloud to use Imaginary by editing your `config.php`:
 
     For large instance, you should follow `Imaginary's scalability recommendation <https://github.com/h2non/imaginary#scalability>`.
 
+.. note::
+
+    To make sure that Imaginary is reachable by your Nextcloud instance, add `-p 9000:9000` to your `docker run` command, e.g. ``docker run -d -p 9000:000 --name nextcloud_imaginary --restart always nextcloud/aio-imaginary:latest``.
+
 Settings
 ^^^^^^^^
 


### PR DESCRIPTION
-p 9000:9000 is a required flag when running the aio-imaginary container, which I'm sure was mentioned in the past somewhere, but it seems to be gone now

### ☑️ Resolves

Issue raised by myself in the community: https://help.nextcloud.com/t/my-nextcloud-doesnt-use-aio-imaginary-anymore-and-i-dont-know-why/213234

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/a8aead29-11b0-48e9-a7d6-bf53495cf09d)

