### PR TITLE
fix(theming): App isn't optional these days + misc section tidying

### DIFF
--- a/admin_manual/configuration_server/theming.rst
+++ b/admin_manual/configuration_server/theming.rst
@@ -2,84 +2,78 @@
 Theming
 =======
 
-With our theming feature, you are able to customize the look and feel of your
-Nextcloud instance according to the corporate design of your organization by
-replacing the Nextcloud logo and color with your own assets.
+The theming feature lets you customize the look and feel of your Nextcloud instance to match your organization's design (or - if for personal use - your own style). You can replace the Nextcloud logo and background images with your own assets, customize colors and slogans, and add dedicated legal and privacy links.
 
-The theming app is enabled by default so the section should appear by default in
-your admin-settings. If not, check in the apps management that this app is enabled.
+Theme customization is provided by the shipped and always-enabled ``theming`` app. Use the **Theming** section within the *Administration settings* menu to access all theming-related settings.
 
-Modify the appearance of Nextcloud
-----------------------------------
+Customize the appearance of Nextcloud
+-------------------------------------
 
-You can change the following parameters of the look and feel on your instance:
+You can change the following aspects of your instance's appearance:
 
 .. figure:: ../configuration_server/images/theming1.png
 
-* Name (e.g. ACME Inc. Cloud)
-* Web link (e.g. https://acme.inc/)
-* Slogan
-* Primary color: The color used for important buttons, checkboxes, and folder icon
-* Background color: The background color if no image is used, the color of header bar icons is also generated from this
-* Logo: The logo will appear in the header and on the login page. The default has 62/34 px.
-* Background and login image: The background image
+* **Name** (e.g., ACME Inc. Cloud).
+* **Web link** (e.g., https://acme.inc/).
+* **Slogan**.
+* **Primary color**: Used for important buttons, checkboxes, and folder icons.
+* **Background color**: Used when no image is set; header bar icon color is also derived from this.
+* **Logo**: Appears in the header and on the login page (default size: 62x34 px).
+* **Background and login image**: Sets the page background.
 
 .. figure:: ../configuration_server/images/theming2.png
 
-* Additional legal links (Legal notice and Privacy policy link)
-* Custom header logo and favicon as an alternative to auto-generation based on logo
-* Disable user theming: Although you can select and customize your instance, users can change their backgrounds and colors. If you want to enforce your customization, you can toggle this on.
-		
+* **Additional legal links**: Legal notice and privacy policy.
+* **Custom header logo and favicon**: Optionally override the auto-generated favicon based on your logo.
+* **Disable user theming**: Prevent users from changing backgrounds and colors. Toggle this to enforce your custom theme.
 
-Configure theming through CLI
------------------------------
+Configure theming via CLI
+-------------------------
 
-Theming configuration can also be adjusted through the ``occ theming:config`` command.
+You can also configure theming using the ``occ theming:config`` command.
 
-The following values are available to be set through this:
+Available settings include:
 
-- name, url, imprintUrl, privacyUrl, slogan, color, primary_color ``occ theming:config name "My Example Cloud"``
-- background, logo, favicon, logoheader ``occ theming:config logo /tmp/mylogo.png``
-- disable-user-theming (yes/no) ``occ theming:config disable-user-theming yes`` 
+- `name`, `url`, `imprintUrl`, `privacyUrl`, `slogan`, `color`, `primary_color`.
+  Example: ``occ theming:config name "My Example Cloud"``
+- `background`, `logo`, `favicon`, `logoheader`.
+  Example: ``occ theming:config logo /tmp/mylogo.png``
+- `disable-user-theming` (yes/no).
+  Example: ``occ theming:config disable-user-theming yes``
 
-.. note:: Images require to be read from a local file on the Nextcloud server
+.. note:: Images must be read from a local file on the Nextcloud server.
 
-Use a color instead of an image as a background:
+To use a color (instead of an image) for the background:
 
 ::
 
    occ theming:config color "#0082c9"
    occ theming:config background backgroundColor
 
-Theming of icons
-----------------
+Icon theming
+------------
 
-According to the parameters you have set, Nextcloud will automatically generate
-favicons and a header logo depending on the current logo and theming color.
+Based on your settings, Nextcloud will automatically generate favicons and a header logo using your logo and theme color.
 
-This requires the following additional dependencies:
+This requires:
 
- - PHP module ``imagick``
- - SVG support for imagick (e.g. ``libmagickcore-6.q16-3-extra`` on Debian 9 and Ubuntu 18.04)
+ - The PHP ``imagick`` module.
+ - SVG support for imagick (e.g., ``libmagickcore-7.q16-10-extra`` on Debian 13 and ``libmagickcore-6.q16-7-extra`` on Ubuntu 24.04).
 
-.. note:: In the advanced options of the theming app you are able to set a custom
-   favicon in case you do not want to use the same logo resources you have set above
-   or you do not want to install the mentioned dependencies.
+.. tip:: In the advanced options of the theming app, you can set a custom favicon if you do not want to use auto-generated resources or install the above dependencies.
 
 Branded clients
 ---------------
 
-.. note:: Nextcloud GmbH provides branding services, delivering sync clients (mobile
-   and desktop) which use your corporate identity and are pre-configured to help your
-   users get up and running in no time. If you are interested in our advanced branding &
-   support subscription, `contact our sales team <https://nextcloud.com/enterprise/>`_.
+.. TODO: Consider dropping this section (other than the note) since this isn't even available/applicable for non-enterprise users (who presumably will use docs at https://portal.nextcloud.com).
 
-The theming app supports changing the URLs to the mobile apps (Android & iOS) that
-are shown when the web interface is opened on one of those devices. Then there was a
-header shown, that redirects the user to the app in the app store. By default,
-this redirects to the Nextcloud apps. In some cases, it is wanted that this
-links to branded versions of those apps. In those cases the IDs and URLs can be
-set via the ``occ``-command::
+.. note:: Nextcloud GmbH - the company that employs Nextcloud's core maintainers - offers branding services, providing sync clients (mobile and desktop) that use your corporate identity and are pre-configured for your users. For more information on advanced branding and enterprise support offerings, `contact Nextcloud GmbH <https://nextcloud.com/enterprise/>`_.
+
+The theming app supports changing the URLs for the mobile apps (Android and iOS) that appear when users access the web interface from mobile devices. By default, these links point to the official Nextcloud apps, but you can set them to branded versions.
+
+Set custom app links using the ``occ`` command:
+
+::
 
     occ config:app:set theming AndroidClientUrl --value "https://play.google.com/store/apps/details?id=com.nextcloud.client"
     occ config:app:set theming iTunesAppId --value "1125420102"


### PR DESCRIPTION
### ☑️ Resolves

- Theming app has been `alwaysEnabled` since v26 (nextcloud/server#34609)
- Some minor clean-up of grammar and section headings
- Some very light addition / clarifications (section opener, enterprise services note)
- Updated SVG imagick package names for current Debian/Ubuntu releases

### 🖼️ Screenshots

#### BEFORE

<img width="1461" height="4780" alt="image" src="https://github.com/user-attachments/assets/93031ed5-3565-49c5-9c78-5091cf01d3c0" />

#### AFTER

<img width="1146" height="4338" alt="image" src="https://github.com/user-attachments/assets/ae64222c-ac53-4de3-ae36-e8f8e1dd3d67" />


<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
