### PR TITLE
fix(webhook_listeners): Document Tag{Assigned,Unassigned}Event

### DIFF
--- a/admin_manual/webhook_listeners/index.rst
+++ b/admin_manual/webhook_listeners/index.rst
@@ -662,7 +662,7 @@ This is an exhaustive list of available events. It features the event ID and the
       }
     }
 
-* OCP\\SystemTag\\MapperEvent
+ * OCP\\SystemTag\\TagAssignedEvent
 
   .. code-block:: text
 
@@ -671,9 +671,23 @@ This is an exhaustive list of available events. It features the event ID and the
       "time": int,
       "event": array{
         "class": string,
-        'eventType' => 'OCP\SystemTag\ISystemTagObjectMapper::assignTags' | 'OCP\SystemTag\ISystemTagObjectMapper::unassignTags',
-		'objectType' => string (e.g. 'files'),
-        'objectId' => string,
-        'tagIds' => int[],
+        "objectType": string (e.g. 'files'),
+        "objectIds": string[],
+        "tagIds": int[],
+      }
+    }
+
+ * OCP\\SystemTag\\TagUnassignedEvent
+
+  .. code-block:: text
+
+    array {
+      "user": array {"uid": string, "displayName": string},
+      "time": int,
+      "event": array{
+        "class": string,
+        "objectType": string (e.g. 'files'),
+        "objectIds": string[],
+        "tagIds": int[],
       }
     }


### PR DESCRIPTION
instead of not-working MapperEvent

See https://github.com/nextcloud/server/pull/54810

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
<img width="994" height="790" alt="image" src="https://github.com/user-attachments/assets/aec3c031-afc9-4a6d-a4b9-bc6f5498dc5b" />
