### PR TITLE
Document default setting for validateWrites (S3 Storage)

### DIFF
--- a/admin_manual/configuration_files/primary_storage.rst
+++ b/admin_manual/configuration_files/primary_storage.rst
@@ -203,6 +203,7 @@ Optional parameters less commonly needing adjustment:
 * :code:`legacy_auth` has no default
 * :code:`version` defaults to :code:`latest`
 * :code:`verify_bucket_exists` defaults to :code:`true` [Note: Setting this to :code:`false` *after* confirming the bucket has been created may provide a performance benefit, but may not be possible in multibucket scenarios.]
+* :code:`validateWrites` defaults to :code:`true` [Note: Setting this to :code:false is recommended for object stores with "eventual consistency". It prevents false errors where a file is successfully uploaded but not yet visible to an immediate check.]
 
 **If you are using Amazon S3:** the :code:`region` parameter is required unless you're happy with 
 the default of :code:`eu-west-1`. There is no need to override the :code:`hostname` or :code:`port`. 


### PR DESCRIPTION
Added note about 'validateWrites' default setting for object stores.

### ☑️ Resolves

According to https://github.com/nextcloud/server/issues/55814, i added the variable to the documentation, allowing the object's storage to be disabled from being checked on an S3 storage.


