### PR TITLE
chore: document removal of `OC.fileIsBlacklisted`

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
@@ -32,6 +32,8 @@ Removed APIs
 - ``OC.redirect`` and ``OC.reload`` were removed. Both were deprecated since Nextcloud 17.
   To replace ``OC.redirect`` directly use ``window.location``.
   To replace ``OC.reload`` directly use ``window.location.reload``.
+- ``OC.fileIsBlacklisted`` was removed. It was deprecated since Nextcloud 18.
+  The replacement is to use ``validateFilename`` from the `@nextcloud/files <https://www.npmjs.com/package/@nextcloud/files>`_ package.
 - The `OCA.Sharing.ExternalLinkActions` API was deprecated in Nextcloud 23 and is now removed.
   It was replaced with `OCA.Sharing.ExternalShareAction` which now have a proper API by using `registerSidebarAction` from `@nextcloud/sharing` instead.
 


### PR DESCRIPTION
### ☑️ Resolves

- for https://github.com/nextcloud/server/pull/56088

### 🖼️ Screenshots
<img width="900" height="760" alt="Screenshot 2025-10-31 at 14-32-55 Upgrade to Nextcloud 33 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/c9b7c5a6-5e1b-414b-92c4-19bbe080c19c" />
