### PR TITLE
chore: `OC.AppConfig` was removed in favor of `OCP.AppConfig`

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
@@ -25,6 +25,7 @@ Removed APIs
 
 - The global ``md5`` implementation is removed. It was deprecated since Nextcloud 20 and not used by Nextcloud anymore.
   If you still need a ``md5`` implementation you can just use some external package like `crypto-browserify <https://www.npmjs.com/package/crypto-browserify>`_.
+- ``OC.AppConfig`` was deprecated since Nextcloud 16 and was now removed. Instead use ``OCP.AppConfig``.
 - The ``OC.SystemTags`` api was removed. If you need to get the list of system tags, check `this merge request <https://github.com/nextcloud/files_retention/pull/855>`_ for how to fetch the tags directly.
 - ``OC.set`` and ``OC.get`` were removed. Both are deprecated since Nextcloud 19.
   For ``get``, if really needed, use `lodash get <https://lodash.com/docs#get>`_.


### PR DESCRIPTION
### ☑️ Resolves

* for https://github.com/nextcloud/server/pull/56129

### 🖼️ Screenshots

<img width="900" height="560" alt="Screenshot 2025-11-03 at 16-30-28 Upgrade to Nextcloud 33 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/0fb00863-25ec-4d21-b450-a2198f14920f" />
