### PR TITLE
chore: bump min android version to 8.1

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -119,7 +119,7 @@ Files App
 ^^^^^^^^^
 
 - **iOS** 15.0+
-- **Android** 8.0+
+- **Android** 8.1+
 
 Talk App
 ^^^^^^^^


### PR DESCRIPTION
Starting from [3.33.0](https://github.com/nextcloud/android/releases/tag/stable-3.33.0), the minimum supported Android version for the Files app is 8.1.