### PR TITLE
Patch of add repository command in example-ubuntu.rst

### DIFF
--- a/admin_manual/office/example-ubuntu.rst
+++ b/admin_manual/office/example-ubuntu.rst
@@ -14,7 +14,7 @@ Add repository:
 
 .. code-block:: bash
 
-    sudo echo "Types: deb\nURIs: https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-deb\nSuites: ./\nSigned-By: /usr/share/keyrings/collaboraonline-release-keyring.gpg" > /etc/apt/sources.list.d/collaboraonline.sources
+    sudo echo -e "Types: deb\nURIs: https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-deb\nSuites: ./\nSigned-By: /usr/share/keyrings/collaboraonline-release-keyring.gpg" > /etc/apt/sources.list.d/collaboraonline.sources
 
 Install packages
 ****************


### PR DESCRIPTION
Added -e option at echo to enable special character to be interpreted like \n or it will raise this error due to a bad interpretation of apt in the collaboraonline.sources file:

E: Type 'deb\nURIs:' is not known on stanza 1 in source list /etc/apt/sources.list.d/collaboraonline.sources
E: The list of sources could not be read.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
