### PR TITLE
fix(developer): add isContextChatAvailable method to Context Chat OCP API

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.rst
@@ -36,6 +36,7 @@ Back-end changes
 Added APIs
 ^^^^^^^^^^
 
+- New ``OCP\ContextChat`` API. See :ref:`context_chat` for details.
 - New task processing task type ``OCP\TaskProcessing\TextToSpeech`` to convert text to speech.
 - New interface ``\OCP\Share\IShareProviderSupportsAllSharesInFolder`` extending ``\OCP\Share\IShareProvider`` to add the method ``\OCP\Share\IShareProviderSupportsAllSharesInFolder::getAllSharesInFolder`` used for querying all shares in a folder without filtering by user.
 - New method ``\OCP\IUser::canChangeEmail`` allowing to check if the user backend allows the user to change their email address.

--- a/developer_manual/digging_deeper/context_chat.rst
+++ b/developer_manual/digging_deeper/context_chat.rst
@@ -116,7 +116,10 @@ if you want to trigger an initial import of content items.
 Submitting ContentItem data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To submit content, wrap it in an ``\OCP\ContextChat\ContentItem`` object:
+Before submitting, you should check that the Context Chat app is enabled first
+by calling the ``isContextChatAvailable()`` method.
+
+Then, to submit content, wrap it in a list of ``\OCP\ContextChat\ContentItem`` objects:
 
 .. code-block:: php
 

--- a/developer_manual/digging_deeper/context_chat.rst
+++ b/developer_manual/digging_deeper/context_chat.rst
@@ -72,7 +72,7 @@ To add content and register your provider implementation you will need to use th
 The ``IContentManager`` class has the following methods:
 
  * ``isContextChatAvailable()``: Returns ``true`` if the Context Chat app is enabled, ``false`` otherwise.
- * ``registerContentProvider(string $providerClass)``
+ * ``registerContentProvider(string $providerClass)``: Register a new content provider.
  * ``submitContent(string $appId, array $items)``: Providers can use this to submit content for indexing in Context Chat.
  * ``updateAccess(string $appId, string $providerId, string $itemId, string $op, array $userIds)``: Update the access rights for a content item. Use ``\OCP\ContextChat\Type\UpdateAccessOp`` constants for the ``$op`` value.
  * ``updateAccessProvider(string $appId, string $providerId, string $op, array $userIds)``: Update the access rights for all content items from a provider. Use ``\OCP\ContextChat\Type\UpdateAccessOp`` constants for the ``$op`` value.

--- a/developer_manual/digging_deeper/context_chat.rst
+++ b/developer_manual/digging_deeper/context_chat.rst
@@ -71,6 +71,7 @@ To add content and register your provider implementation you will need to use th
 
 The ``IContentManager`` class has the following methods:
 
+ * ``isContextChatAvailable()``: Returns ``true`` if the Context Chat app is enabled, ``false`` otherwise.
  * ``registerContentProvider(string $providerClass)``
  * ``submitContent(string $appId, array $items)``: Providers can use this to submit content for indexing in Context Chat.
  * ``updateAccess(string $appId, string $providerId, string $itemId, string $op, array $userIds)``: Update the access rights for a content item. Use ``\OCP\ContextChat\Type\UpdateAccessOp`` constants for the ``$op`` value.


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #13399 
* Based on https://github.com/nextcloud/server/pull/53859#pullrequestreview-3009722950

### 🖼️ Screenshots

<img width="900" height="483" alt="Screenshot 2025-07-11 at 10-04-12 Context Chat — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/bb7cba06-cfd8-4ecf-b608-84ca5bf9270b" />
<img width="900" height="478" alt="Screenshot 2025-07-11 at 10-04-24 Context Chat — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/15148438-0daf-435e-869a-6d5e84e9615c" />
<img width="900" height="130" alt="Screenshot 2025-07-11 at 10-26-14 Upgrade to Nextcloud 32 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/002be214-d00a-4cd9-8d23-dfae709cbb5c" />
