### PR TITLE
feat(user): don't recommend tbsync for thunderbird as it is EOL

### DIFF
--- a/user_manual/groupware/sync_thunderbird.rst
+++ b/user_manual/groupware/sync_thunderbird.rst
@@ -38,31 +38,11 @@ Calendars
 
 Same thing here, if you later want to add more calendars, just redo the procedure.
 
-Alternative: Using the TbSync addon
------------------------------------
-
-For this method, you need to have two add-ons installed:
-
-#. `TbSync <https://addons.thunderbird.net/en/thunderbird/addon/tbsync/>`_.
-#. `TbSync provider for CalDAV and CardDAV <https://addons.thunderbird.net/en/thunderbird/addon/dav-4-tbsync/>`_.
-
-When they are installed, go to **Extras**/**Synchronization settings (TbSync)** if you are on Windows, or **Edit/Synchronization settings (TbSync)** if on Linux, then:
-
-#. In the account manager choose **Add new account** > **CalDAV & CardDAV**
-#. In the next window, go with the default called **Automatic Configuration** and click **Next**
-#. Enter an **Account name** (which you can freely choose), a **User name**, a **Password**, the **Server URL**, and click **Next**
-#. In the next window, TbSync should have auto-discovered the CalDAV and CardDAV addresses. When it has, click **Finish**
-#. Check the **Enable and synchronize this account** box. TbSync will now discover all address books and calendars your account has access to on the server
-#. Check the box next to each calendar and address book you want to have synchronized, set how often you want them to be synchronized, and push the button **synchronize now**
-#. After the first successful synchronization is complete, you can close the window.
-
-Henceforth, TbSync will do the work for you. You are done with the basic configuration and can skip the next sections unless you need a more advanced address book.
-
 
 Alternative: Using the CardBook add-on (Contacts only)
 ------------------------------------------------------
 
-`CardBook <https://addons.thunderbird.net/en/thunderbird/addon/cardbook/>`_ is an advanced alternative to Thunderbird's address book, which supports CardDAV. You can have TbSync and CardBook installed in parallel.
+`CardBook <https://addons.thunderbird.net/en/thunderbird/addon/cardbook/>`_ is an advanced alternative to Thunderbird's address book, which supports CardDAV.
 
 #. Click the CardBook icon in the upper right corner of Thunderbird:
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/documentation/issues/8123

### 🖼️ Screenshots

The TbSync plugin has been officially sunset and Thunderbird has been supporting CalDAV natively for over 2 years now.

#### Removed section

![spectacle_20250128_192002](https://github.com/user-attachments/assets/c8205195-caff-4c33-bbd9-745d7d7b1608)

#### Changed section

(Removed the reference to TbSync.)

![spectacle_20250128_191953](https://github.com/user-attachments/assets/ca455761-d921-4f74-8109-7a77d467189c)