### PR TITLE
Fix typo in Ubuntu installation docs (.sources → .list)

### DIFF
--- a/admin_manual/office/example-ubuntu.rst
+++ b/admin_manual/office/example-ubuntu.rst
@@ -14,7 +14,7 @@ Add repository:
 
 .. code-block:: bash
 
-    sudo echo -e "Types: deb\nURIs: https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-deb\nSuites: ./\nSigned-By: /usr/share/keyrings/collaboraonline-release-keyring.gpg" > /etc/apt/sources.list.d/collaboraonline.sources
+    sudo echo -e "Types: deb\nURIs: https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-deb\nSuites: ./\nSigned-By: /usr/share/keyrings/collaboraonline-release-keyring.gpg" > /etc/apt/sources.list.d/collaboraonline.list
 
 Install packages
 ****************


### PR DESCRIPTION
This PR fixes a typo in the Ubuntu installation documentation.
The current command uses .sources, which leads to an error:

Malformed stanza 1 in source list


Updated it to .list to ensure the correct behavior.

Issue reference: Fixes #12826