### PR TITLE
fix(developer_manual): typo on IAppConfig AppFramework service usage

### DIFF
--- a/developer_manual/digging_deeper/config/appconfig.rst
+++ b/developer_manual/digging_deeper/config/appconfig.rst
@@ -26,7 +26,7 @@ Any of the methods below will automatically be scoped to your app, meaning you c
         ) {}
 
         public function getSomeConfig(): string {
-            return $this->appConfig->getValueString('mykey', 'default');
+            return $this->appConfig->getAppValueString('mykey', 'default');
         }
     }
 


### PR DESCRIPTION
https://github.com/nextcloud/documentation/pull/12941#pullrequestreview-2720360086