### PR TITLE
docs(release-notes): add hint about s3 integrity protection

### DIFF
--- a/admin_manual/release_notes/upgrade_to_32.rst
+++ b/admin_manual/release_notes/upgrade_to_32.rst
@@ -32,3 +32,12 @@ Previews
 
 Starting with Nextcloud 32.0.1, the preview provider for MP3 files, which reads cover images embedded in the files, is disabled by default for performance and stability reasons.
 See :doc:`../configuration_files/previews_configuration` for details on how to enable or disable the preview provider.
+
+S3 integrity protections enabled, configuration update may be needed
+--------------------------------------------------------------------
+
+The AWS SDK for PHP was updated and now enables the default integrity protections for S3. If your S3 backend does not support the default integrity protection yet, you can disable it since Nextcloud 32.0.2 by adding ``'request_checksum_calculation' => 'when_required',`` and ``'response_checksum_validation' => 'when_required',`` to the object store configuration.
+
+If your S3 backend does not support this, you may see an error such as ``Checksum Type mismatch occurred, expected checksum Type: null, actual checksum Type: crc32`` in your logs when uploading files.
+
+More details about S3 integrity protection can be found at https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html and https://github.com/aws/aws-sdk-php/discussions/3100.


### PR DESCRIPTION
### ☑️ Resolves

Documentation for https://github.com/nextcloud/server/pull/56096.

### 🖼️ Screenshots

<img width="1156" height="384" alt="image" src="https://github.com/user-attachments/assets/a693052f-2656-4c02-ad82-568efb94c5ff" />


<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
