### PR TITLE
chore(talk): Update minimum requirements to 9.0+

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -125,10 +125,8 @@ Talk App
 
 - **iOS** 15.0+
 - **Android** 8.0+
-- **Nextcloud Server** 14.0+
-- **Nextcloud Talk** 4.0+
-
-.. note:: When using Nextcloud Talk 12.0+ please update the Android Talk App to the newest version (or at least to v12.1).
+- **Nextcloud Server** 19.0+
+- **Nextcloud Talk** 9.0+
 
 Web browser
 -----------


### PR DESCRIPTION
As discussed, the minimum talk version is 9.0+ (Nextcloud 19.0+)

Also I removed a note about talk-android, which was released 4 years ago and should be superseded by now.

### 🖼️ Screenshots
![image](https://github.com/user-attachments/assets/49333bb6-f332-4b1e-ae99-0dcbff50d7a0)