### PR TITLE
docs(admin): remove X-XSS-Protection header from Nginx assets

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -1,4 +1,4 @@
-# Version 2024-07-17
+# Version 2025-07-23
 
 upstream php-handler {
     server 127.0.0.1:9000;
@@ -179,7 +179,6 @@ server {
         add_header X-Frame-Options                   "SAMEORIGIN"        always;
         add_header X-Permitted-Cross-Domain-Policies "none"              always;
         add_header X-Robots-Tag                      "noindex, nofollow" always;
-        add_header X-XSS-Protection                  "1; mode=block"     always;
         access_log off;     # Optional: Don't log access to assets
     }
 

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -1,3 +1,5 @@
+# Version 2025-07-23
+
 upstream php-handler {
     server 127.0.0.1:9000;
     #server unix:/run/php/php8.2-fpm.sock;
@@ -176,7 +178,6 @@ server {
             add_header X-Frame-Options                   "SAMEORIGIN"        always;
             add_header X-Permitted-Cross-Domain-Policies "none"              always;
             add_header X-Robots-Tag                      "noindex, nofollow" always;
-            add_header X-XSS-Protection                  "1; mode=block"     always;
             access_log off;     # Optional: Don't log access to assets
         }
 


### PR DESCRIPTION
It was removed from the config in #9188, but forgotten for the static assets block.

In addition, the date added with #12100 is updated and added to the subdir config as well, for consistency.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
