### PR TITLE
perf: enable caching setup-python to build docs faster

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: 'pip'
     - name: Install pip dependencies
       run: pip install -r requirements.txt
     - name: Build using Makefile
@@ -35,6 +36,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: 'pip'
     - name: Install pip dependencies
       run: pip install -r requirements.txt
     - name: Build using Makefile
@@ -47,6 +49,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: 'pip'
     - name: Install pip dependencies
       run: pip install -r requirements.txt
     - name: Build using Makefile
@@ -67,6 +70,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: 'pip'
     - name: Install pip dependencies
       run: pip install -r requirements.txt
     - name: Build using Makefile


### PR DESCRIPTION
### ☑️ Resolves

Uses [`setup-python`'s built-in support for GitHub's `cache` action](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows).

Looks simple per https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies

If it breaks something we can revert. ;)

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
