### PR TITLE
refactor: Light editing of server tuning guide

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -2,6 +2,10 @@
 Server tuning
 =============
 
+.. TODO: Add introductory paragraph
+.. TODO: Sort according to (generalized) difficulty
+.. TODO: Consider adding a category (or even table) with Impact vs Difficulty
+
 Using cron to perform background jobs
 -------------------------------------
 
@@ -11,24 +15,25 @@ benefits.
 Reducing system load
 --------------------
 
-High system load will slow down Nextcloud and might also lead to other unwanted
-side effects. To reduce load you should first identify the source of the problem.
-Tools such as htop, iotop, `netdata <https://my-netdata.io>`_ or
+High system load will slow down Nextcloud and may also lead to other unwanted
+side effects. To reduce load, you should first identify the source of the problem.
+Tools such as htop, iotop, `netdata <https://my-netdata.io>`_, or
 `glances <https://nicolargo.github.io/glances/>`_
-will help to identify the process or the drive that slows down your system. First
-you should make sure that you installed/assigned enough RAM. Swap usage should be
-prevented by all means. If you run your database inside a VM, you should not
-store it inside a VM image file. Better put it on a dedicated block device to
-reduce latency due to multiple abstraction layers.
+can help you identify the process or drive that slows down your system.
+First, make sure that you have installed and assigned enough RAM. Minimize swap 
+usage as much as possible, as excessive swapping can severely degrade performance.
+If you run your database inside a VM, use a dedicated block device for database storage
+rather than storing it inside the VM's disk image file, to reduce latency caused by 
+multiple abstraction layers.
 
 .. _caching:
 
 Log Levels
 ----------
 
-Verify the ``loglevel`` in your ``config.php``. The default the log level is 
+Verify the ``loglevel`` in your ``config.php`` file. The default log level is 
 set to ``2`` (WARN) in new installations. Sometimes this parameter is inadvertently 
-left at the DEBUG level (``0``) after a troubleshooting event. In some older installations this 
+left at the DEBUG level (``0``) after troubleshooting. In some older installations, this 
 parameter may also be something other than the default. Use ``0`` (DEBUG) 
 when you have a problem to diagnose, and then reset your log level to a 
 less-verbose level. DEBUG outputs a lot of information, and can affect your 
@@ -37,46 +42,64 @@ server performance.
 Debug Mode
 ----------
 
-Verify that ``debug`` is ``false`` in your ``config.php``. The default is ``false`` in new 
+Verify that ``debug`` is set to ``false`` in your ``config.php`` file. The default is ``false`` in new 
 installations (or when not specified). While similar to the DEBUG logging level, this option
 also disables various optimizations (to facilitate easier debugging) and generates additional 
 debug output both at the browser level and server-side. It should not be enabled in production 
-environments outside of isolated troubleshooting situations.
+environments except during isolated troubleshooting.
 
 Caching
 -------
 
-Caching improves performance by storing data, code, and other objects in memory.
-Memory cache configuration for the Nextcloud server must be installed and configured.
-See :doc:`../configuration_server/caching_configuration`.
+Caching improves performance by storing data, code, and other objects in memory. Memory caching is not enabled by default because it requires optional extensions (such as APCu) and/or system components (e.g., Redis). Although these add-ons are generally not challenging to install and activate—at least in single-server deployments—you must install them before enabling their use in Nextcloud. See :doc:../configuration_server/caching_configuration for guidance.
 
 Compression
 -----------
 
-Enabling compression in your web server for JavaScript, CSS, and SVG files improves the 
-performance because fewer bytes need to be transferred to the clients.
+Enabling compression in your web server for JavaScript, CSS, and SVG files improves performance 
+because less data is transferred to clients.
 
-Using MariaDB/MySQL instead of SQLite
--------------------------------------
+Replacing SQLite
+----------------
 
-MySQL or MariaDB are preferred because of the `performance limitations of
-SQLite with highly concurrent applications
+SQLite is a suitable database for some use cases, but using MariaDB, MySQL, or PostgreSQL can be 
+more beneficial with Nextcloud.
+
+If you do not select a database at installation time, SQLite is used by default because it does not require 
+any external components.
+
+However, MySQL/MariaDB or PostgreSQL are generally recommended for Nextcloud because of the 
+`performance limitations of SQLite with highly concurrent applications
 <https://www.sqlite.org/whentouse.html>`_, like Nextcloud.
 
-See the section :doc:`../configuration_database/linux_database_configuration` for how to
-configure Nextcloud for MySQL or MariaDB. If your installation is already running on
-SQLite then it is possible to convert to MySQL or MariaDB using the steps provided
-in :doc:`../configuration_database/db_conversion`.
+If your installation is already running on
+SQLite, you can convert to MySQL or MariaDB using the steps provided in 
+:doc:`../configuration_database/db_conversion`.
 
-For more details and help tuning your database, check `this article at MariaDB <https://mariadb.com/kb/en/optimization-and-tuning/>`_.
+See the section :doc:`../configuration_database/linux_database_configuration` for instructions
+on configuring Nextcloud for MySQL or MariaDB.
+
+Tuning your database
+--------------------
+
+Databases are not plug-and-play. They benefit not only from basic configuration for compatibility 
+with Nextcloud, but also from tuning within the environment in which they are deployed. This
+tuning should be based on your hardware, storage, usage patterns, underlying operating system,
+priorities, and other factors.
+
+For more details and help tuning your database:
+
+- `MariaDB – Optimization and Tuning <https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/>`_
+- `PostgreSQL – Resource Consumption <https://www.postgresql.org/docs/17/runtime-config-resource.html>`_
+- `PostgreSQL – Tuning Your PostgreSQL Server <https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server>`_
 
 Using Redis-based transactional file locking
 --------------------------------------------
 
-File locking is enabled by default, using the database locking backend. This
-places a significant load on your database. See the section
-:doc:`../configuration_files/files_locking_transactional` for how to
-configure Nextcloud to use Redis-based Transactional File Locking.
+Transactional File Focking uses the database as the default backend. This
+additional load on your database. See the section
+:doc:`../configuration_files/files_locking_transactional` for instructions on
+configuring Nextcloud to use Redis-based Transactional File Locking.
 
 TLS / encryption app
 --------------------
@@ -86,25 +109,23 @@ AES-NI extension. This can both speed up these operations while lowering
 processing overhead. This requires a processor with the `AES-NI instruction set
 <https://wikipedia.org/wiki/AES_instruction_set>`_.
 
-Here are some examples how to check if your CPU / environment supports the
+Here are some examples of how to check if your CPU/environment supports the
 AES-NI extension:
 
 * For each CPU core present: ``grep flags /proc/cpuinfo`` or as a summary for
-  all cores: ``grep -m 1 '^flags' /proc/cpuinfo`` If the result contains any
+  all cores: ``grep -m 1 '^flags' /proc/cpuinfo``. If the result contains
   ``aes``, the extension is present.
 
-* Search eg. on the Intel web if the processor used supports the extension
-  `Intel Processor Feature Filter
-  <https://ark.intel.com/MySearch.aspx?AESTech=true>`_ You may set a filter by
-  ``"AES New Instructions"`` to get a reduced result set.
+* For Intel processors, you can search the Intel ARK database to check if your CPU supports AES-NI. Use the `Intel Processor Feature Filter
+  <https://ark.intel.com/MySearch.aspx?AESTech=true>`_, filtering by "AES New Instructions".
 
 * For versions of openssl >= 1.0.1, AES-NI does not work via an engine and
   will not show up in the ``openssl engine`` command. It is active by default
-  on the supported hardware. You can check the openssl version via ``openssl
-  version -a``
+  on supported hardware. You can check the OpenSSL version via ``openssl
+  version -a``.
 
-* If your processor supports AES-NI but it does not show up eg via grep or
-  coreinfo, it is maybe disabled in the BIOS.
+* If your processor supports AES-NI but it does not show up via ``grep`` or
+  ``coreinfo``, it may be just be disabled in the BIOS. Check your BIOS settings.
 
 * If your environment runs virtualized, check the virtualization vendor for
   support.
@@ -112,18 +133,17 @@ AES-NI extension:
 Enable HTTP/2 for faster loading
 --------------------------------
 
-HTTP/2 has `huge speed improvements <https://www.troyhunt.com/i-wanna-go-fast-https-massive-speed-advantage/>`_ over HTTP with multiple request. Most `browsers already support HTTP/2 over TLS (HTTPS) <https://caniuse.com/#feat=http2>`_. Refer to your web server manual for guides on how to enable HTTP/2.
+HTTP/2 has `huge speed improvements <https://www.troyhunt.com/i-wanna-go-fast-https-massive-speed-advantage/>`_ over HTTP with multiple requests. Most `browsers already support HTTP/2 over TLS (HTTPS)`.
 
 Tune PHP-FPM
 ------------
 
-If you are using a default installation of PHP-FPM you might have noticed
-excessive load times on the web interface or even sync issues. This is due
-to the fact that each simultaneous request of an element is handled by a
-separate PHP-FPM process. So even on a small installation you should allow
-more processes to run in parallel to handle the requests.
+The default configuration of PHP-FPM is extremely conservative. You might notice
+excessive load times on the web interface or even sync issues. Each simultaneous
+request is handled by a separate PHP-FPM process, so even on a small installation you
+should allow more processes to run in parallel to handle requests. 
 
-`This link <https://spot13.com/pmcalculator/>`_ can help you calculate the good values for your system.
+`This link <https://spot13.com/pmcalculator/>`_ can help you calculate the optimal values for your system.
 
 Enable PHP OPcache
 ------------------
@@ -136,51 +156,49 @@ Revalidation
 OPcache revalidation in PHP handles changes made to PHP application code stored on disk. Code changes occur whenever:
 
 - Nextcloud or a Nextcloud app is upgraded 
-- a configuration change is made (e.g. ``config.php`` is modified) 
+- a configuration change is made (e.g. when ``config.php`` is modified) 
 
-Nextcloud, as much as possible, handles cache revalidation internally when required. However this is not foolproof. In a default PHP environment, revalidation is 
-enabled and cached scripts are revalidated to ensure that changes (on disk) take effect every ``2`` seconds. In many environments, these default 
-values are reasonable (and may never need to be changed). 
+Nextcloud, as much as possible, handles cache revalidation internally when required. However, this is not foolproof. In a default PHP environment, revalidation is enabled, and cached scripts are checked for changes on disk every ``2`` seconds. In many environments, these default values are reasonable and may never need to be changed.
 
 However, the revalidation frequency can be adjusted and may *potentially* enhance performance. We make no recommendations here about appropriate values for revalidation (other than the PHP defaults).
 
 .. danger::
-    Lengthening the time between revalidation (or disabling it completely) means that manual changes to scripts, including ``config.php``, will take longer before they become active (or will never do so, if
-    revalidation is disabled completely). Lengthening also increases the likelihood of transient server and application upgrade problems. It also prevents the proper toggling of maintenance mode.
-    
-.. warning::
-    If you adjust these parameters, you are more likely to need to restart/reload your web server (mod_php) or fpm after making configuration changes or performing upgrades. If you forget to do so, you 
-    will likely experience unusual behavior due to a mismatch between what is on disk and is in memory. These may appear to be bugs, but will go away as soon as you restart/reload mod_php/fpm.
+    Increasing the time between revalidations (or disabling it completely) means that changes to scripts, including ``config.php``, will take longer to become active (or may never do so if revalidation is disabled completely). Increasing the interval also raises the risk of transient server and application upgrade problems and prevents the proper toggling of maintenance mode.
 
-To change the default from ``2`` and check for changes on disk at most every ``60`` seconds, use the following setting:
+.. warning::
+    If you adjust these parameters, you are more likely to need to restart/reload your web server (``mod_php``) or PHP-FPM after making configuration changes or performing upgrades. If you forget to do so, you may experience unusual behavior due to a mismatch between what is on disk and what is in memory. These may appear to be bugs, but will go away as soon as you restart/reload ``mod_php`` / fpm.
+
+To change the default from ``2`` and check for changes on disk at most every ``60`` seconds, add the following setting to your ``php.ini`` file:
 
 .. code:: ini
 
   opcache.revalidate_freq = 60
 
-To disable the revalidation completely:
+Alternatively, you can disable the revalidation completely:
 
 .. code:: ini
 
   opcache.validate_timestamps = 0
 
-Any Server/app upgrades or changes to ``config.php`` will then require restarting PHP (or otherwise manually clearing the cache or invalidating this particular script).
+Any server or app upgrades, or changes to ``config.php``, will then require restarting PHP (or otherwise manually clearing the cache or invalidating this particular script).
 
 .. warning::
-   To avoid false reports, if your environment isn't using the PHP default revalidation values, please do not report bugs/odd behavior after upgrading Nextcloud or Nextcloud apps until after you've 
-   restarted mod_php/fpm (to confirm they are not simply caused by local revalidation configuration).
+   Please do not report bugs or odd behavior after upgrading Nextcloud or Nextcloud apps until after you've 
+   restarted mod_php/fpm (to confirm the issue is not caused by local revalidation configuration).
 
 Sizing
 ^^^^^^
 
-If any cache size limit is reached by more than 90%, the admin panel will show a related warning and suggested changes.
+If any OPcache size limit exceeds 90% of its allocated size, the admin panel will show a related warning and suggest changes.
 
-For more details check out the `official PHP documentation <https://php.net/manual/en/opcache.configuration.php>`_. To monitor OPcache usage, clear individual or all cache entries, `opcache-gui <https://github.com/amnuts/opcache-gui>`_ can be used.
+For more details, check the `official PHP documentation <https://php.net/manual/en/opcache.configuration.php>`_. To monitor OPcache usage and clear individual or all cache entries, you can use `opcache-gui <https://github.com/amnuts/opcache-gui>`_.
 
 Comments
 ^^^^^^^^
 
-Nextcloud strictly requires code comments to be preserved in opcode, which is the default. But in case PHP settings are changed on your system, you may need set the following:
+.. NOTE: This is more a troubleshooting item than a tuning one IMO
+
+Nextcloud strictly requires code comments to be preserved in opcode, which is the default. If your PHP settings have changed, ensure the following is set in your ``php.ini``:
 
 .. code:: ini
 
@@ -189,7 +207,7 @@ Nextcloud strictly requires code comments to be preserved in opcode, which is th
 JIT
 ^^^
 
-PHP 8.0 and above ship with a JIT compiler that can be enabled on x86 platforms to benefit any CPU intensive apps you might be running. To enable a tracing JIT with all optimizations:
+PHP ships with a JIT compiler that can be enabled on x86 platforms to benefit any CPU-intensive apps you might be running. To enable a tracing JIT with all optimizations, add to your ``php.ini``:
 
 .. code:: ini
 
@@ -198,8 +216,10 @@ PHP 8.0 and above ship with a JIT compiler that can be enabled on x86 platforms 
 
 .. note::
 
-    Single Nextcloud instances have shown to use less than 2 MiB of the configured JIT buffer size, so that 8 MiB is sufficient by a large margin. The overall OPcache usage however raises by a larger amount, so that ``opcache.memory_consumption`` might need to be raised in some cases. The Nextcloud admin panel will then show a related warning.
-    JIT buffer usage can be monitored with `opcache-gui <https://github.com/amnuts/opcache-gui>`_ as well.
+    Most Nextcloud instances use less than 2 MiB of the configured JIT buffer size, so 8 MiB is generally sufficient. 
+    The overall OPcache usage, however, increases by a larger margin. The PHP paramater ``opcache.memory_consumption``
+    might need to be raised in some cases. JIT buffer usage can be monitored with 
+    `opcache-gui <https://github.com/amnuts/opcache-gui>`_ as well.
 
 Previews
 --------
@@ -209,15 +229,18 @@ external microservice: `Imaginary <https://github.com/h2non/imaginary>`_.
 
 .. warning::
 
-   Imaginary is currently incompatible with server-side-encryption. 
+   Imaginary is currently incompatible with server-side encryption. 
    See https://github.com/nextcloud/server/issues/34262
 
-We strongly recommend running our custom docker image that is more up to date than the official image.
-You can find the image at `https://ghcr.io/nextcloud-releases/aio-imaginary`. When running it, a port must be mapped by adding `-p <port>:9000` to the `docker run` command, e.g. ``docker run -d -p 9000:9000 --name nextcloud_imaginary --restart always ghcr.io/nextcloud-releases/aio-imaginary:latest``.
+We strongly recommend running our custom Docker image, which is more up to date than the official image.
+You can find the image at `<https://ghcr.io/nextcloud-releases/aio-imaginary>`_. When running it, map a port by adding `-p <port>:9000` to the `docker run` command (or Compose equivalent), e.g. 
 
-To do so, you will need to deploy the service and make sure that it is
-not accessible from outside of your servers. Then you can configure
-Nextcloud to use Imaginary by editing your `config.php`:
+.. code::
+
+  docker run -d -p 9000:9000 --name nextcloud_imaginary --restart always ghcr.io/nextcloud-releases/aio-imaginary:latest
+
+Ensure the service is only accessible from your internal servers. Then, configure
+Nextcloud to use Imaginary by editing your ``config.php`` file:
 
 .. code:: php
 
@@ -233,30 +256,31 @@ Nextcloud to use Imaginary by editing your `config.php`:
 
 .. warning::
 
-   Make sure to start Imaginary with the `-return-size` command line parameter. Otherwise, there will be a minor performance impact. The flag requires a recent version of Imaginary (newer than v1.2.4) and is by default added to the `aio-imaginary` container.
-   Also make sure to add the capability `SYS_NICE` via `--cap-add=sys_nice` or `cap_add: - SYS_NICE` as it is required by imaginary to generate HEIC previews.
+   Make sure to start Imaginary with the ``-return-size`` command line parameter. Otherwise, there will be a 
+   minor performance impact. The flag requires a recent version of Imaginary (newer than v1.2.4).
+   Also, ensure to add the capability ``SYS_NICE`` via ``--cap-add=sys_nice`` or (for Compose)
+   ``cap_add: - SYS_NICE``, as it is required by Imaginary to generate HEIC previews.
 
 .. note::
 
-    For large instance, you should follow `Imaginary's scalability recommendation <https://github.com/h2non/imaginary#scalability>`.
+    For large instances, follow `Imaginary's scalability recommendation <https://github.com/h2non/imaginary#scalability>`_.
 
 Settings
 ^^^^^^^^
 
-If you want set the preview format for imaginary.  
-You can change between jpeg and webp, the default is jpeg:
+To set the preview format for Imaginary (default is jpeg), add to your ``config.php``:
 
 ::
 
     'preview_format' => 'webp',
 
-If you want set a api key for imaginary':
+To set an API key for Imaginary:
 
 ::
 
     'preview_imaginary_key' => 'secret',
 
-Default WebP quality setting for preview images is '80'. Change this with:
+The default WebP quality setting for preview images is '80'. Change this with:
 
 ::
 


### PR DESCRIPTION
### ☑️ Resolves

Note this was specifically only a minor refactor. Bigger changes will have to wait.

Mostly just typos, minor formatting matters, etc.
Minor rewording in a couple spots.

Other notable changes:

- Renamed **Using MariaDB/MySQL instead of SQLite** section to **Replacing SQLite** (and expanded it to incorporate PostgreSQL as a coequal option)
- Added **Tuning your database** section which was really a place to move the MariaDB tuning comment that was in the previous section. Also added a PostgreSQL relevant link there for consistency.

### 🖼️ Screenshots

<img width="1371" height="8055" alt="image" src="https://github.com/user-attachments/assets/eb1c6ff9-4d76-4b4d-b312-99f081c0119c" />

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
