### PR TITLE
stable30: Fix incorrect heading markup in example_centos.rst

### DIFF
--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -136,7 +136,8 @@ Redis
     systemctl start redis.service
 
 
-**Installing Nextcloud**
+Installing Nextcloud
+--------------------
 
 Nearly there, so keep at it, you are doing great!
 
@@ -189,7 +190,8 @@ Create a firewall rule for access to apache::
     firewall-cmd --zone=public --add-service=http --permanent
     firewall-cmd --reload
 
-**SELinux**
+SELinux
+-------
 
 Again, there is an extensive write-up done on SELinux which can be found at :doc:`../installation/selinux_configuration`, so if you are using SELinux in Enforcing mode, please run the commands suggested on that page.
 The following commands only refers to this tutorial::


### PR DESCRIPTION

### ☑️ Resolves

Fixes #13633 in stable30.

### 🖼️ Screenshots

<img width="556" height="302" alt="image" src="https://github.com/user-attachments/assets/3d3310e5-446a-422d-a360-1476c5043029" />
