### PR TITLE
chore(developer): document deprecation of `OC_Helper::canExecute`

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.rst
@@ -51,6 +51,7 @@ Deprecated APIs
 
 - The files API endpoint ``/apps/files/api/v1/thumbnail/`` for generating previews is deprecated.
   Instead use the preview endpoint provided by Nextcloud core (``/core/preview``).
+- The legacy method ``\OC_Helper::canExecute`` is deprecated, please use the ``OCP\IBinaryFinder`` instead.
 
 Removed APIs
 ^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

* for https://github.com/nextcloud/server/pull/52802

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
