### PR TITLE
Fix wrong data types in app_assistant.rst

### DIFF
--- a/admin_manual/ai/app_assistant.rst
+++ b/admin_manual/ai/app_assistant.rst
@@ -124,7 +124,7 @@ Assistant configuration
 
 .. code-block::
 
-   occ config:app:set assistant assistant_enabled --value=1 --type=integer
+   occ config:app:set assistant assistant_enabled --value=1 --type=string
 
 To enable/disable the assistant button from the top-right corner for all the users.
 
@@ -132,7 +132,7 @@ To enable/disable the assistant button from the top-right corner for all the use
 
 .. code-block::
 
-   occ config:app:set assistant free_prompt_picker_enabled --value=1 --type=integer
+   occ config:app:set assistant free_prompt_picker_enabled --value=1 --type=string
 
 To enable/disable the AI text generation smart picker for all the users.
 
@@ -140,7 +140,7 @@ To enable/disable the AI text generation smart picker for all the users.
 
 .. code-block::
 
-   occ config:app:set assistant text_to_image_picker_enabled --value=1 --type=integer
+   occ config:app:set assistant text_to_image_picker_enabled --value=1 --type=string
 
 To enable/disable the text-to-image smart picker for all the users.
 
@@ -148,7 +148,7 @@ To enable/disable the text-to-image smart picker for all the users.
 
 .. code-block::
 
-   occ config:app:set assistant speech_to_text_picker_enabled --value=1 --type=integer
+   occ config:app:set assistant speech_to_text_picker_enabled --value=1 --type=string
 
 To enable/disable the speech-to-text smart picker for all the users.
 


### PR DESCRIPTION
Fixes the data types for the configuration of the assistant Configuring it as string returns in internal server error in Nextcloud 30.0.5

### ☑️ Resolves

* Setting data types like mentioned in the documentation results in internal server error visualized on frontend:

![grafik](https://github.com/user-attachments/assets/2c7e2a11-586b-4f19-9abc-017a4de1574e)

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
