### PR TITLE
improve nginx conf examples to mention php-fpm timeouts

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -173,6 +173,12 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_request_buffering off;
 
+        # PHP-FPM 504 response timeouts
+        # Uncomment and increase these if facing timeout errors during large file uploads
+        #fastcgi_read_timeout 60s;
+        #fastcgi_send_timeout 60s;
+        #fastcgi_connect_timeout 60s;
+
         fastcgi_max_temp_file_size 0;
     }
 

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -172,6 +172,12 @@ server {
             fastcgi_intercept_errors on;
             fastcgi_request_buffering off;
 
+            # PHP-FPM 504 response timeouts
+            # Uncomment and increase these if facing timeout errors during large file uploads
+            #fastcgi_read_timeout 60s;
+            #fastcgi_send_timeout 60s;
+            #fastcgi_connect_timeout 60s;
+
             fastcgi_max_temp_file_size 0;
         }
 


### PR DESCRIPTION
When uploading large files, a 504 error occurs in the Nextcloud client: "It’s taking too long to connect to the server. Please try again later. If you need help, contact your server administrator.|504". Add the appropriate directives to prevent this error.
