### PR TITLE
fix(devcontainer): upgrade Python to match minimal requirements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 as final
+FROM python:3.10 as final
 
 USER root
 


### PR DESCRIPTION
`alabaster==1.0.0` requires at least Python 3.10, while DevContainer has 3.9

Upgrading to 3.10

Alternative: upgrade to the 3.13 as the latest