### PR TITLE
fix(admin): Specify php-sodium requirements

### DIFF
--- a/admin_manual/installation/php_configuration.rst
+++ b/admin_manual/installation/php_configuration.rst
@@ -44,7 +44,7 @@ Database connectors (pick the one for your database):
 
 * PHP module intl (increases language translation performance and fixes sorting
   of non-ASCII characters)
-* PHP module sodium (for Argon2 for password hashing. bcrypt is used as fallback, but if passwords were hashed with Argon2 already and the module is missing, your users can't log in. Included with PHP >= 7.2)
+* PHP module sodium (for Argon2 for password hashing when PHP < 8.4 is used and PHP was built without libargon2. bcrypt is used as fallback, but if passwords were hashed with Argon2 already and the module is missing, your users can't log in.)
 
 Required for specific apps:
 


### PR DESCRIPTION
### ☑️ Resolves

The sodium extension is only needed for argon2, iff:
- PHP is < 8.4 and built without libargon2

With PHP < 8.4 you can also enable argon2 without sodium by compiling with libargon2 support.
With PHP 8.4 the argon2 support is included in php-openssl which is already a hard requirement of Nextcloud.
