### PR TITLE
Update migrating.rst

### DIFF
--- a/admin_manual/maintenance/migrating.rst
+++ b/admin_manual/maintenance/migrating.rst
@@ -71,6 +71,13 @@ the new location. It is also assumed that the authentication method
     sure to also run the ``maintenance:data-fingerprint`` command on the **NEW**
     system, similarly to how it is required when performing a backup restoration (See :doc:`restore` for details).
 
+#.  Delete the line 
+   'instanceid' => 'xxxxxxxxx',
+   from the nextcloud/config/config.php. It would be a duplicate of the 
+   original instance on the origin server and may make your server fail miserably.
+   It is recreated on-the-fly when you log in on your new machine, but it is 
+   appended at the end of the file.
+
 
 #.  While still having Nextcloud in maintenance mode (confirm!) and **BEFORE**
     changing the ``CNAME`` record in the DNS start up the database, Web server /


### PR DESCRIPTION
Copying the config.php works mostly fine, but making a copy of the instanceid setting (which i suppose shall be unique) makes the server fail (Internal server error / 500)
I moved my instance from the old apache server i was running to a new nginx machine. Worked fine after i deleted the instanceid setting which was recreated automatically at the end of the file.

### ☑️ Resolves

1:1 copy of a complete server installation, including server software change

### 🖼️ Screenshots
<?php
$CONFIG = array (
  'passwordsalt' => 'fakesalthjsafgvsavjnksjn',
  'secret' => 'fakesecretfdse3456789IOKJNBGT%67890OPOLKJHZGT&7ztgfds',
  'trusted_domains' =>
  array (
    0 => 'nextcloud.domain1.tld',
    1 => 'nextcloud.domain2.de',
  ),