### PR TITLE
harden_server.rst: larger HSTS max-age value

### DIFF
--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -140,7 +140,7 @@ VirtualHost file::
  <VirtualHost *:443>
    ServerName cloud.nextcloud.com
      <IfModule mod_headers.c>
-       Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"
+       Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
      </IfModule>
   </VirtualHost>
 


### PR DESCRIPTION
Nowadays, the common recommendation is to set HTTP Strict Transport Security max-age value to at least 1 year.
It's also min. acceptable value for preload lists.   
Please see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#preload

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
