### PR TITLE
Fix call on null errors in cache docs code blocks

### DIFF
--- a/developer_manual/basics/caching.rst
+++ b/developer_manual/basics/caching.rst
@@ -121,7 +121,7 @@ A local cache instance can be acquired through the ``\OCP\ICacheFactory`` servic
 
         public function getPicture(string $url): void {
             $cache = $this->cacheFactory->createLocal('my-app-pictures');
-            $cachedPicture = $this->cache->get($url);
+            $cachedPicture = $cache->get($url);
             if ($cachedPicture !== null) {
                 return $cachedPicture;
             }
@@ -157,7 +157,7 @@ A distributed cache instance can be acquired through the ``\OCP\ICacheFactory`` 
 
         public function getPicture(string $url): void {
             $cache = $this->cacheFactory->createDistributed('my-app-pictures');
-            $cachedPicture = $this->cache->get($url);
+            $cachedPicture = $cache->get($url);
             if ($cachedPicture !== null) {
                 return $cachedPicture;
             }


### PR DESCRIPTION


### ☑️ Resolves

* Fix: Some code blocks referenced an undefined $this->cache variable instead of the defined $cache

### 🖼️ Screenshots

before:
![image](https://github.com/user-attachments/assets/9b38d0b3-4054-4d74-b53e-647c3ea629b7)

after:
![image](https://github.com/user-attachments/assets/2d282fe3-2c7a-4cff-96a3-47e08d278335)
