### PR TITLE
chore(l10n): Fix error of docutils

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -4016,9 +4016,8 @@ defined in ``OCP\Accounts\IAccountManager``. Values are merged with defaults
 from ``OC\Accounts\AccountManager``.
 
 Example: Set phone property to private scope:
-[
-  \OCP\Accounts\IAccountManager::PROPERTY_PHONE => \OCP\Accounts\IAccountManager::SCOPE_PRIVATE
-]
+
+``[\OCP\Accounts\IAccountManager::PROPERTY_PHONE => \OCP\Accounts\IAccountManager::SCOPE_PRIVATE]``
 
 projects.enabled
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
IAccountManager/home/runner/actions-runner/_work/documentation/documentation/admin_manual/configuration_server/config_sample_php_parameters.rst:4020: ERROR: Unexpected indentation. [docutils]

