### PR TITLE
Fixed invalid stt_whisper2 docker volume name (nc_app_llm2_data -> nc_app_stt_whisper2_data)

### DIFF
--- a/admin_manual/ai/app_stt_whisper2.rst
+++ b/admin_manual/ai/app_stt_whisper2.rst
@@ -39,10 +39,10 @@ Installation
 Supplying alternate models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This app allows supplying alternate models in the ``/nc_app_llm2_data`` directory of the docker container. You can use any `*faster-whisper* model by Systran on hugging face <https://huggingface.co/Systran>`_ in the following way:
+This app allows supplying alternate models in the ``/nc_app_stt_whisper2_data`` directory of the docker container. You can use any `*faster-whisper* model by Systran on hugging face <https://huggingface.co/Systran>`_ in the following way:
 
 1. git cloning the respective repository
-2. Copying the folder with the git repository to ``/nc_app_llm2_data`` inside the docker container.
+2. Copying the folder with the git repository to ``/nc_app_stt_whisper2_data`` inside the docker container.
 3. Restarting the Whisper ExApp
 4. Selecting the respective model in the Nextcloud AI admin settings
 


### PR DESCRIPTION
### ☑️ Resolves

Apparently it was just a copy-pasting error on the page, it was copied from the `llm2` documentation and the typo was missed.


