### PR TITLE
Add documentation for changes on `IDateTimeZone`

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.rst
@@ -77,6 +77,7 @@ Added APIs
 - New method ``\OCP\Files\Template\ITemplateManager::listTemplateFields`` to allow listing the fields of a template.
 - New method ``\OCP\Files\Template\BeforeGetTemplatesEvent::shouldGetFields`` to get the event's ``withFields`` property, which should determine whether or not to perform template field extraction on the returned templates.
 - New method ``\OCP\IUser::canChangeEmail`` allowing to check if the user backend allows the user to change their email address.
+- New method ``\OCP\IDateTimeZone::getDefaultTimezone`` allowing to get the default timezone configured for Nextcloud.
 - Task processing API:
 
   - New task processing task type ``OCP\TaskProcessing\TextToSpeech`` to convert text to speech.
@@ -88,6 +89,7 @@ Changed APIs
 
 - ``\OCP\Authentication\TwoFactorAuth\ILoginSetupProvider::getBody``, ``\OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings::getBody`` and ``\OCP\Authentication\TwoFactorAuth\IProvider::getBody`` return type was broaden from ``\OCP\Template`` class to ``\OCP\Template\ITemplate`` interface. Should not change anything for applications.
 - ``\OCP\Files\Template\BeforeGetTemplatesEvent`` now takes an optional boolean constructor value, ``withFields``, that allows you to explicitly control whether template fields should be extracted. The default value is ``false``.
+- ``\OCP\IDateTimeZone::getTimezone`` now has a new optional string parameter ``userId`` allowing to request the timezone of another user than the current.
 
 Deprecated APIs
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

* for https://github.com/nextcloud/server/pull/54483/files

### 🖼️ Screenshots

before | after
---|---
<img width="3840" height="9026" alt="Screenshot 2025-08-18 at 20-48-26 Upgrade to Nextcloud 32 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/f7590487-245e-4041-8ec2-74bf28f0514e" />|<img width="3840" height="9226" alt="Screenshot 2025-08-18 at 20-48-46 Upgrade to Nextcloud 32 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/91df5cd8-e7e8-45aa-ad9e-faebed29a679" />
