### PR TITLE
fix(admin_manual/release_notes): correct ROW FORMAT migration in 31

### DIFF
--- a/admin_manual/release_notes/upgrade_to_31.rst
+++ b/admin_manual/release_notes/upgrade_to_31.rst
@@ -14,8 +14,10 @@ Database configuration
 Other row formats than ``DYNAMIC`` for MySQL and MariaDB databases will `issue a warning since Nextcloud 24 <https://github.com/nextcloud/server/issues/34497>`_,
 as they often cause performance issues.
 With Nextcloud 31 a `more prominent new setup warning <https://github.com/nextcloud/server/pull/48547>`_ for this was added.
-To resolve the warning, in most cases running ``occ db:convert-mysql-charset`` will resolve the issue.
-If some tables are not covered by the ``occ`` command, issuing the proper ``ALTER TABLE`` DDL commands to change the row format during a maintenance window is needed.
+
+The row format can be changed via ``ALTER TABLE`` DDL commands during a maintenance window.
+Changing the row format from ``COMPRESSED`` to ``DYNAMIC`` requires about 2x the disk space and may take a long time depending on the size of the database.
+See the `MySQL documentation <https://dev.mysql.com/doc/refman/en/innodb-row-format.html>`_ for more information.
 If you're not sure how to do this, you can `find some tips and tricks from the community <https://help.nextcloud.com/t/upgrade-to-nextcloud-hub-10-31-0-0-incorrect-row-format-found-in-your-database/218366/>`_.
 
 PHP configuration


### PR DESCRIPTION
### ☑️ Resolves

* For: https://github.com/nextcloud/documentation/pull/13086
* Ref: https://github.com/nextcloud/server/pull/48547/
* The `occ db:convert-mysql-charset` command changes the **charset**, not the `ROW_FORMAT`

### 🖼️ Screenshots

<img width="922" height="266" alt="image" src="https://github.com/user-attachments/assets/7df1faec-2634-4ab3-b174-a17077609a23" />
