### PR TITLE
fix: fix share-attributes description of the object properties names

### DIFF
--- a/developer_manual/client_apis/WebDAV/basic.rst
+++ b/developer_manual/client_apis/WebDAV/basic.rst
@@ -264,7 +264,7 @@ Supported properties
 | <ocm:share-permissions />     | | The permissions that the user has             | ``["share", "read", "write"]``                                                       |
 |                               | | over the share as a JSON array.               |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:share-attributes />       | User set attributes as a JSON array.            | ``[{ "scope" => <string>, "key" => <string>, "enabled" => <bool> }]``                |
+| <nc:share-attributes />       | User set attributes as a JSON array.            | ``[{ "scope" => <string>, "key" => <string>, "value" => <bool> }]``                  |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:sharees />                | The list of share recipient.                    | .. code-block:: XML                                                                  |
 |                               |                                                 |                                                                                      |


### PR DESCRIPTION
* Fix description of share-attributes WebDAV property JSON object structure

for reference the code is doing this
https://github.com/nextcloud/server/blob/master/lib/private/Share20/ShareAttributes.php#L50-L52