### PR TITLE
fix(troubleshooting): outdated Apache modules

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -215,9 +215,7 @@ these modules:
 * mod_security
 * mod_reqtimeout
 * mod_deflate
-* libapache2-mod-php*filter (use libapache2-mod-php8.3 instead)
-* mod_spdy together with libapache2-mod-php5 / mod_php (use fcgi or php-fpm
-  instead)
+* mod_spdy
 * mod_dav
 * mod_xsendfile / X-Sendfile (causing broken downloads if not configured
   correctly)


### PR DESCRIPTION
The apache2filter SAPI hasn't existed since PHP 7.0.

### ☑️ Resolves

See related: https://github.com/nextcloud/documentation/pull/9389#discussion_r2320224928

And SPDY is basically dead though one can find third party unmaintained Apache 2.4 ports so I'll leave it, but drop the no applicable specific comment on it.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
