### PR TITLE
chore(admin): drop impossible to disable PHP ext: json, hash

### DIFF
--- a/admin_manual/installation/php_configuration.rst
+++ b/admin_manual/installation/php_configuration.rst
@@ -38,8 +38,6 @@ The following PHP modules **must** be installed and enabled for Nextcloud Server
 - `fileinfo` (included with PHP)
 - `filter` (only on Mageia and FreeBSD)
 - `GD`
-- `hash` (only on FreeBSD)
-- `JSON` (included with PHP)
 - `libxml` (requires Linux package `libxml2` version >= 2.7.0)
 - `mbstring`
 - `OpenSSL` (included with PHP)
@@ -51,7 +49,7 @@ The following PHP modules **must** be installed and enabled for Nextcloud Server
 - `zip`
 - `zlib`
 
-The `ctype`, `fileinfo`, `JSON` and `OpenSSL` modules are generally included and enabled in PHP by default. Often 
+The `ctype`, `fileinfo`, and `OpenSSL` modules are generally included and enabled in PHP by default. Often 
 some of the other required modules are automatically installed by OS distribution package managers. 
 
 **How to check if a module is enabled:**  
@@ -59,7 +57,7 @@ some of the other required modules are automatically installed by OS distributio
 - Run ``php -m | grep -i <module_name>``. If you see output, the module is active.
 
 .. note::
-    The `filter` and `hash` modules are required only on Mageia and FreeBSD.  
+    The `filter` module is required only on Mageia and FreeBSD.  
 
 --------------------------------
 Required PHP Database Connectors


### PR DESCRIPTION
### ☑️ Resolves

No need to document these any longer (`json`, `hash`) because they're guaranteed to be enabled.

They're not only a part of PHP core, but impossible to disable at compile since PHP 8.0.0 and 7.4.0, respectively (including for FreeBSD).

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
