### PR TITLE
docs: add documentation for OC-OwnerId and OC-Permissions headers

### DIFF
--- a/developer_manual/client_apis/WebDAV/basic.rst
+++ b/developer_manual/client_apis/WebDAV/basic.rst
@@ -550,12 +550,18 @@ You can set some special headers that Nextcloud will interpret.
 Response Headers
 ----------------
 
-+-----------+------------------------------------------------+-----------------------------------------+
-|  Header   |                  Description                   |                 Example                 |
-+===========+================================================+=========================================+
-| OC-Etag   | | On creation, move and copy,                  | ``"50ef2eba7b74aa84feff013efee2a5ef"``  |
-|           | | the response contain the etag of the file.   |                                         |
-+-----------+------------------------------------------------+-----------------------------------------+
-| OC-FileId | | On creation, move and copy,                  | | Format: ``<padded-id><instance-id>``. |
-|           | | the response contain the fileid of the file. | | Example: ``00000259oczn5x60nrdu``     |
-+-----------+------------------------------------------------+-----------------------------------------+
++-------------------+-----------------------------------------------+-----------------------------------------+
+| Header            | Description                                   | Example                                 |
++===================+===============================================+=========================================+
+|| OC-Etag          || On creation, move and copy,                  || ``"50ef2eba7b74aa84feff013efee2a5ef"`` |
+||                  || the response contain the etag of the file.   ||                                        |
++-------------------+-----------------------------------------------+-----------------------------------------+
+|| OC-FileId        || On creation, move and copy,                  || Format: ``<padded-id><instance-id>``.  |
+||                  || the response contain the fileid of the file. || Example: ``00000259oczn5x60nrdu``      |
++-------------------+-----------------------------------------------+-----------------------------------------+
+|| X-NC-OwnerId     || On creation, the response contains the owner || Example: ``admin``                     |
+||                  || ID.                                          ||                                        |
++-------------------+-----------------------------------------------+-----------------------------------------+
+|| X-NC-Permissions || On creation, the response contains the       || Example: ``RGDNVW``                    |
+||                  || permissions string.                          ||                                        |
++-------------------+-----------------------------------------------+-----------------------------------------+


### PR DESCRIPTION
### Description

Relates to https://github.com/nextcloud/server/pull/54542

Adds documentation for newly added headers `OC-OwnerId` and `OC-Permissions` when uploading a file.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

<img width="1055" height="665" alt="Screenshot From 2025-08-21 18-44-38" src="https://github.com/user-attachments/assets/90b1cbc3-2c55-4b69-9053-17c6d1fd4399" />

