### PR TITLE
Update server_tuning.rst to include example Imaginary Docker run command

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -213,7 +213,7 @@ external microservice: `Imaginary <https://github.com/h2non/imaginary>`_.
    See https://github.com/nextcloud/server/issues/34262
 
 We strongly recommend running our custom docker image that is more up to date than the official image.
-You can find the image at `https://ghcr.io/nextcloud-releases/aio-imaginary`. When running it, a port must be mapped by adding `-p <port>:9000` to the `docker run` command, e.g. ``docker run -d -p 9000:9000 --name nextcloud_imaginary --restart always nextcloud/aio-imaginary:latest``.
+You can find the image at `https://ghcr.io/nextcloud-releases/aio-imaginary`. When running it, a port must be mapped by adding `-p <port>:9000` to the `docker run` command, e.g. ``docker run -d -p 9000:9000 --name nextcloud_imaginary --restart always ghcr.io/nextcloud-releases/aio-imaginary:latest``.
 
 To do so, you will need to deploy the service and make sure that it is
 not accessible from outside of your servers. Then you can configure

--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -213,7 +213,7 @@ external microservice: `Imaginary <https://github.com/h2non/imaginary>`_.
    See https://github.com/nextcloud/server/issues/34262
 
 We strongly recommend running our custom docker image that is more up to date than the official image.
-You can find the image at `https://ghcr.io/nextcloud-releases/aio-imaginary`.
+You can find the image at `https://ghcr.io/nextcloud-releases/aio-imaginary`. When running it, a port must be mapped by adding `-p <port>:9000` to the `docker run` command, e.g. ``docker run -d -p 9000:9000 --name nextcloud_imaginary --restart always nextcloud/aio-imaginary:latest``.
 
 To do so, you will need to deploy the service and make sure that it is
 not accessible from outside of your servers. Then you can configure
@@ -230,7 +230,7 @@ Nextcloud to use Imaginary by editing your `config.php`:
         'OC\Preview\Krita',
         'OC\Preview\Imaginary',
     ],
-    'preview_imaginary_url' => 'http://<url of imaginary>',
+    'preview_imaginary_url' => 'http://<url of imaginary>:<port>',
 
 .. warning::
 


### PR DESCRIPTION
-p 9000:9000 is a required flag when running the aio-imaginary container, which I'm sure was mentioned in the past somewhere, but it seems to be gone now

☑️ Resolves
Issue raised by myself in the community: https://help.nextcloud.com/t/my-nextcloud-doesnt-use-aio-imaginary-anymore-and-i-dont-know-why/213234

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/ae1a5b9d-ccf9-4dfe-9e60-b579c5f0acd7)
