### PR TITLE
fix(webhook_listeners): removed non-existing NodeReadEvent event from documentation

### DIFF
--- a/admin_manual/webhook_listeners/index.rst
+++ b/admin_manual/webhook_listeners/index.rst
@@ -565,19 +565,6 @@ This is an exhaustive list of available events. It features the event ID and the
       }
     }
 
- * OCP\\Files\\Events\\Node\\NodeReadEvent
-
-  .. code-block:: text
-
-    array{
-      "user": array {"uid": string, "displayName": string},
-      "time": int,
-      "event": array{
-        "class": string,
-        "node": array{"id": string, "path": string}
-      }
-    }
-
  * OCP\\Files\\Events\\Node\\NodeDeletedEvent
 
   .. code-block:: text


### PR DESCRIPTION
### ☑️ Resolves

* Fix: Event `NodeReadEvent` does not exist, looks like a simple typo in the documentation.

### 🖼️ Screenshots

Not needed
