### PR TITLE
Removing database READ-COMMITTED obsolete indications

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -26,15 +26,6 @@ Requirements
 
 .. _db-transaction-label:
 
-Database "READ COMMITTED" transaction isolation level
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-As discussed above Nextcloud is using the ``TRANSACTION_READ_COMMITTED`` transaction isolation
-level. Some database configurations are enforcing other transaction isolation levels. To avoid
-data loss under high load scenarios (e.g. by using the sync client with many clients/users and
-many parallel operations) you need to configure the transaction isolation level accordingly.
-Please refer to the `MySQL manual <https://dev.mysql.com/doc/refman/8.0/en/set-transaction.html>`_
-for detailed information.
 
 Parameters
 ----------

--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -24,8 +24,6 @@ Requirements
   scope of this document.  Please refer to the documentation for your specific
   database choice for instructions.
 
-.. _db-transaction-label:
-
 
 Parameters
 ----------

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -68,7 +68,6 @@ Database requirements for MySQL / MariaDB
 The following is currently required if you're running Nextcloud together with a MySQL / MariaDB database:
 
 * InnoDB storage engine (MyISAM is not supported)
-* "READ COMMITTED" transaction isolation level (See: :ref:`db-transaction-label`)
 * Disabled or BINLOG_FORMAT = ROW configured Binary Logging (See: https://dev.mysql.com/doc/refman/5.7/en/binary-log-formats.html)
 * For **Emoji (UTF8 4-byte) support** see :doc:`../configuration_database/mysql_4byte_support`
 


### PR DESCRIPTION
Hello,

As per this PR https://github.com/nextcloud/server/issues/17947 and an internal NC helpdesk ticket (number 9653557), Nextcloud sets the transaction isolation level automatically on every connection, thus removing the need to configure it on the database engine. 
This PR removes two mentions of "READ COMMITTED" in the latest doc. This can also probably be merged in older versions of the documentation.

Best regards,