### PR TITLE
fix: misleading code examples

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -254,8 +254,6 @@ If you want set a api key for imaginary':
 
 ::
 
-  <?php
-  $CONFIG = array (
     'preview_imaginary_key' => 'secret',
 
 Default WebP quality setting for preview images is '80'. Change this with:


### PR DESCRIPTION
added   $CONFIG = array ( where it was missing, and would have resultet in an broken instance

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
