### PR TITLE
stable32: Fix incorrect heading markup in example_centos.rst

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -136,7 +136,8 @@ Redis
     systemctl start redis.service
 
 
-**Installing Nextcloud**
+Installing Nextcloud
+--------------------
 
 Nearly there, so keep at it, you are doing great!
 
@@ -189,7 +190,8 @@ Create a firewall rule for access to apache::
     firewall-cmd --zone=public --add-service=http --permanent
     firewall-cmd --reload
 
-**SELinux**
+SELinux
+-------
 
 Again, there is an extensive write-up done on SELinux which can be found at :doc:`../installation/selinux_configuration`, so if you are using SELinux in Enforcing mode, please run the commands suggested on that page.
 The following commands only refers to this tutorial::


### PR DESCRIPTION
### ☑️ Resolves

Fixes #13633 for stable32.

### 🖼️ Screenshots

<img width="608" height="293" alt="image" src="https://github.com/user-attachments/assets/d24c4625-e954-4d8d-93a1-e468e3a6e725" />
