### PR TITLE
chore: document removal of `OC.get`, `OC.set`, `OC.reload` and `OC.redirect`

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
@@ -29,6 +29,9 @@ Removed APIs
 - ``OC.set`` and ``OC.get`` were removed. Both are deprecated since Nextcloud 19.
   For ``get``, if really needed, use `lodash get <https://lodash.com/docs#get>`_.
   And for ``set``, use `lodash set <https://lodash.com/docs#set>`_.
+- ``OC.redirect`` and ``OC.reload`` were removed. Both were deprecated since Nextcloud 17.
+  To replace ``OC.redirect`` directly use ``window.location``.
+  To replace ``OC.reload`` directly use ``window.location.reload``.
 - The `OCA.Sharing.ExternalLinkActions` API was deprecated in Nextcloud 23 and is now removed.
   It was replaced with `OCA.Sharing.ExternalShareAction` which now have a proper API by using `registerSidebarAction` from `@nextcloud/sharing` instead.
 


### PR DESCRIPTION
### ☑️ Resolves

* for https://github.com/nextcloud/server/pull/56089
* and for https://github.com/nextcloud/server/pull/56086

### 🖼️ Screenshots

<img width="1800" height="1242" alt="Screenshot 2025-10-30 at 23-04-37 Upgrade to Nextcloud 33 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/b6f42140-ffb0-4724-88e5-95eca532b05c" />

and second commit

<img width="1800" height="1346" alt="Screenshot 2025-10-30 at 23-42-17 Upgrade to Nextcloud 33 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/866ffcd5-8ac2-479d-a3cf-a65834fc5f58" />
