### PR TITLE
[stable30] docs: aio-imaginary image has been moved to ghcr.io

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -213,7 +213,7 @@ external microservice: `Imaginary <https://github.com/h2non/imaginary>`_.
    See https://github.com/nextcloud/server/issues/34262
 
 We strongly recommend running our custom docker image that is more up to date than the official image.
-You can find the image at `docker.io/nextcloud/aio-imaginary:latest`.
+You can find the image at `https://ghcr.io/nextcloud-releases/aio-imaginary`.
 
 To do so, you will need to deploy the service and make sure that it is
 not accessible from outside of your servers. Then you can configure


### PR DESCRIPTION
Manual backport of #13020 