### PR TITLE
[stable30] docs: monitoring app returns a different active user count

### DIFF
--- a/admin_manual/release_notes/upgrade_to_30.rst
+++ b/admin_manual/release_notes/upgrade_to_30.rst
@@ -36,3 +36,8 @@ Automated clean-up of app password
 ----------------------------------
 
 Nextcloud 30 will :ref:`clean-up unused app passwords<authentication-app-password-clean-up>`.
+
+Monitoring: Counting of active users
+------------------------------------
+
+Starting with Nextcloud 30.0.12 the monitoring app was adjusted to count the active users in the same way as occ user:report and the support app.


### PR DESCRIPTION
Backport of https://github.com/nextcloud/documentation/pull/13442
