### PR TITLE
fix: clarify that group admins cannot add existing users to their group

### DIFF
--- a/admin_manual/configuration_user/user_configuration.rst
+++ b/admin_manual/configuration_user/user_configuration.rst
@@ -61,8 +61,10 @@ User accounts have the following properties:
 
 *Group Admin*
   Group admins are granted administrative privileges on specific groups, and
-  can add and remove users from their groups. This means they can modify the
-  username, password, email, quota, etc. of members of the group.
+  can create and remove users from their groups. This means they can modify the
+  username, password, email, quota, etc. of members of the group. Group admins
+  are not allowed to add existing users to their groups.
+
 
 *Quota*
   The maximum disk space assigned to each user. Any user that exceeds the quota


### PR DESCRIPTION
It wasn't clear enough in my opinion.
Group admins can CREATE & DELETE.
But they cannot see all the existing users and add them to their groups.