### PR TITLE
Update Minimum Supported Android Version for Files App

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -119,7 +119,7 @@ Files App
 ^^^^^^^^^
 
 - **iOS** 15.0+
-- **Android** 7.0+
+- **Android** 8.0+
 
 Talk App
 ^^^^^^^^


### PR DESCRIPTION
Starting from [3.32.0](https://github.com/nextcloud/android/releases/tag/stable-3.32.0), the minimum supported Android version for the Files app is 8.0.


