### PR TITLE
fix(admin): Update required sqlite to 3.24+

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -27,7 +27,7 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - Oracle Database 11g, 18, 21, 23                                     |
 |                  |   (*only as part of an enterprise subscription*)                      |
 |                  | - PostgreSQL 13/14/15/16/17                                           |
-|                  | - SQLite 3.16+ (*only recommended for testing and minimal-instances*) |
+|                  | - SQLite 3.24+ (*only recommended for testing and minimal-instances*) |
 +------------------+-----------------------------------------------------------------------+
 | Webserver        | - **Apache 2.4 with** ``mod_php`` **or** ``php-fpm`` (recommended)    |
 |                  | - nginx with ``php-fpm``                                              |


### PR DESCRIPTION
### ☑️ Resolves

3.24+ is required for UPSERT

Used by Server v30 in nextcloud/server#45655

Noticed because someone tried to install v30 on Debian 9 ;-)

Refs:

- https://www.sqlite.org/lang_upsert.html
- https://www.sqlite.org/lang_conflict.html

P.S. Might even make sense to bump to 3.35, but this gets us closer.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
