### PR TITLE
docs(admin): Document change of `max_chunk_size`

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -152,17 +152,18 @@ low. This setting needs to be configured to at least the time (in seconds) that
 the longest upload will take. If unsure remove this completely from your
 configuration to reset it to the default shown in the ``config.sample.php``.
 
+.. _files_configure_max_chunk_size:
 
 Adjust chunk size on Nextcloud side
 -----------------------------------
 
 For upload performance improvements in environments with high upload bandwidth, the server's upload chunk size may be adjusted::
 
- sudo -u www-data php occ config:app:set files max_chunk_size --value 20971520
+ sudo -u www-data php occ config:system:set --type int --value 20971520 files.chunked_upload.max_size
 
 Put in a value in bytes (in this example, 20MB). Set ``--value 0`` for no chunking at all.
 
-Default is 10485760 (10 MiB).
+Default is ``104857600`` (100 MiB).
 
 .. note:: Changing ``max_chunk_size`` will not have any performance impact on files uploaded through File Drop shares as unauthenticated file uploads are not chunked.
 

--- a/admin_manual/release_notes/upgrade_to_31.rst
+++ b/admin_manual/release_notes/upgrade_to_31.rst
@@ -11,4 +11,20 @@ System requirements
 PHP configuration
 -----------------
 
-We have a new setup warning to check if the memory reserved for APCu is high enough. If you see this warning, you should increase the memory reserved for APCu. You can do this by increasing the value of the ``apc.shm_size`` directive in your ``php.ini`` file. It is generally advised to review this value and increase it if necessary depending on your instance size.
+We have a new setup warning to check if the memory reserved for APCu is high enough.
+If you see this warning, you should increase the memory reserved for APCu.
+You can do this by increasing the value of the ``apc.shm_size`` directive in your ``php.ini`` file.
+It is generally advised to review this value and increase it if necessary depending on your instance size.
+
+Nextcloud configuration
+-----------------------
+
+Maximum chunk size
+^^^^^^^^^^^^^^^^^^
+
+We have adjusted the default maximum chunk size for big file uploading.
+Previously it was set to 10MiB, it is now increased to 100MiB.
+
+Also the configuration was moved from an app configuration to the system configuration (``config.php``).
+If you set up a custom value previously the value will be automatically migrated to the system configuration during the update.
+But if you need to set a new custom value you need now to use the system configuration, see also :ref:`files_configure_max_chunk_size`.


### PR DESCRIPTION
It is now 100MiB instead of 10MiB and no longer an app config, but a system config option.

### ☑️ Resolves

* https://github.com/nextcloud/server/pull/48461

### 🖼️ Screenshots

![Screenshot 2025-01-17 at 13-12-35 Uploading big files 512MB — Nextcloud latest Administration Manual latest documentation](https://github.com/user-attachments/assets/281ae7a7-736a-489b-ae2a-7d68785f642f)
![Screenshot 2025-01-17 at 13-11-52 Upgrade to Nextcloud 31 — Nextcloud latest Administration Manual latest documentation](https://github.com/user-attachments/assets/30ff5642-476a-4b29-83af-f54d41a540a3)

