### PR TITLE
Add Accept header to curl example in ocs-api-overview.rst

### DIFF
--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -37,6 +37,13 @@ For example: you can perform a :code:`GET` request to get information about a us
 
     curl -u username:password -X GET 'https://cloud.example.com/ocs/v1.php/...' -H "OCS-APIRequest: true"
 
+You can change the response type of your request by adding an Accept header. For example, if you prefer JSON respones:
+
+.. code-block:: bash
+
+    curl -u username:password -X GET 'https://cloud.example.com/ocs/v1.php/...' -H "Accept: application/json" -H "OCS-APIRequest: true"
+
+Adding the Accept header also ensures consistency of your responses, since some legacy OCS requests return XML as their default response, while newer requests return JSON.
 
 User metadata
 -------------

--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -37,7 +37,7 @@ For example: you can perform a :code:`GET` request to get information about a us
 
     curl -u username:password -X GET 'https://cloud.example.com/ocs/v1.php/...' -H "OCS-APIRequest: true"
 
-You can change the response type of your request by adding an Accept header. For example, if you prefer JSON respones:
+You can change the response type of your request by adding an Accept header. For example, if you prefer JSON responses:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The return type of ocs calls can easily be changed by adding an Accept header to the request. Since some ocs calls return xml as their default, while others return json, it might be beneficial to the reader to state this early in the documentation.
