### PR TITLE
Fix some API descriptions in developer_manual/client_apis/OCS

### DIFF
--- a/developer_manual/client_apis/OCS/ocs-out-of-office-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-out-of-office-api.rst
@@ -8,7 +8,7 @@ OCS Out-of-office API
 
 The OCS Out-of-office API allows you to access and modify out-of-office data of users.
 
-The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/dav/api/v1/outOfOffice``
+The base URL for all calls to the Out-of-Office API is: ``<nextcloud_base_url>/ocs/v2.php/apps/dav/api/v1/outOfOffice``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-recommendations-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-recommendations-api.rst
@@ -6,7 +6,7 @@ The OCS Recommendations API allows you to get a list of recommended files and fo
 
 .. note:: This API requires the Recommendations app to be enabled.
 
-The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/recommendations/api/v1/``
+The base URL for all calls to the Recommendations API is: ``<nextcloud_base_url>/ocs/v2.php/apps/recommendations/api/v1/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-sharee-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-sharee-api.rst
@@ -5,7 +5,7 @@ OCS Sharee API
 The OCS Sharee API allows you to access the sharing API from outside over
 pre-defined OCS calls.
 
-The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v1.php/apps/files_sharing/api/v1``
+The base URL for all calls to the Sharee API is: ``<nextcloud_base_url>/ocs/v1.php/apps/files_sharing/api/v1``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-status-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-status-api.rst
@@ -4,7 +4,7 @@ OCS Status API
 
 The OCS Status API allows you to access and modify status API from outside over pre-defined OCS calls.
 
-The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/user_status/api/v1/user_status``
+The base URL for all calls to the Status API is: ``<nextcloud_base_url>/ocs/v2.php/apps/user_status/api/v1/user_status``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-translation-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-translation-api.rst
@@ -8,7 +8,7 @@ OCS Translation API
 
 The OCS Translation API allows you to translate strings from a language to another.
 
-The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/translation/``
+The base URL for all calls to the Translation API is: ``<nextcloud_base_url>/ocs/v2.php/translation/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/developer_manual/client_apis/OCS/ocs-user-preferences-api.rst
+++ b/developer_manual/client_apis/OCS/ocs-user-preferences-api.rst
@@ -4,7 +4,7 @@ OCS user preferences API
 
 The OCS user preferences API allows you to set and delete preferences from outside over pre-defined OCS calls.
 
-The base URL for all calls to the share API is: ``<nextcloud_base_url>/ocs/v2.php/apps/provisioning_api/api/v1/config/users/``
+The base URL for all calls to the User Preferences API is: ``<nextcloud_base_url>/ocs/v2.php/apps/provisioning_api/api/v1/config/users/``
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 


### PR DESCRIPTION
It looks like a few of these pages were copy/pasted from `ocs-share-api.rst` and still had a reference to "share api" at the top instead of to the actual API topic of the page. 
