### PR TITLE
fix(admin): supported openSUSE Leap version is 15.6

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -20,7 +20,7 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - Red Hat Enterprise Linux 8                                          |
 |                  | - Debian 12 (Bookworm)                                                |
 |                  | - SUSE Linux Enterprise Server 15                                     |
-|                  | - openSUSE Leap 15.5                                                  |
+|                  | - openSUSE Leap 15.6                                                  |
 |                  | - CentOS Stream                                                       |
 |                  | - Alpine Linux                                                        |
 +------------------+-----------------------------------------------------------------------+


### PR DESCRIPTION
### ☑️ Resolves

15.5 is eol since half a year, the supported version is 15.6.
Ref: https://en.opensuse.org/Lifetime#openSUSE_Leap