### PR TITLE
fix(AI/Overview): keep systemd runners alive when restarting the AIO

### DIFF
--- a/admin_manual/ai/overview.rst
+++ b/admin_manual/ai/overview.rst
@@ -217,6 +217,9 @@ Systemd service
    [Service]
    ExecStart=/opt/nextcloud-ai-worker/taskprocessing.sh %i
    Restart=always
+   RestartSec=30
+   StartLimitIntervalSec=300
+   StartLimitBurst=10
 
    [Install]
    WantedBy=multi-user.target

--- a/admin_manual/ai/overview.rst
+++ b/admin_manual/ai/overview.rst
@@ -217,8 +217,7 @@ Systemd service
    [Service]
    ExecStart=/opt/nextcloud-ai-worker/taskprocessing.sh %i
    Restart=always
-   RestartSec=30
-   StartLimitIntervalSec=300
+   StartLimitInterval=60
    StartLimitBurst=10
 
    [Install]


### PR DESCRIPTION
I added some configurations to the Service block of the AI worker. This changes allow the AIO Container keep the runnners alive even when restarting the AIO.

### ☑️ Resolves

* Fix AIO AI sheduler fail after restart.
