### PR TITLE
fix(docs): update copyright shown in footer

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -13,7 +13,7 @@ os.environ["READTHEDOCS"] = "True"
 extensions = ['sphinx_rtd_theme', 'sphinx_rtd_dark_mode', 'sphinx_copybutton', 'sphinxcontrib.mermaid']
 
 # General information about the project.
-copyright = str(now.year) + ' Nextcloud GmbH'
+copyright = '2016-' + str(now.year) + ' Nextcloud GmbH and Nextcloud contibutors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
### ☑️ Resolves

* Makes consistent with other copyright statements in the project

Two asides:

- License in this repository is CC `Attribution 3.0 Unported`
  - This is a very old version at this point; might be worth seeing what's involved in bumping it upward
 - No SPDX used in this repo currently
   - Not entirely sure what's involved in doing that or if its worth it here
 - Is there any historical (i.e. oC) stuff that should be identified differently
   - if need be Sphinx allows us to have multiple copyright lines

### 🖼️ Screenshots

Existing:

<img width="1412" height="212" alt="image" src="https://github.com/user-attachments/assets/d11c5080-1536-4dfa-a9f1-072b3a13bea6" />


New:

<img width="1412" height="234" alt="image" src="https://github.com/user-attachments/assets/0089ace0-f350-4cb9-a4a9-4889620a3fa3" />

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
