### PR TITLE
Update backup.rst to specify MariaDB command

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -44,13 +44,15 @@ MySQL/MariaDB
 ^^^^^^^^^^^^^
 
 MySQL or MariaDB, which is a drop-in MySQL replacement, is the recommended
-database engine. To backup MySQL/MariaDB::
+database engine. To backup **MySQL**::
 
     mysqldump --single-transaction -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
 If you use enabled MySQL/MariaDB 4-byte support (:doc:`../configuration_database/mysql_4byte_support`, needed for emoji), you will need to add ``--default-character-set=utf8mb4`` like this::
 
     mysqldump --single-transaction --default-character-set=utf8mb4 -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
+
+To backup **MariaDB**, replace `mysqldump` with `mariadb-dump` in the above commands.
 
 SQLite
 ^^^^^^


### PR DESCRIPTION
Specify MariaDB command, as per [MariaDB container back-up documenation](https://mariadb.com/kb/en/container-backup-and-restoration/)

### ☑️ Resolves

An issue where running `mysqldump` gives `mysqldump: not found` when MariaDB is used.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
