### PR TITLE
fix(config_sample_php_parameters): Fix typo (administrators)

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -45,7 +45,7 @@ Format
 
 The short answer is that ``config/`` files are plain text files with some special formatting 
 requirements for different types of parameters and values. This makes it extensible and easy for
-Nextcloud to interact with. It also makes it easy for administartors to view with any text viewer 
+Nextcloud to interact with. It also makes it easy for administrators to view with any text viewer 
 and from the command-line.
 
 Technically these configuration files are PHP files containing a special (to Nextcloud) PHP array 


### PR DESCRIPTION
### ☑️ Resolves

Fix a trivial typo in [Format — Configuration Parameters — Nextcloud latest Administration Manual latest documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#format).  Please let me know if an issue is required to merge this PR.

### 🖼️ Screenshots

<img width="587" height="181" alt="image" src="https://github.com/user-attachments/assets/77de9a84-59e9-4528-8a25-b1b43eaef117" />
