### PR TITLE
fix: dead link for core navigation ocs api

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -1931,7 +1931,7 @@ defaultapp
 	'defaultapp' => 'dashboard,files',
 
 Set the default app to open on login. The entry IDs can be retrieved from
-the Navigations OCS API endpoint: https://docs.nextcloud.com/server/latest/develper_manual/_static/openapi.html#/operations/core-navigation-get-apps-navigation.
+the Navigations OCS API endpoint: https://docs.nextcloud.com/server/stable/developer_manual/_static/openapi.html#/operations/core-navigation-get-apps-navigation.
 
 You can use a comma-separated list of app names, so if the first
 app is not enabled for a user then Nextcloud will try the second one, and so


### PR DESCRIPTION
### ☑️ Resolves

* Fix dead link to Core Navigation OCS API


