### PR TITLE
fix(ooo): POST/DELETE endpoint

### DIFF
--- a/developer_manual/client_apis/OCS/ocs-out-of-office-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-out-of-office-api.rst
@@ -86,7 +86,7 @@ Modify out-of-office data
 It is only possible to modify out-of-office data of the currently logged in user.
 
 * Method: ``POST``
-* Endpoint: ``/``
+* Endpoint: ``/{userId}``
 * Data:
 
 +---------------------------------+-------------+---------------------------------------------------------------------+
@@ -139,7 +139,7 @@ Clear data and disable out-of-office
 It is only possible to clear out-of-office data of the currently logged in user.
 
 * Method: ``DELETE``
-* Endpoint: ``/``
+* Endpoint: ``/{userId}``
 * Response:
     - Status code:
         + ``200 OK`` Out-of-office data was cleared


### PR DESCRIPTION
Although the methods itself don't make use of the `userId` parameter:

https://github.com/nextcloud/server/blob/222e6d74dafcc5c309904bf5358c4d3b31a0fdde/apps/dav/lib/Controller/OutOfOfficeController.php#L118-L126

https://github.com/nextcloud/server/blob/222e6d74dafcc5c309904bf5358c4d3b31a0fdde/apps/dav/lib/Controller/OutOfOfficeController.php#L177

it is still required:
https://github.com/nextcloud/server/blob/222e6d74dafcc5c309904bf5358c4d3b31a0fdde/apps/dav/appinfo/routes.php#L20-L21