### PR TITLE
fix: update macOS requirement for desktop clients

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -105,7 +105,7 @@ We strongly recommend using the latest version of your operating system to get t
 of our clients.
 
 * **Windows** 10+
-* **macOS** Lion (10.14)+ (64-bits only)
+* **macOS** Monterey (12.0)+ (64-bits only)
   * Please note that your server may need to be Apple App Transport Security compliant in order for the desktop client to connect successfully. This may involve using a digital certificate that is adequately signed to the standards established by Apple. More information is provided by Apple in their developer documentation: https://developer.apple.com/documentation/security/preventing-insecure-network-connections
 * **Linux** (64-bits only) Should run on any distribution newer than Ubuntu 18.04 with our official AppImage package
 

--- a/user_manual/desktop/installation.rst
+++ b/user_manual/desktop/installation.rst
@@ -34,8 +34,8 @@ System Requirements
 ----------------------------------
 
 - Windows 10+ (64-bits only)
-- macOS 11.4+ (64-bits only)
-- Linux (Ubuntu 22.04 or openSUSE 15.5 or ...) (64-bits only)
+- macOS 12.0+ (64-bits only)
+- Linux (Ubuntu 22.04 or openSUSE 15.5 or Alma 8 or ...) (64-bits only)
 
 .. note::
    For Linux distributions, we support, if technically feasible, the current LTS releases.


### PR DESCRIPTION
Qt6 only supports macOS 12 and newer.  The download websites mention 12+ already.

Also include Alma 8 (RHEL8 / Rocky 8) as a supported distro for our AppImages, as this is the base we use for building the client...

