### PR TITLE
remove warning that nginx is not officially supported

### DIFF
--- a/admin_manual/installation/nginx.rst
+++ b/admin_manual/installation/nginx.rst
@@ -4,9 +4,6 @@
 NGINX configuration
 ===================
 
-.. warning::
-    Please note that web servers other than Apache 2.x are not officially supported.
-
 .. note::
     This page covers example NGINX configurations to run a Nextcloud server.
     These configurations examples were originally provided by `@josh4trunks <https://github.com/josh4trunks>`_


### PR DESCRIPTION
https://docs.nextcloud.com/server/stable/admin_manual/installation/system_requirements.html lists nginx as official recommendation, so this warning needs to be removed