### PR TITLE
fix(bigFiles): add note re: nginx fastcgi_read_timeout when chunking

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -91,7 +91,7 @@ Apache with mod_proxy_fcgi
 nginx
 ^^^^^
 * `client_max_body_size <https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size>`_
-* `fastcgi_read_timeout <https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout>`_
+* `fastcgi_read_timeout <https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout>`_ [often the solution to 504 timeouts during ``MOVE`` transactions that occur even when using chunking]
 * `client_body_temp_path <https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path>`_
 
 Since nginx 1.7.11 a new config option `fastcgi_request_buffering


### PR DESCRIPTION
### ☑️ Resolves

Came up again on the forum. Fixes some timeout scenarios during the `MOVE` (assembly) of a chunked upload (i.e. if they take longer than 60s).

Just adding the information via a quick note for now so it'll be there for those troubleshooting... and for whenever we clean up the presentation / organization of all the raw info and advice in this chapter (that is kind of overwhelming and a PITA to sort through).

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
