### PR TITLE
Update for new iOS calendar & contacts synchronisation navigation path

### DIFF
--- a/user_manual/groupware/sync_ios.rst
+++ b/user_manual/groupware/sync_ios.rst
@@ -6,17 +6,18 @@ Calendar
 --------
 
 #. Open the settings application.
+#. Select Apps.
 #. Select Calendar.
-#. Select Accounts.
+#. Select Calendar Accounts.
 #. Select Add Account.
 #. Select Other as account type.
 #. Select Add CalDAV account.
 #. For server, type the domain name of your server i.e. ``example.com``.
+#. Enter your user name and password.
+#. Select Next.
 #. Open Advanced Settings
 #. For server, type the domain name of your server and username i.e. ``example.com/remote.php/dav/principals/users/username/``
 #. Close Advanced Settings
-#. Enter your user name and password.
-#. Select Next.
 
 Your calendar will now be visible in the Calendar application.
 
@@ -28,8 +29,9 @@ Contacts
 --------
 
 #. Open the settings application.
+#. Select Apps.
 #. Select Contacts.
-#. Select Accounts.
+#. Select Contacts Accounts.
 #. Select Add Account.
 #. Select Other as account type.
 #. Select Add CardDAV account.


### PR DESCRIPTION
This changes the navigation pathway in the docs to account for the slight difference in the new navigation pathway in iOS settings to add calendar & contacts accounts

### ☑️ Resolves

New iOS versions have a different pathway for adding calendar & contacts accounts. This change reflects this change

### 🖼️ Screenshots

Not really necessary as the whole thing is just one ordered list
