### PR TITLE
fix(developer_manual/translations): non-breaking space before ellipsis

### DIFF
--- a/developer_manual/basics/translations.rst
+++ b/developer_manual/basics/translations.rst
@@ -150,9 +150,14 @@ Dos and Don'ts
      - ``'``
      - Use ascii single quote
    * - ``Loading...``
-     - ``Loading …``
-     - | Use unicode triple-dot character.
-       | Add a space before the triple-dot when trimming a sentence instead of a word.
+     - ``Loading …``
+     - | Use **Unicode triple-dot** character.
+       | Add a **non-breaking space** before the triple-dot when trimming a sentence instead of a word.
+   * - | ``Loading …``
+       | (a general space ``U+0020``)
+     - | ``Loading …``
+       | (a non-breaking space ``U+00A0``)
+     - | Only use a **non-breaking space** before the triple-dot (``U+00A0``).
    * - Don't
      - Do not
      - Using the spelled out version is easier to understand and makes translating easier.


### PR DESCRIPTION
### ☑️ Resolves

* Document using non-breaking space before ellipsis.

### 🖼️ Screenshots

#### Before

<img width="915" height="668" alt="image" src="https://github.com/user-attachments/assets/1c676c84-fda9-4092-abc4-69197545a1af" />

#### After

<img width="913" height="754" alt="image" src="https://github.com/user-attachments/assets/efd9a9b1-aef7-4788-8ff6-e01ad4836e7f" />