### PR TITLE
fix: connectivity check domains list

### DIFF
--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -255,7 +255,7 @@ Some functionalities require the Nextcloud server to be able to connect remote s
 This paragraph also includes the data which is being transmitted to the Nextcloud GmbH.
 Depending on your server setup, these are the possible connections:
 
-- www.nextcloud.com, www.startpage.com, www.eff.org, www.edri.org
+- www.nextcloud.com, www.startpage.com, www.eff.org, www.edri.org, nextcloud.com, startpage.com, eff.org, edri.org
 	- `optional (config)`_
 	- for checking the internet connection
 - cloud.nextcloud.com


### PR DESCRIPTION
### ☑️ Resolves

Customer reported that when using a NGFW with URL Filtering enabled, its not enough to enable `nextcloud.com` for Internet-Checking, instead we needed to allow `nextcloud.com` AND `www.nextcloud.com` otherwise the yellow error Message complaining about no Internet connection appears.

I am a bit unsure whether both `nextcloud.com` and `www.nextcloud.com` are needed.

### 🖼️ Screenshots

<img width="574" height="256" alt="image" src="https://github.com/user-attachments/assets/9e8f835e-bee0-4de1-bd8f-ca4d8aa4c4c9" />

