### PR TITLE
Warning about Share URL change after moving a calendar via occ

### DIFF
--- a/admin_manual/occ_command.rst
+++ b/admin_manual/occ_command.rst
@@ -594,7 +594,7 @@ This example will list all addressbooks for user annie::
 to move a calendar named ``name`` from a user ``sourceuid`` to the user
 ``destinationuid``. You can use the force option `-f` to enforce the move if there
 are conflicts with existing shares. The system will also generate a new unique
-calendar name in case there is a conflict over the destination user.
+calendar name in case there is a conflict over the destination user. Note that this will cause a share link to change.
 
 This example will move calendar named personal from user dennis to user sabine::
 


### PR DESCRIPTION
Warning about Share URL change after moving a calendar.

### ☑️ Resolves

This should be known before running the command as clients (propably many) need to be adjusted manually.
