### PR TITLE
Add mp4 and webm to nginx config

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -183,7 +183,7 @@ server {
     }
 
     # Serve static files
-    location ~ \.(?:css|js|mjs|svg|gif|ico|jpg|png|webp|wasm|tflite|map|ogg|flac)$ {
+    location ~ \.(?:css|js|mjs|svg|gif|ico|jpg|png|webp|wasm|tflite|map|ogg|flac|mp4|webm)$ {
         try_files $uri /index.php$request_uri;
         # HTTP response headers borrowed from Nextcloud `.htaccess`
         add_header Cache-Control                     "public, max-age=15778463$asset_immutable";

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -182,7 +182,7 @@ server {
         }
 
         # Serve static files
-        location ~ \.(?:css|js|mjs|svg|gif|ico|jpg|png|webp|wasm|tflite|map|ogg|flac)$ {
+        location ~ \.(?:css|js|mjs|svg|gif|ico|jpg|png|webp|wasm|tflite|map|ogg|flac|mp4|webm)$ {
             try_files $uri /nextcloud/index.php$request_uri;
             # HTTP response headers borrowed from Nextcloud `.htaccess`
             add_header Cache-Control                     "public, max-age=15778463$asset_immutable";


### PR DESCRIPTION
Mp4 is used by the firstrun plugin. Without these being mentioned in this section, the firstrun movie isn't shown and the first run modal dialog apparently can't be closed.

Webm added for completeness as there are files like this in firstrun assets.

### ☑️ Resolves

* no issue that I know of

### 🖼️ Screenshots

That's evident in the PR.
