### PR TITLE
13770: Update Documentation: Federated Calendar Shares

### DIFF
--- a/admin_manual/groupware/calendar.rst
+++ b/admin_manual/groupware/calendar.rst
@@ -149,7 +149,7 @@ Run the following command to disable creating new federated calendar shares for 
 
   sudo -E -u www-data php occ config:app:set dav enableCalendarFederation --type=bool --value=false
 
-Note that existing shares will not be deleted when the feature is disabled.
+Note that existing shares will be deleted when the feature is disabled as they will fail to sync.
 
 Trash bin
 ---------


### PR DESCRIPTION
Clarified that existing federated calendar shares will be deleted when the feature is disabled.

### ☑️ Resolves outdated admin documentation

* Fix #13770 

### 🖼️ Screenshots
<img width="1171" height="437" alt="Screenshot 2025-11-04 at 12 30 54" src="https://github.com/user-attachments/assets/bdbd8456-98bb-47df-bcd3-0428a9f5786a" />

