### PR TITLE
Update link for public shares access_webdav.rst

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -357,7 +357,7 @@ Nextcloud provides the possibility to access public shares anonymously over WebD
 
 To access the public share, open::
 
-  https://example.com/nextcloud/public.php/webdav
+  https://example.com/nextcloud/public.php/dav/files/USERNAME
 
 in a WebDAV client, use the share token as username and the (optional) share password as the password. For example, with a share link https://example.com/s/kFy9Lek5sm928xP, ``kFy9Lek5sm928xP`` will be the username.
 


### PR DESCRIPTION
This PR fixes an old url for public shares. The old url would cause errors in nextcloud when accessing clients like rclone.
I don't know this for sure, but I think the old url got left over from a long time a go and was forgotten to be updated with the other ones.

The [developer docs](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html) contain the correct link and explanation. 

The error that appeared:
```
OC\Files\FilenameValidator::isForbidden(): Argument #1 ($path) must be of type string, null given, called in /var/www/html/lib/private/Files/View.php on line 1967
```