### PR TITLE
fix: Invalid nested inline markup found in admin_manual/maintenance/m…

### DIFF
--- a/admin_manual/maintenance/manual_upgrade.rst
+++ b/admin_manual/maintenance/manual_upgrade.rst
@@ -10,7 +10,7 @@ timeouts) and running it in command-line mode is not an option (such as in some 
 In these cases a manual upgrade may be the best approach.
 
 A manual upgrade consists of downloading and unpacking the Nextcloud Archive file either to your PC or host. Then
-deleting your existing Nextcloud Server installation files and folders, **except ``data/`` and ``config/``**, on 
+deleting your existing Nextcloud Server installation files and folders, **except** ``data/`` and ``config/``, on 
 your host. Then moving the new Nextcloud Server installation files into the appropriate place on your host, 
 again preserving your existing ``data/`` and ``config/`` files. And doing a few other housekeeping items, such as
 making sure your installed apps are transferred into the new installation and adjusting permissions. That may sound


### PR DESCRIPTION
…anual_upgrade.rst

This PR fixes Invalid nested inline markup, reStructuredText does not support nested inline markup. added bold to only 'except' instead of around 'except ``data/`` and ``config/``'

Also this is my first contribution to any open source repo, any suggestions are welcome!

☑️ Resolves
See https://github.com/nextcloud/documentation/issues/13809

### 🖼️ Screenshots
Before - 
<img width="994" height="90" alt="Screenshot 2025-11-12 164923" src="https://github.com/user-attachments/assets/d8fa3f18-68a9-4d6f-8298-b9318e14c286" />
After -

<img width="1247" height="161" alt="Screenshot 2025-11-12 171827" src="https://github.com/user-attachments/assets/3cbcdb8a-7ee5-4c9d-8ad6-dd534d72f941" />
