### PR TITLE
Fix incorrect heading markup in example_centos.rst

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -136,7 +136,8 @@ Redis
     systemctl start redis.service
 
 
-**Installing Nextcloud**
+Installing Nextcloud
+--------------------
 
 Nearly there, so keep at it, you are doing great!
 
@@ -189,7 +190,8 @@ Create a firewall rule for access to apache::
     firewall-cmd --zone=public --add-service=http --permanent
     firewall-cmd --reload
 
-**SELinux**
+SELinux
+-------
 
 Again, there is an extensive write-up done on SELinux which can be found at :doc:`../installation/selinux_configuration`, so if you are using SELinux in Enforcing mode, please run the commands suggested on that page.
 The following commands only refers to this tutorial::


### PR DESCRIPTION
### ☑️ Resolves

Fixes #13633.

### 🖼️ Screenshots

Before(reference-only ToC at the right side):

<img width="665" height="344" alt="image" src="https://github.com/user-attachments/assets/b8a8eb6b-7e0d-44c3-a890-5fa488c4e0cc" />

After:

<img width="659" height="452" alt="image" src="https://github.com/user-attachments/assets/db71da97-92b0-4d04-b1ca-35a5d94bb552" />
