### PR TITLE
Fix typo in logging_configuration.rst, "admit_audit" to "admin_audit"

### DIFF
--- a/admin_manual/configuration_server/logging_configuration.rst
+++ b/admin_manual/configuration_server/logging_configuration.rst
@@ -4,7 +4,7 @@ Logging
 
 Use your Nextcloud log to review system status, or to help debug problems. You may adjust logging levels, and choose how and where log data is stored. If additional event logging is required, you can optionally activate the **admin_audit** app. 
 
-When ``file`` based logging is utilized, both the Nextcloud log and, optionally, the **admit_audit** app log can be viewed within the Nextcloud interface under *Administration settings -> Logging* (this functionality is provided by the **logreader** app).
+When ``file`` based logging is utilized, both the Nextcloud log and, optionally, the **admin_audit** app log can be viewed within the Nextcloud interface under *Administration settings -> Logging* (this functionality is provided by the **logreader** app).
 
 Further configuration and usage details for both the standard Nextcloud log and the optional **admin_audit** app log can be found below. 
 


### PR DESCRIPTION
In first section about logging, the "admin_audit app" is referred to erroneously as "admit_audit app". Not a significant typo but can cause confusion upon first reading.