### PR TITLE
feat(docs): friendly 404 page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -10,7 +10,13 @@ now = datetime.datetime.now()
 
 os.environ["READTHEDOCS"] = "True"
 
-extensions = ['sphinx_rtd_theme', 'sphinx_rtd_dark_mode', 'sphinx_copybutton', 'sphinxcontrib.mermaid']
+extensions = [
+    'sphinx_rtd_theme',
+    'sphinx_rtd_dark_mode',
+    'sphinx_copybutton',
+    'sphinxcontrib.mermaid',
+    'notfound.extension',
+]
 
 # General information about the project.
 copyright = str(now.year) + ' Nextcloud GmbH'
@@ -85,3 +91,25 @@ edit_on_github_branch = 'master'
 default_dark_mode = False
 
 latex_engine = "xelatex"
+
+# -- Options for sphinx-notfound-page extension -----------------------------------
+# https://github.com/readthedocs/sphinx-notfound-page
+
+# content context passed to the 404 template
+notfound_context = {
+    "title": "404 Page Not Found",
+    "body": """
+<h1>Page Not Found</h1>
+<h2>Sorry, we can't seem to find the page you're looking for.</h2>
+<h6>Error code: 404</h6>
+
+<h3>Here are some alternatives:</h3>
+<ol>
+  <li>Try using the search box.</li>
+  <li>Check the content menu on the side of this page.</li>
+  <li>Regroup at our <a href="/">documentation homepage.</a></p></li>
+</ol>
+""",
+}
+
+notfound_urls_prefix = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-mermaid==1.0.0
+sphinx-notfound-page
 sphinxcontrib-phpdomain==0.13.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0


### PR DESCRIPTION
### ☑️ Resolves

Add a proper 404 not found page.

How:

- Uses the [`sphinx-notfound-page` extension](https://sphinx-notfound-page.readthedocs.io/en/latest/) (which Read the Docs maintains). 
- The extension automatically creates a 404.html page for our docs that always matches our theme.

### 🖼️ Screenshots

#### Previous (current) behavior:

<img width="1777" height="756" alt="image" src="https://github.com/user-attachments/assets/f01f6b60-5c15-4efe-817a-7614391848b5" />

#### New: 

<img width="1772" height="753" alt="image" src="https://github.com/user-attachments/assets/875d7315-7a29-49df-8562-87f9de70aeaf" />


<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
