### PR TITLE
fix(admin): Adjust required and recommended modules

### DIFF
--- a/admin_manual/installation/example_ubuntu.rst
+++ b/admin_manual/installation/example_ubuntu.rst
@@ -10,7 +10,7 @@ following commands in a terminal::
 
     sudo apt update && sudo apt upgrade
     sudo apt install apache2 mariadb-server libapache2-mod-php php-gd php-mysql \
-    php-curl php-mbstring php-intl php-gmp php-bcmath php-xml php-imagick php-zip
+    php-curl php-mbstring php-intl php-gmp php-xml php-imagick php-zip
 
 * This installs the packages for the Nextcloud core system. 
   If you are planning on running additional apps, keep in mind that they might

--- a/admin_manual/installation/php_configuration.rst
+++ b/admin_manual/installation/php_configuration.rst
@@ -44,6 +44,7 @@ Database connectors (pick the one for your database):
 
 * PHP module intl (increases language translation performance and fixes sorting
   of non-ASCII characters)
+* PHP module gmp (to improve performance of passwordless login (WebAuthn))
 * PHP module sodium (for Argon2 for password hashing. bcrypt is used as fallback, but if passwords were hashed with Argon2 already and the module is missing, your users can't log in. Included with PHP >= 7.2)
 
 Required for specific apps:
@@ -53,8 +54,6 @@ Required for specific apps:
   :doc:`../configuration_files/external_storage/smb`)
 * PHP module ftp (for FTP storage / external user authentication)
 * PHP module imap (for external user authentication)
-* PHP module bcmath (for passwordless login)
-* PHP module gmp (for passwordless login)
 
 Recommended for specific apps (*optional*):
 


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/pull/51521

- `bcmath` is not needed anymore.
- `gmp` is not required but recommended now for WebAuthn.
