### PR TITLE
Fix colour statement in usage.rst

### DIFF
--- a/user_manual/desktop/usage.rst
+++ b/user_manual/desktop/usage.rst
@@ -19,10 +19,10 @@ synchronization is current and you are connected to your Nextcloud server.
 The blue icon with the white semi-circles means synchronization is in progress.
 
 .. figure:: images/icon-paused.png
-   :alt: Status icon, yellow circle and vertical parallel
+   :alt: Status icon, grey circle and vertical parallel
     lines
 
-The yellow icon with the parallel lines tells you your synchronization
+The grey icon with the parallel lines tells you your synchronization
 has been paused. (Most likely by you.)
 
 .. figure:: images/icon-offline.png


### PR DESCRIPTION
### ☑️ Resolves

* Incorrect background colour in alt text, and supporting text, for pause status icon.

### 🖼️ Screenshots

<img width="778" height="133" alt="image" src="https://github.com/user-attachments/assets/b8b7dd77-24ad-4215-9278-8ff08225a38a" />
