### PR TITLE
Add note about davfs2 group creation

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -146,6 +146,9 @@ automatically every time you log in to your Linux computer.
 
     usermod -aG davfs2 <username>
 
+.. note::
+	**If the davfs2 group doesn't exist after installing the package, you may need to create it yourself and, possibly, adjust the davfs config file to use the group after you've created it.
+
 #. Then create a ``nextcloud`` directory in your home directory for the
    mount point, and ``.davfs2/`` for your personal configuration file::
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -147,7 +147,7 @@ automatically every time you log in to your Linux computer.
     usermod -aG davfs2 <username>
 
 .. note::
-	**If the davfs2 group doesn't exist after installing the package, you may need to create it yourself and, possibly, adjust the davfs config file to use the group after you've created it.
+	If the davfs2 group doesn't exist after installing the package, you may need to create it yourself and, possibly, adjust the davfs config file to use the group after you've created it.
 
 #. Then create a ``nextcloud`` directory in your home directory for the
    mount point, and ``.davfs2/`` for your personal configuration file::


### PR DESCRIPTION
I just went through setting up davfs2 on Arch and it did not create the davfs2 group for me. I also had to edit the config to make it use the group, once I created it, because it was defaulting to network. I was getting the following error when trying to mount it:

user <username> must be member of group network

Please feel free to adjust my comment if need be. :)

### 🖼️ Screenshots

<img width="1061" height="135" alt="Screenshot_20251021_172219" src="https://github.com/user-attachments/assets/0593e9c2-45fc-43f6-966a-4ecc8acf5980" />

