### PR TITLE
chore(AppAPI): fix typo in DSP vs HaRP diagram

### DIFF
--- a/admin_manual/exapps_management/AppAPIAndExternalApps.rst
+++ b/admin_manual/exapps_management/AppAPIAndExternalApps.rst
@@ -134,7 +134,7 @@ Frontend requests in case of Docker Socket Proxy:
 		B[Proxy]
 
 		subgraph Services behind the proxy
-			C[Dcker Socket Proxy]
+			C[Docker Socket Proxy]
 			D[ExApp]
 			E[Nextcloud Server / AppAPI]
 		end


### PR DESCRIPTION
Fixing typo, the diagramm showed Dcker Socket Proxy


