### PR TITLE
feat: Automated EoL warning banner for unsupported releases

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -92,8 +92,8 @@ if (version.isdigit() and version < version_start):
     rst_prolog = """.. danger::
         **OUTDATED DOCUMENTATION**
     
-            *You are viewing documentation for a retired version of Nextcloud.
-            Do not follow these instructions for current releases.*
+        *You are viewing documentation for a retired version of Nextcloud.
+        Do not follow these instructions for current releases.*
 
         **To ensure you have the most reliable and up-to-date guidance,
         please visit the** `Nextcloud Documentation homepage


### PR DESCRIPTION
* Adds a warning banner for outdated documentation
* Visible regardless of landing page
* Applies to all types (Admin + Dev + User).
* Automated (uses existing `version_start` variable to determine currently last supported release)
* Does not require theme changes (the RTD theme doesn't support announcements)

### ☑️ Resolves

* Fix #9634

Should be backported as far back as possible (well to v13+) so that all published (ancient) documentation versions pick this up[^1].

[^1]: (may also need to trigger new deploys for those; not sure if they still get picked up automatically).

### 🖼️ Screenshots

<img width="1777" height="753" alt="image" src="https://github.com/user-attachments/assets/c36db9c0-992c-4550-8bb1-39512fdbfb07" />

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
