### PR TITLE
Add documentation for OWNCLOUD_HTTP2_ENABLED variable

### DIFF
--- a/admin_manual/desktop/envvars.rst
+++ b/admin_manual/desktop/envvars.rst
@@ -13,6 +13,7 @@ The environment variables are:
 - `OWNCLOUD_MAX_PARALLEL` (default: 6) - Maximum number of parallel jobs. 
 - `OWNCLOUD_BLACKLIST_TIME_MIN` (default: 25 s) - Minimum timeout for blacklisted files.
 - `OWNCLOUD_BLACKLIST_TIME_MAX` (default: 24\*60\*60 s; one day) - Maximum timeout for blacklisted files.
+- `OWNCLOUD_HTTP2_ENABLED` (default: false) - If the client should communicate with the server using HTTP/2. (This may not be compatible with all server setups)
 
 Low Disk Space
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

Missing (useful) env variable not being documented

Proof it exists:
https://help.nextcloud.com/t/nextcloud-client-and-http2-support/177698/3
https://help.nextcloud.com/t/windows-client-upload-awful-for-small-files/237634

### 🖼️ Screenshots

<img width="1063" height="762" alt="image" src="https://github.com/user-attachments/assets/a47b7550-6a38-46ef-b3ce-753b44dc536e" />
