### PR TITLE
fix(nginx): `fastcgi_request_buffering` must be `on`

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -94,12 +94,6 @@ nginx
 * `fastcgi_read_timeout <https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout>`_ [often the solution to 504 timeouts during ``MOVE`` transactions that occur even when using chunking]
 * `client_body_temp_path <https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path>`_
 
-Since nginx 1.7.11 a new config option `fastcgi_request_buffering
-<https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering>`_
-is available. Setting this option to ``fastcgi_request_buffering off;`` in your nginx config
-might help with timeouts during the upload. Furthermore it helps if you're running out of
-disc space on the tmp partition of your system.
-
 .. note:: Make sure that ``client_body_temp_path`` points to a partition with
    adequate space for your upload file size, and on the same partition as
    the ``upload_tmp_dir`` or ``tempdirectory`` (see below). For optimal

--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -171,7 +171,7 @@ server {
         fastcgi_pass php-handler;
 
         fastcgi_intercept_errors on;
-        fastcgi_request_buffering off;
+        fastcgi_request_buffering on;                   # Required as PHP-FPM does not support chunked transfer encoding and requires a valid ContentLength header.
 
         # PHP-FPM 504 response timeouts
         # Uncomment and increase these if facing timeout errors during large file uploads

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -170,7 +170,7 @@ server {
             fastcgi_pass php-handler;
 
             fastcgi_intercept_errors on;
-            fastcgi_request_buffering off;
+            fastcgi_request_buffering on;                   # Required as PHP-FPM does not support chunked transfer encoding and requires a valid ContentLength header.
 
             # PHP-FPM 504 response timeouts
             # Uncomment and increase these if facing timeout errors during large file uploads


### PR DESCRIPTION
* resolves: https://github.com/nextcloud/documentation/issues/9574

### ☑️ Resolves

Some clients like DAVx5 use chunked transfer encoding. PHP-FPM does not support this[1] because it requires to comply with the CGI standard - 20+ years old - which enforces a Content-Length header.

So we need to buffer the whole request until passing it to PHP-FPM.

Without this 0-byte files would be created on Nextcloud as PHP-FPM will not only set content-length to 0 but also does not pass the body data stream.

[1] https://bugs.php.net/bug.php?id=51191 and https://github.com/php/php-src/pull/7509