### PR TITLE
fix(nginx): Handle large header responses for root

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -56,6 +56,13 @@ server {
     client_body_timeout 300s;
     fastcgi_buffers 64 4K;
 
+    # avoid 502 at root URL due to too large header response
+    proxy_busy_buffers_size 512k;
+    proxy_buffers 4 512k;
+    proxy_buffer_size 256k;
+    fastcgi_buffer_size 64k;
+    fastcgi_busy_buffers_size 64k;
+
     # Proxy and client response timeouts
     # Uncomment an increase these if facing timeout errors during large file uploads
     #proxy_connect_timeout 60s;

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -82,6 +82,13 @@ server {
         client_body_timeout 300s;
         fastcgi_buffers 64 4K;
 
+        # avoid 502 at root URL due to too large header response
+        proxy_busy_buffers_size 512k;
+        proxy_buffers 4 512k;
+        proxy_buffer_size 256k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         # Proxy and client response timeouts
         # Uncomment an increase these if facing timeout errors during large file uploads
         #proxy_connect_timeout 60s;


### PR DESCRIPTION
### ☑️ Resolves

* See https://help.nextcloud.com/t/resolved-502-on-nextcloud-root-after-update/233954/11.

### 🖼️ Screenshots

I do not know how to locally build and render the documentation but I only added a few lines to the sample `nginx` config files that fix an issue I faced after upgrading to NC32.
