### PR TITLE
docs(dev/events): modernize / expand event system docs

### DIFF
--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -312,7 +312,7 @@ Below is an expanded example, building on on our earlier ``UserCreatedEvent``. I
         }
     }
 
-To register the listener in your app's boostrap class:
+To register the listener in your app's bootstrap class:
 
 .. code-block:: php
 

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -4,130 +4,148 @@
 Events
 ======
 
-Events are used to communicate between different aspects of the Nextcloud eco system. They are used in the Nextcloud server internally, for server-to-apps communication as well as inter-app communication.
+.. contents::
+   :local:
+   :depth: 2
 
+Introduction
+------------
 
-Overview
---------
+In Nextcloud, it is often important for distinct components -- including apps -- to communicate without tightly coupling their code together. **Events** are a standard solution to this problem.
 
-The term "events" is a bit broad in Nextcloud and there are multiple ways of emitting them.
+An **event** is a signal emitted by code when something noteworthy happens, such as: 
 
-* `OCP event dispatcher`_
-* `Hooks`_
-* `Public Emitter`_
+- a user logging in,
+- a file being uploaded, or
+- a group being deleted
 
+Other parts of the system -- including third-party apps -- can "listen" for these events and react by running additional logic, for example:
 
-OCP event dispatcher
+- sending a notification,
+- updating a log, or
+- blocking an operation based on business rules
+
+This pattern enables:
+
+- **Loose coupling:** The code that emits the event does not need to know which listeners will respond.
+- **Extensibility:** New features and apps can add behavior or change workflows by registering listeners for relevant events.
+- **Maintainability:** Changing or extending how an event is handled does not require altering the core functionality that emits it.
+
+**Example:**  
+Imagine a file-sharing platform - ahem - where you want to log every time a file is deleted. Instead of modifying every place in the codebase where deletions happen, the component that handles deletion emits a "file deleted" event whenever it deletes a file. A logging module can then listen for this event and record the deletion whenever it occurs -- no matter the source.
+
+**In summary:**  
+Events allow Nextcloud (and its apps and integrations) to build flexible, maintainable, and powerful features that respond to key actions across the system. 
+
+Overview of Events in Nextcloud
+-------------------------------
+
+The modern mechanism for emitting and listening to events in the server and apps is Nextcloud's **OCP Event Dispatcher**. Utilizing the OCP Event Dispatcher is the recommended and standard approach; it delivers type-safety, dependency-injection-friendly listeners, and clear, future-proof event contracts.
+
+.. warning::
+    Older approaches -- **hooks** and **public emitters** -- were used in early Nextcloud versions. They are now deprecated and available only for rare migration or compatibility scenarios.
+
+.. tip::
+    If you’re migrating old code, see `Hooks (Deprecated)`_ and `Public Emitters (Deprecated)`_ sections -- or refer to older documentation versions -- for more historical context helpful to transitioning, including some of the other ways of registering listeners.
+
+OCP Event Dispatcher
 --------------------
 
-This mechanism is a versatile and typed approach to events in Nextcloud's php code. It uses objects rather than just passing primitives or untyped arrays. This should help provide a better developer experience while lowering the risk of unexpected changes in the API that are hard to find after the initial implementation.
+This mechanism provides a robust, typed approach to events in Nextcloud's PHP code. It uses objects rather than just passing primitives or untyped arrays, improving developer experience and reducing the risk of unexpected API changes that are hard to diagnose after the initial implementation.
 
-Naming scheme
+Naming Events
 `````````````
 
-The name should reflect the subject and the actions. Suffixing event classes with `Event` makes it easier to recognize their purpose.
+Event class names should clearly reflect the subject and the action, and should be suffixed with ``Event``, making their purpose immediately recognizable.
 
-For example, if a user is created, a `UserCreatedEvent` will be emitted.
+For example, if a user is created, a ``UserCreatedEvent`` will be emitted.
 
-Events are usually emitted *after* the event has happened. If it's emitted before, it should be prefixed with `Before`.
+Events are usually emitted *after* the action has occurred. If emitted before, the event should be prefixed with ``Before``, e.g., ``BeforeUserCreatedEvent`` is emitted before user data is written to the database.
 
-Thus `BeforeUserCreatedEvent` is emitted *before* the user data is written to the database.
+.. note:: 
+    Although you may choose to name your event classes differently, sticking to this naming convention helps all Nextcloud developers understand each other's apps more easily.
 
-.. note:: Although you may choose to name your event classes differently, sticking to the convention will allow Nextcloud developers understand each other's apps more easily.
-
-.. note:: For backwards compatibility with the Symfony class `GenericEvent <https://symfony.com/doc/current/components/event_dispatcher/generic_event.html>`_, Nextcloud also provides a ``\OCP\EventDispatcher\Event`` class. With the release of Nextcloud 22 this class has been deprecated. Named and typed event classes should be used instead.
-
-Writing events
+Writing Events
 ``````````````
 
-As a rule events are dedicated classes extending ``\OCP\EventDispatcher\Event``.
+Events are dedicated classes extending ``\OCP\EventDispatcher\Event``:
 
 .. code-block:: php
 
     <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Events;
 
     use OCP\EventDispatcher\Event;
 
-    namespace OCA\MyApp\Event;
-
+    /**
+     * Event emitted when something is added in MyApp.
+     */
     class AddEvent extends Event {}
 
-The event above allows signalling that *something happened*. But in many cases you want to actually transport data like the affected resource with the event. Then the events act as simple `data transfer objects <https://en.wikipedia.org/wiki/Data_transfer_object>`_. Therefore they need a constructor that takes the arguments, private members to store them and getters to access the values in listeners.
+This event simply signals that *something happened*. In many cases, you want to transport data with the event -- for example, the affected resource. In these cases, events act as `data transfer objects <https://en.wikipedia.org/wiki/Data_transfer_object>`_: they need a constructor for the data, private members to store it, and getters for listeners to access the values:
 
 .. code-block:: php
 
     <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Events;
 
     use OCP\EventDispatcher\Event;
     use OCP\IUser;
 
+    /**
+     * Event emitted after a user has been created.
+     */
     class UserCreatedEvent extends Event {
-        private IUser $user;
 
-        public function __construct(IUser $user) {
-            parent::__construct();
-            $this->user = $user;
+        public function __construct(
+            private IUser $user
+        ) {
         }
 
         public function getUser(): IUser {
             return $this->user;
         }
-
     }
 
-Writing a listener
-``````````````````
+You may never need to write your own event, as many `Public Events <Available Public Events>`_ are already implemented by Nextcloud core and apps.
 
-A listener can be a simple callback function (or anything else that is `callable <https://www.php.net/manual/en/language.types.callable.php>`_, or a dedicated class.
+.. tip::
+    Don't get too hung up regarding data transportation at the moment if you're unfamiliar  with the topic. We'll return to the ``UserCreatedEvent`` and DTO in the context of a fuller example later on. For now, let's return to the simpler ``AddEvent``, which merely fires ("this happened"), without transporting any data to our listener.
 
+.. note::
+    You may see older code that calls the parent constructor (i.e. ``parent::__construct();``) in its Event class. This is no longer necessary; it won't hurt anything in existing code, but is a no-op.
 
-Listener callbacks
-******************
+Writing Listeners
+`````````````````
 
-You can use simple callback to react on events. They will receive the event object as first and only parameter. You can type-hint the base `Event` class or the subclass you expect and register for.
+A listener is a class that handles an event by implementing the ``OCP\EventDispatcher\IEventListener`` interface. Class names should end with ``Listener``.
 
 .. code-block:: php
 
     <?php
 
-    use OCA\MyApp\Event\AddEvent;
-    use OCP\AppFramework\App;
-    use OCP\EventDispatcher\IEventDispatcher;
+    declare(strict_types=1);
 
-    namespace OCA\MyApp\AppInfo;
+    namespace OCA\MyApp\Events;
 
-    class Application extends App {
-        public function __construct() {
-            parent::__construct('myapp');
-                /* @var IEventDispatcher $dispatcher */
-                $dispatcher = $this->getContainer()->query(IEventDispatcher::class);
-                $dispatcher->addListener(AddEvent::class, function(AddEvent $event) {
-                    // ...
-                });
-        }
-    }
-
-.. note:: Type-hinting the actual event class will give you better IDE and static analyzers support. It's generally safe to assume the dispatcher will not give you any other objects.
-
-Listener classes
-****************
-
-A class that can handle an event will implement the ``\OCP\EventDispatcher\IEventListener`` interface. Class names should end with `Listener`.
-
-.. code-block:: php
-
-    <?php
-
-    use OCA\MyApp\Event\AddEvent;
+    use OCA\MyApp\Events\AddEvent;
     use OCP\EventDispatcher\Event;
     use OCP\EventDispatcher\IEventListener;
 
-    namespace OCA\MyApp\Event;
-
+    /**
+     * Listener that adds two to a counter whenever an AddEvent is fired.
+     */
     class AddTwoListener implements IEventListener {
 
+        // The logic triggered in response to an event
         public function handle(Event $event): void {
-            if (!($event instanceOf AddEvent)) {
+            if (!($event instanceof AddEvent)) {
                 return;
             }
 
@@ -135,35 +153,237 @@ A class that can handle an event will implement the ``\OCP\EventDispatcher\IEven
         }
     }
 
+The listener is registered during app bootstrap and is instantiated by the upstream DI container when the corresponding event is fired. During the listener's existence, the handler (``handle()``) within it is called whenever an ``AddEvent`` is fired. The listener's handler implements the business logic (i.e. does the 
+interesting thing).
 
-.. note:: Php parameter type hints are not allowed to be more specific than the type hints on the interface, thus you can't use `AddEvent` in the method signature but use an `instanceOf` instead.
+.. note::
+    PHP parameter type hints cannot be more specific than those on the interface, so you can't type-hint ``AddEvent`` in the method signature; instead use instanceof inside the handler method.
 
-In the ``Application.php`` the event and the listener class are connected. The class is instantiated only when the actual event is fired.
+.. note::
+    By default there is no persistent "listener object" kept by the dispatcher. Each time the event is fired, the DI container will lazily instantiate a new instance of the listener (the class), invoke the handle() method, and then discard the instance. There are more advanced approaches to listener registration (singleton/shared), but
+    that is a more advanced use case -- not the default for DI-registered event listeners in Nextcloud. You may find this approach in core, but rarely in apps.
+
+Registering Listeners 
+`````````````````````
+
+Registering connects your listener class to the events. Modern Nextcloud apps implement the ``IBootstrap`` interface in their ``Application`` class. Event listeners should be registered in the :php:meth:`register()` method of this class by calling ``registerEventListener()``. The listener class is instantiated only when the event is fired:
 
 .. code-block:: php
 
     <?php
 
-    use OCA\MyApp\Event\AddEvent;
-    use OCA\MyApp\Listener\AddTwoListener;
-    use OCP\AppFramework\App;
-    use OCP\EventDispatcher\IEventDispatcher;
-
     namespace OCA\MyApp\AppInfo;
 
-    class Application extends App {
-        public function __construct() {
-            parent::__construct('myapp');
-            /* @var IEventDispatcher $eventDispatcher */
-            $dispatcher = $this->getContainer()->get(IEventDispatcher::class);
-            $dispatcher->addServiceListener(AddEvent::class, AddTwoListener::class);
+    use OCA\MyApp\Events\AddEvent;
+    use OCA\MyApp\Listener\AddTwoListener;
+    use OCP\AppFramework\App;
+    use OCP\AppFramework\Bootstrap\IBootstrap;
+    use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+    class Application extends App implements IBootstrap {
+        public const APP_ID = 'myapp';
+
+	    public function __construct(array $urlParams = []) {
+		    parent::__construct(self::APP_ID, $urlParams);
+	    }
+
+        public function register(IRegistrationContext $context): void {
+            // Register event listener AddTwoListener for handling AddEvent events
+            $context->registerEventListener(AddEvent::class, AddTwoListener::class);
+        }
+
+        public function boot(IBootContext $context): void {
         }
     }
 
-.. note:: The listener is resolved via the DI container, therefore you can add a constructor and type-hint services required for processing the event.
+The ``EventListener`` class (``AddTwoListener``) is instantiated by the DI container, so you can add a constructor (in the listener class) with any type-hinted dependencies your event listener needs (such as services). The ``Event`` object itself will be passed to the ``handle()`` method when the event fires. Example based on the ``AddTwoListener`` event listener class we created previously:
 
-Available Events
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Events;
+
+    use OCA\MyApp\Events\AddEvent;
+    use OCP\EventDispatcher\Event;
+    use OCP\EventDispatcher\IEventListener;
+
+    /**
+     * Listener that uses MyService (external dependency) when an AddEvent is fired.
+     */
+    class AddTwoListener implements IEventListener {
+
+        // The service/dependency is injected by the DI container
+        public function __construct(
+            private MyService $myService // injected and assigned to a private property
+        ) {
+        }
+
+        // The logic
+        public function handle(Event $event): void {
+            if (!($event instanceof AddEvent)) {
+                return;
+            }
+
+            // Use the injected service to do something (e.g. log or process the event)
+            $this->myService->logAdded($event);
+
+            // Continue with other logic if needed
+            $event->addToCounter(2);
+        }
+    }
+
+The event (``AddEvent``, etc) will **not** be passed to the listener's constructor; it’s passed to ``handle()``. The listener is injected with ``MyService`` at instantiate time; its handler is called whenever ``AddEvent`` is fired during its lifetime. When the event listener is instantiated, the upstream container injects dependencies per the type-hints in the listener's constructor (In this case, a service called ``MyService $myservice``). The``MyService`` dependency/injected service is available for use by the handler as needed.
+
+.. tip::
+    You may see older code that registers listeners in a slightly different way, such as by using lower level functions such as ``addServiceListener()`` and ``addListener()`` (and/or possibly registering via the constructor). These are not covered here as they are not recommended for newer implementations. If maintaining a 
+    legacy app that does not implement ``IBootstrap``, event listeners may be registered in the ``Application`` class as outlined in previous versions of the documentation. For all new development, use ``IBootstrap`` pattern described here.
+
+Expanded Example
 ````````````````
+
+Below is an expanded example, building on on our earlier ``UserCreatedEvent``. It demonstrates:
+
+- How to use the event's ``getUser()`` method to access payload data
+- How to inject and use a logger service in the listener
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Events;
+
+    use OCP\EventDispatcher\Event;
+    use OCP\EventDispatcher\IEventListener;
+    use OCP\IUser;
+
+    /**
+     * Event emitted after a user has been created.
+     */
+    class UserCreatedEvent extends Event {
+
+        public function __construct(
+            private IUser $user
+        ) {
+        }
+
+        // one of our DTO getters
+        public function getUser(): IUser {
+            return $this->user;
+        }
+    }
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    use OCP\EventDispatcher\Event;
+    use OCP\EventDispatcher\IEventListener;
+    use Psr\Log\LoggerInterface;
+
+    /**
+     * Listener that logs the creation of a user when UserCreatedEvent is fired.
+     */
+    class LogCreatedUserListener implements IEventListener {
+
+        // Logger is injected by the DI container
+        public function __construct(
+            private LoggerInterface $logger
+        ) {
+        }
+
+        public function handle(Event $event): void {
+            if (!($event instanceof UserCreatedEvent)) {
+                return;
+            }
+
+            // Access the created user per the event's payload
+            $user = $event->getUser();
+
+            // Log the username of the created user
+            $username = $user->getUID();
+            $this->logger->info("A new user was created: {$username}");
+        }
+    }
+
+To register the listener in your app's boostrap class:
+
+.. code-block:: php
+
+    <?php
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\AppInfo;
+
+    use OCP\AppFramework\Bootstrap\IBootstrap;
+    use OCP\AppFramework\Bootstrap\IRegistrationContext;
+    use OCA\MyApp\Events\UserCreatedEvent;
+    use OCA\MyApp\Events\LogCreatedUserListener;
+
+    class Bootstrap implements IBootstrap {
+
+        public function register(IRegistrationContext $context): void {
+            $context->registerEventListener(UserCreatedEvent::class, LogCreatedUserListener::class);
+        }
+
+        public function boot(IBootContext $context): void {
+        }
+    }
+}
+
+**Explanation:**
+
+- The ``UserCreatedEvent`` transports the ``IUser`` object as its payload.
+- ``LogCreatedUserListener`` is an event listener that receives an injected logger service via DI.
+- Inside ``handle()``, it checks if the event is a ``UserCreatedEvent``, uses ``getUser()``, then logs the new user’s UID.
+- The listener is registered using ``registerEventListener()`` within the app's bootstrap.
+
+Emitting Events
+```````````````
+
+To allow other apps or components to react to actions in your app, you can emit (dispatch) your own events at key points in your code using the ``\OCP\EventDispatcher\IEventDispatcher`` service, typically injected into your services or controllers:
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Service;
+
+    use OCP\EventDispatcher\IEventDispatcher;
+    use OCP\IUser;
+    use OCA\MyApp\Events\UserCreatedEvent;
+
+    class UserManager {
+
+        public function __construct(
+            private IEventDispatcher $dispatcher
+        ) {
+        }
+
+        public function createUser(string $uid): IUser {
+            // ... create the user in your backend/database, e.g.:
+            // $user = $this->userFactory->create($uid);
+
+            // ... any other logic ...
+
+            // Emit an event so other apps can react
+            $event = new UserCreatedEvent($user);
+            $this->dispatcher->dispatch($event);
+
+            return $user;
+        }
+    }
+
+Available Public Events
+```````````````````````
 
 Here you find an overview of the public events that can be consumed in apps. See their source files for more details.
 
@@ -393,18 +613,20 @@ This event is triggered whenever the viewer is loaded and extensions should be l
 
 .. include:: _available_events_ocp.rst
 
-Hooks
------
+Hooks (Deprecated)
+------------------
 
 .. deprecated:: 18
     Use the `OCP event dispatcher`_ instead.
 
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
 
-Hooks are used to execute code before or after an event has occurred. This is for instance useful to run cleanup code after users, groups or files have been deleted. Hooks should be registered in the :doc:`Bootstrapping process <../app_development/bootstrap>`.
+Hooks are a legacy event mechanism. Do **NOT** use for new app development.
 
-Available hooks
-```````````````
+Hooks should be registered in the :doc:`Bootstrapping process <../app_development/bootstrap>`.
+
+Using Hooks
+```````````
 
 The scope is the first parameter that is passed to the **listen** method, the second parameter is the method and the third one the callback that should be executed once the hook is being called, e.g.:
 
@@ -429,10 +651,13 @@ Hooks can also be removed by using the **removeListener** method on the object:
     $userManager->removeListener(null, null, $callback);
 
 
+Available hooks
+```````````````
+
 The following hooks are available:
 
 Session
-```````
+*******
 
 Injectable from the ServerContainer with the ``\OCP\IUserSession`` service.
 
@@ -450,7 +675,7 @@ Hooks available in scope **\\OC\\User**:
 * **logout** ()
 
 UserManager
-```````````
+***********
 
 Injectable from the ServerContainer with the ``\OCP\IUserManager`` service.
 
@@ -464,7 +689,7 @@ Hooks available in scope **\\OC\\User**:
 * **postCreateUser** (\\OC\\User\\User $user, string $password)
 
 GroupManager
-````````````
+************
 
 Hooks available in scope **\\OC\\Group**:
 
@@ -478,7 +703,7 @@ Hooks available in scope **\\OC\\Group**:
 * **postCreate** (\\OC\\Group\\Group $group)
 
 Filesystem root
-```````````````
+***************
 
 Injectable from the ServerContainer by calling the method **getRootFolder()**, **getUserFolder()** or **getAppFolder()**.
 
@@ -506,7 +731,7 @@ Filesystem hooks available in scope **\\OC\\Files**:
 * **postRename** (\\OCP\\Files\\Node $source, \\OCP\\Files\\Node $target)
 
 Filesystem scanner
-``````````````````
+******************
 
 Filesystem scanner hooks available in scope **\\OC\\Files\\Utils\\Scanner**:
 
@@ -516,10 +741,10 @@ Filesystem scanner hooks available in scope **\\OC\\Files\\Utils\\Scanner**:
 * **postScanFolder** (string $absolutePath)
 
 
-Public emitter
---------------
+Public emitters (Deprecated)
+---------------------------
 
 .. deprecated:: 18
     Use the `OCP event dispatcher`_ instead.
 
-tbd
+Emitters are a legacy event mechanism. Do **NOT** use for new app development.

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -335,7 +335,6 @@ To register the listener in your app's boostrap class:
         public function boot(IBootContext $context): void {
         }
     }
-}
 
 **Explanation:**
 
@@ -742,7 +741,7 @@ Filesystem scanner hooks available in scope **\\OC\\Files\\Utils\\Scanner**:
 
 
 Public emitters (Deprecated)
----------------------------
+----------------------------
 
 .. deprecated:: 18
     Use the `OCP event dispatcher`_ instead.

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -375,7 +375,7 @@ To allow other apps or components to react to actions in your app, you can emit 
 
             // Emit an event so other apps can react
             $event = new UserCreatedEvent($user);
-            $this->dispatcher->dispatch($event);
+            $this->dispatcher->dispatchTyped($event);
 
             return $user;
         }

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -240,6 +240,13 @@ The ``EventListener`` class (``AddTwoListener``) is instantiated by the DI conta
 
 The event (``AddEvent``, etc) will **not** be passed to the listener's constructor; it’s passed to ``handle()``. The listener is injected with ``MyService`` at instantiate time; its handler is called whenever ``AddEvent`` is fired during its lifetime. When the event listener is instantiated, the upstream container injects dependencies per the type-hints in the listener's constructor (In this case, a service called ``MyService $myservice``). The``MyService`` dependency/injected service is available for use by the handler as needed.
 
+.. warning::
+   Known limitation: Event listeners are resolved from the server container, not your app's container.
+   This means standard OCP services and auto-wirable OCA\* classes work as constructor dependencies,
+   but custom aliases, parameters, or string-keyed services registered in your app container may not
+   be available. To avoid issues, type-hint only concrete classes or OCP interfaces in your listener
+   constructors. See nextcloud/server#27793 for details and status.
+
 .. tip::
     You may see older code that registers listeners in a slightly different way, such as by using lower level functions such as ``addServiceListener()`` and ``addListener()`` (and/or possibly registering via the constructor). These are not covered here as they are not recommended for newer implementations. If maintaining a 
     legacy app that does not implement ``IBootstrap``, event listeners may be registered in the ``Application`` class as outlined in previous versions of the documentation. For all new development, use ``IBootstrap`` pattern described here.

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -53,6 +53,13 @@ OCP Event Dispatcher
 
 This mechanism provides a robust, typed approach to events in Nextcloud's PHP code. It uses objects rather than just passing primitives or untyped arrays, improving developer experience and reducing the risk of unexpected API changes that are hard to diagnose after the initial implementation.
 
+.. versionadded:: 17
+    The OCP Event Dispatcher (``\OCP\EventDispatcher\IEventDispatcher``) was introduced.
+
+.. versionadded:: 20
+    The ``IBootstrap`` interface and ``registerEventListener()`` on ``IRegistrationContext``
+    were introduced, providing the recommended registration pattern.
+
 Naming Events
 `````````````
 
@@ -117,11 +124,15 @@ This event simply signals that *something happened*. In many cases, you want to 
 You may never need to write your own event, as many `Public Events <Available Public Events>`_ are already implemented by Nextcloud core and apps.
 
 .. tip::
-    Don't get too hung up regarding data transportation at the moment if you're unfamiliar  with the topic. We'll return to the ``UserCreatedEvent`` and DTO in the context of a fuller example later on. For now, let's return to the simpler ``AddEvent``, which merely fires ("this happened"), without transporting any data to our listener.
+    Don't get too hung up regarding data transportation at the moment if you're unfamiliar with
+    the topic. We'll return to the ``UserCreatedEvent`` and DTO in the context of a fuller example
+    later on. For now, let's return to the simpler ``AddEvent``, which merely fires ("this happened"),
+    without transporting any data to our listener.
 
 .. note::
-   You might notice code calling the parent constructor in the Event class.
-   This is an empty compatibility shim; calling it is safe, but it is not required.
+   The base ``Event`` class has an empty constructor that was added as a compatibility shim.
+   Calling ``parent::__construct()`` is safe and many core event classes still do so by convention,
+   but it is not strictly required. Omitting or including it will not affect behavior.
 
 Writing Listeners
 `````````````````
@@ -166,7 +177,10 @@ interesting thing). If the event fires again within the same request, the same l
 Registering Listeners 
 `````````````````````
 
-Registering connects your listener class to the events. Modern Nextcloud apps implement the ``IBootstrap`` interface in their ``Application`` class. Event listeners should be registered in the :php:meth:`register()` method of this class by calling ``registerEventListener()``. The listener class is instantiated only when the event is fired:
+Registering connects your listener class to the events. Modern Nextcloud apps (Nextcloud 20+)
+implement the ``IBootstrap`` interface in their ``Application`` class. Event listeners should
+be registered in the :php:meth:`register()` method of this class by calling
+``registerEventListener()``. The listener class is instantiated only when the event is fired:
 
 .. code-block:: php
 
@@ -196,6 +210,14 @@ Registering connects your listener class to the events. Modern Nextcloud apps im
         public function boot(IBootContext $context): void {
         }
     }
+
+An optional third argument, ``$priority``, controls the order in which listeners fire (default ``0``).
+Higher values cause earlier execution:
+
+.. code-block:: php
+
+    // This listener fires before others registered at the default priority
+    $context->registerEventListener(AddEvent::class, AddTwoListener::class, 100);
 
 The ``EventListener`` class (``AddTwoListener``) is instantiated by the DI container, so you can add a constructor (in the listener class) with any type-hinted dependencies your event listener needs (such as services). The ``Event`` object itself will be passed to the ``handle()`` method when the event fires. Example based on the ``AddTwoListener`` event listener class we created previously:
 
@@ -238,18 +260,58 @@ The ``EventListener`` class (``AddTwoListener``) is instantiated by the DI conta
         }
     }
 
-The event (``AddEvent``, etc) will **not** be passed to the listener's constructor; it’s passed to ``handle()``. The listener is injected with ``MyService`` at instantiate time; its handler is called whenever ``AddEvent`` is fired during its lifetime. When the event listener is instantiated, the upstream container injects dependencies per the type-hints in the listener's constructor (In this case, a service called ``MyService $myservice``). The``MyService`` dependency/injected service is available for use by the handler as needed.
+The event (``AddEvent``, etc) will **not** be passed to the listener's constructor; it’s passed to
+``handle()``. The listener is injected with ``MyService`` at instantiate time; its handler is called
+whenever ``AddEvent`` is fired during its lifetime. When the event listener is instantiated, the
+upstream container injects dependencies per the type-hints in the listener's constructor (In this
+case, a service called ``MyService $myservice``). The``MyService`` dependency/injected service is
+available for use by the handler as needed.
 
 .. warning::
-   Known limitation: Event listeners are resolved from the server container, not your app's container.
-   This means standard OCP services and auto-wirable OCA\* classes work as constructor dependencies,
-   but custom aliases, parameters, or string-keyed services registered in your app container may not
-   be available. To avoid issues, type-hint only concrete classes or OCP interfaces in your listener
-   constructors. See nextcloud/server#27793 for details and status.
+   Known limitation: Event listeners are resolved from the **server** container, not your
+   app's container. The server container does attempt to route ``OCA\*`` class lookups through
+   the corresponding app container, so standard OCP services and auto-wirable ``OCA\*`` classes
+   generally work as constructor dependencies. However, custom aliases, parameters, or
+   string-keyed services registered only in your app container will **not** be available.
+   To avoid issues, type-hint only concrete classes or OCP interfaces in your listener
+   constructors. See `nextcloud/server#27793 <https://github.com/nextcloud/server/issues/27793>`_
+   (still open) for details and status.
 
 .. tip::
-    You may see older code that registers listeners in a slightly different way, such as by using lower level functions such as ``addServiceListener()`` and ``addListener()`` (and/or possibly registering via the constructor). These are not covered here as they are not recommended for newer implementations. If maintaining a 
-    legacy app that does not implement ``IBootstrap``, event listeners may be registered in the ``Application`` class as outlined in previous versions of the documentation. For all new development, use ``IBootstrap`` pattern described here.
+    **register() vs boot():** Always register ``IEventListener`` classes in ``register()`` using
+    ``registerEventListener()``. This ensures lazy loading -- your listener class is only
+    instantiated when its event fires.
+
+    The ``register()`` method is for **declarative registrations only** -- use it to tell the
+    framework what classes, aliases, and listeners exist. Do not attempt to **query or resolve**
+    services from the DI container during ``register()``, as containers are not yet fully
+    assembled. The ``IRegistrationContext`` provides methods like ``registerService()`` and
+    ``registerServiceAlias()`` for deferred service registration, but the factories you provide
+    will not be invoked until the services are actually needed.
+
+    Use ``boot()`` when you need to **resolve services or perform imperative actions**. As the
+    PHPDoc on ``IBootstrap::boot()`` states: *"At this stage you can assume that all services
+    are registered and the DI container(s) are ready to be queried."* For example, registering
+    a closure-based listener that needs a fully resolved service:
+
+    .. code-block:: php
+
+        public function boot(IBootContext $context): void {
+            $context->injectFn(function (IEventDispatcher $dispatcher) {
+                $dispatcher->addListener(SomeEvent::class, function (SomeEvent $event) {
+                    // closure-based listener with full DI access
+                });
+            });
+        }
+
+    For all new development, prefer ``IEventListener`` classes registered in ``register()``
+    over closure-based listeners registered in ``boot()``.
+
+    You may also see older code that uses lower-level functions such as ``addServiceListener()``
+    and ``addListener()`` directly. The ``registerEventListener()`` method on
+    ``IRegistrationContext`` is a convenience wrapper around ``addServiceListener()``. If
+    maintaining a legacy app that does not implement ``IBootstrap``, event listeners may be
+    registered in the ``Application`` class as outlined in previous versions of the documentation.
 
 Expanded Example
 ````````````````
@@ -267,6 +329,7 @@ Below is an expanded example, reusing our earlier ``UserCreatedEvent``. It demon
 
     namespace OCA\MyApp\Listeners;
 
+    use OCA\MyApp\Events\UserCreatedEvent;
     use OCP\EventDispatcher\Event;
     use OCP\EventDispatcher\IEventListener;
     use Psr\Log\LoggerInterface;
@@ -372,6 +435,158 @@ To allow other apps or components to react to actions in your app, you can emit 
             return $user;
         }
     }
+
+.. note::
+    Always use ``dispatchTyped()`` (available since Nextcloud 18) to emit events. The older
+    ``dispatch(string $eventName, Event $event)`` method is deprecated since Nextcloud 21 and
+    should not be used in new code.
+
+.. tip::
+    If constructing the event object is expensive, you can check whether any listeners are
+    registered before building it, using ``$dispatcher->hasListeners(UserCreatedEvent::class)``.
+    This method returns ``true`` if at least one listener is registered for the given event class.
+
+    .. versionadded:: 29
+        ``hasListeners()`` was added to ``IEventDispatcher``.
+
+Stopping Event Propagation
+``````````````````````````
+
+The base ``\OCP\EventDispatcher\Event`` class implements the `PSR-14 <https://www.php-fig.org/psr/psr-14/>`__
+``StoppableEventInterface``. Any listener can call ``$event->stopPropagation()`` to prevent subsequent
+listeners from being called for this event dispatch. You can check whether propagation has been
+stopped with ``$event->isPropagationStopped()``.
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Listeners;
+
+    use OCA\MyApp\Events\SomethingHappenedEvent;
+    use OCP\EventDispatcher\Event;
+    use OCP\EventDispatcher\IEventListener;
+
+    /**
+     * @template-implements IEventListener<SomethingHappenedEvent>
+     */
+    class StopEarlyListener implements IEventListener {
+        public function handle(Event $event): void {
+            if (!($event instanceof SomethingHappenedEvent)) {
+                return;
+            }
+
+            // Prevent any further listeners from receiving this event
+            $event->stopPropagation();
+        }
+    }
+
+.. versionadded:: 22
+    stopPropagation() and isPropagationStopped() were added to the base Event class.
+
+.. note::
+    Stopping propagation prevents later listeners from running, but it does not by
+    itself cancel or undo the action that triggered the event. To block an operation,
+    see Blocking Operations with Before Events_ below.
+
+Blocking Operations with Before Events
+``````````````````````````````````````
+
+Some ``Before*`` events allow listeners to prevent the underlying operation from completing.
+The modern approach (since Nextcloud 29) is to throw ``\OCP\Exceptions\AbortedEventException``
+from your listener:
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Listeners;
+
+    use OCP\EventDispatcher\Event;
+    use OCP\EventDispatcher\IEventListener;
+    use OCP\Exceptions\AbortedEventException;
+    use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
+
+    /**
+     * Listener that prevents deletion of nodes under certain conditions.
+     *
+     * @template-implements IEventListener<BeforeNodeDeletedEvent>
+     */
+    class PreventDeletionListener implements IEventListener {
+        public function handle(Event $event): void {
+            if (!($event instanceof BeforeNodeDeletedEvent)) {
+                return;
+            }
+
+            $node = $event->getNode();
+            if ($node->getName() === 'protected-file.txt') {
+                throw new AbortedEventException('Deletion of this file is not allowed');
+            }
+        }
+    }
+
+Not every ``Before*`` event supports aborting the operation. Check the source of the
+specific event class to see whether the emitting code catches ``AbortedEventException``.
+For example, ``BeforeNodeDeletedEvent`` and ``BeforeNodeRenamedEvent`` support this
+pattern. Some older events use a different mechanism: for example, ``BeforeDirectFileDownloadEvent``
+provides a ``setSuccessful(false)`` method instead.
+
+.. versionadded:: 29
+    ``\OCP\Exceptions\AbortedEventException` was introduced as the standard way to abort
+    operations from ``Before*`` event listeners.
+
+.. note::
+    Some events still have a legacy ``abortOperation()`` method (e.g.,
+    ``BeforeNodeDeletedEvent::abortOperation()``), but this method is deprecated since
+    Nextcloud 29 and internally just wraps/throws ``AbortedEventException``.
+
+Broadcasted Events
+``````````````````
+
+Events that extend ``\OCP\EventDispatcher\ABroadcastedEvent`` are automatically pushed to
+connected web clients (via the Nextcloud push service) after being dispatched.
+
+To create a broadcasted event, extend ``ABroadcastedEvent`` instead of ``Event`` and
+implement the required methods:
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace OCA\MyApp\Events;
+
+    use OCP\EventDispatcher\ABroadcastedEvent;
+
+    class ItemUpdatedEvent extends ABroadcastedEvent {
+
+        public function __construct(
+            private string $itemId,
+            private string $userId,
+        ) {
+        }
+
+        // Which users should receive the push notification
+        public function getUids(): array {
+            return [$this->userId];
+        }
+
+        // Serialized payload sent to clients
+        public function jsonSerialize(): array {
+            return ['itemId' => $this->itemId];
+        }
+    }
+
+You can optionally override ``broadcastAs()`` to customize the event name seen by
+clients (defaults to the fully-qualified class name).
+
+.. versionadded:: 18
+    ABroadcastedEvent was introduced.
 
 Available Public Events
 ```````````````````````
@@ -604,8 +819,11 @@ This event is triggered whenever the viewer is loaded and extensions should be l
 
 .. include:: _available_events_ocp.rst
 
-Hooks (Deprecated)
-------------------
+Deprecated
+----------
+
+Hooks
+`````
 
 .. deprecated:: 18
     Use the `OCP event dispatcher`_ instead.
@@ -617,7 +835,7 @@ Hooks are a legacy event mechanism. Do **NOT** use for new app development.
 Hooks should be registered in the :doc:`Bootstrapping process <../app_development/bootstrap>`.
 
 Using Hooks
-```````````
+***********
 
 The scope is the first parameter that is passed to the **listen** method, the second parameter is the method and the third one the callback that should be executed once the hook is being called, e.g.:
 
@@ -643,12 +861,12 @@ Hooks can also be removed by using the **removeListener** method on the object:
 
 
 Available hooks
-```````````````
+***************
 
 The following hooks are available:
 
 Session
-*******
+~~~~~~~
 
 Injectable from the ServerContainer with the ``\OCP\IUserSession`` service.
 
@@ -666,7 +884,7 @@ Hooks available in scope **\\OC\\User**:
 * **logout** ()
 
 UserManager
-***********
+~~~~~~~~~~~
 
 Injectable from the ServerContainer with the ``\OCP\IUserManager`` service.
 
@@ -680,7 +898,7 @@ Hooks available in scope **\\OC\\User**:
 * **postCreateUser** (\\OC\\User\\User $user, string $password)
 
 GroupManager
-************
+~~~~~~~~~~~~
 
 Hooks available in scope **\\OC\\Group**:
 
@@ -694,7 +912,7 @@ Hooks available in scope **\\OC\\Group**:
 * **postCreate** (\\OC\\Group\\Group $group)
 
 Filesystem root
-***************
+~~~~~~~~~~~~~~~
 
 Injectable from the ServerContainer by calling the method **getRootFolder()**, **getUserFolder()** or **getAppFolder()**.
 
@@ -722,7 +940,7 @@ Filesystem hooks available in scope **\\OC\\Files**:
 * **postRename** (\\OCP\\Files\\Node $source, \\OCP\\Files\\Node $target)
 
 Filesystem scanner
-******************
+~~~~~~~~~~~~~~~~~~
 
 Filesystem scanner hooks available in scope **\\OC\\Files\\Utils\\Scanner**:
 
@@ -731,14 +949,22 @@ Filesystem scanner hooks available in scope **\\OC\\Files\\Utils\\Scanner**:
 * **postScanFile** (string $absolutePath)
 * **postScanFolder** (string $absolutePath)
 
-Deprecated
-----------
+GenericEvent
+````````````
+
+.. deprecated:: 22
+    Use dedicated, typed event classes extending ``\OCP\EventDispatcher\Event`` instead.
+
+``\OCP\EventDispatcher\GenericEvent`` is a convenience class that allows passing arbitrary
+key-value data via an array. It still exists in the codebase for backward compatibility,
+but all new code should use purpose-built event classes with typed properties and getters.
+If you encounter ``GenericEvent`` in existing code, consider migrating to a dedicated event class.
 
 dispatch() - string-named
 `````````````````````````
 
 .. deprecated:: 21
-   Use ``dispatchType()`` instead.
+   Use ``dispatchTyped()`` instead.
 
 Public emitters
 ```````````````

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -83,7 +83,7 @@ Events are dedicated classes extending ``\OCP\EventDispatcher\Event``:
     /**
      * Event emitted when something is added in MyApp.
      */
-    class AddEvent extends Event {}
+    class SomethingHappenedEvent extends Event {}
 
 This event simply signals that *something happened*. In many cases, you want to transport data with the event -- for example, the affected resource. In these cases, events act as `data transfer objects <https://en.wikipedia.org/wiki/Data_transfer_object>`_: they need a constructor for the data, private members to store it, and getters for listeners to access the values:
 
@@ -96,6 +96,7 @@ This event simply signals that *something happened*. In many cases, you want to 
     namespace OCA\MyApp\Events;
 
     use OCP\EventDispatcher\Event;
+    use OCP\EventDispatcher\IEventListener;
     use OCP\IUser;
 
     /**
@@ -108,6 +109,7 @@ This event simply signals that *something happened*. In many cases, you want to 
         ) {
         }
 
+        // one of our DTO getters
         public function getUser(): IUser {
             return $this->user;
         }
@@ -132,7 +134,7 @@ A listener is a class that handles an event by implementing the ``OCP\EventDispa
 
     declare(strict_types=1);
 
-    namespace OCA\MyApp\Events;
+    namespace OCA\MyApp\Listeners;
 
     use OCA\MyApp\Events\AddEvent;
     use OCP\EventDispatcher\Event;
@@ -175,17 +177,18 @@ Registering connects your listener class to the events. Modern Nextcloud apps im
     namespace OCA\MyApp\AppInfo;
 
     use OCA\MyApp\Events\AddEvent;
-    use OCA\MyApp\Listener\AddTwoListener;
+    use OCA\MyApp\Listeners\AddTwoListener;
     use OCP\AppFramework\App;
+    use OCP\AppFramework\Bootstrap\IBootContext;
     use OCP\AppFramework\Bootstrap\IBootstrap;
     use OCP\AppFramework\Bootstrap\IRegistrationContext;
 
     class Application extends App implements IBootstrap {
         public const APP_ID = 'myapp';
 
-	    public function __construct(array $urlParams = []) {
-		    parent::__construct(self::APP_ID, $urlParams);
-	    }
+        public function __construct(array $urlParams = []) {
+            parent::__construct(self::APP_ID, $urlParams);
+        }
 
         public function register(IRegistrationContext $context): void {
             // Register event listener AddTwoListener for handling AddEvent events
@@ -204,7 +207,7 @@ The ``EventListener`` class (``AddTwoListener``) is instantiated by the DI conta
 
     declare(strict_types=1);
 
-    namespace OCA\MyApp\Events;
+    namespace OCA\MyApp\Listeners;
 
     use OCA\MyApp\Events\AddEvent;
     use OCP\EventDispatcher\Event;
@@ -244,7 +247,7 @@ The event (``AddEvent``, etc) will **not** be passed to the listener's construct
 Expanded Example
 ````````````````
 
-Below is an expanded example, building on on our earlier ``UserCreatedEvent``. It demonstrates:
+Below is an expanded example, reusing our earlier ``UserCreatedEvent``. It demonstrates:
 
 - How to use the event's ``getUser()`` method to access payload data
 - How to inject and use a logger service in the listener
@@ -255,33 +258,7 @@ Below is an expanded example, building on on our earlier ``UserCreatedEvent``. I
 
     declare(strict_types=1);
 
-    namespace OCA\MyApp\Events;
-
-    use OCP\EventDispatcher\Event;
-    use OCP\EventDispatcher\IEventListener;
-    use OCP\IUser;
-
-    /**
-     * Event emitted after a user has been created.
-     */
-    class UserCreatedEvent extends Event {
-
-        public function __construct(
-            private IUser $user
-        ) {
-        }
-
-        // one of our DTO getters
-        public function getUser(): IUser {
-            return $this->user;
-        }
-    }
-
-.. code-block:: php
-
-    <?php
-
-    declare(strict_types=1);
+    namespace OCA\MyApp\Listeners;
 
     use OCP\EventDispatcher\Event;
     use OCP\EventDispatcher\IEventListener;
@@ -321,12 +298,19 @@ To register the listener in your app's bootstrap class:
 
     namespace OCA\MyApp\AppInfo;
 
+    use OCA\MyApp\Events\UserCreatedEvent;
+    use OCA\MyApp\Listeners\LogCreatedUserListener;
+    use OCP\AppFramework\App;
+    use OCP\AppFramework\Bootstrap\IBootContext;
     use OCP\AppFramework\Bootstrap\IBootstrap;
     use OCP\AppFramework\Bootstrap\IRegistrationContext;
-    use OCA\MyApp\Events\UserCreatedEvent;
-    use OCA\MyApp\Events\LogCreatedUserListener;
 
-    class Bootstrap implements IBootstrap {
+    class Application extends App implements IBootstrap {
+        public const APP_ID = 'myapp';
+
+        public function __construct(array $urlParams = []) {
+            parent::__construct(self::APP_ID, $urlParams);
+        }
 
         public function register(IRegistrationContext $context): void {
             $context->registerEventListener(UserCreatedEvent::class, LogCreatedUserListener::class);

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -142,6 +142,8 @@ A listener is a class that handles an event by implementing the ``OCP\EventDispa
 
     /**
      * Listener that adds two to a counter whenever an AddEvent is fired.
+     *
+     * @template-implements IEventListener<AddEvent>
      */
     class AddTwoListener implements IEventListener {
 
@@ -211,6 +213,8 @@ The ``EventListener`` class (``AddTwoListener``) is instantiated by the DI conta
 
     /**
      * Listener that uses MyService (external dependency) when an AddEvent is fired.
+     *
+     * @template-implements IEventListener<AddEvent>
      */
     class AddTwoListener implements IEventListener {
 
@@ -262,12 +266,14 @@ Below is an expanded example, reusing our earlier ``UserCreatedEvent``. It demon
 
     /**
      * Listener that logs the creation of a user when UserCreatedEvent is fired.
+     *
+     * @template-implements IEventListener<UserCreatedEvent>
      */
     class LogCreatedUserListener implements IEventListener {
 
         // Logger is injected by the DI container
         public function __construct(
-            private LoggerInterface $logger
+            private LoggerInterface $logger,
         ) {
         }
 
@@ -341,9 +347,8 @@ To allow other apps or components to react to actions in your app, you can emit 
     use OCA\MyApp\Events\UserCreatedEvent;
 
     class UserManager {
-
         public function __construct(
-            private IEventDispatcher $dispatcher
+            private IEventDispatcher $dispatcher,
         ) {
         }
 

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -155,15 +155,11 @@ A listener is a class that handles an event by implementing the ``OCP\EventDispa
         }
     }
 
-The listener is registered during app bootstrap and is instantiated by the upstream DI container when the corresponding event is fired. During the listener's existence, the handler (``handle()``) within it is called whenever an ``AddEvent`` is fired. The listener's handler implements the business logic (i.e. does the 
-interesting thing).
+The listener is registered during app bootstrap and is lazily instantiated by the upstream DI container the first time the corresponding event fires. During the listener's existence, the handler (``handle()``) within it is called whenever an ``AddEvent`` is fired. The listener's handler implements the business logic (i.e. does the 
+interesting thing). If the event fires again within the same request, the same listener instance is reused.
 
 .. note::
     PHP parameter type hints cannot be more specific than those on the interface, so you can't type-hint ``AddEvent`` in the method signature; instead use instanceof inside the handler method.
-
-.. note::
-    By default there is no persistent "listener object" kept by the dispatcher. Each time the event is fired, the DI container will lazily instantiate a new instance of the listener (the class), invoke the handle() method, and then discard the instance. There are more advanced approaches to listener registration (singleton/shared), but
-    that is a more advanced use case -- not the default for DI-registered event listeners in Nextcloud. You may find this approach in core, but rarely in apps.
 
 Registering Listeners 
 `````````````````````

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -46,7 +46,7 @@ The modern mechanism for emitting and listening to events in the server and apps
     Older approaches -- **hooks** and **public emitters** -- were used in early Nextcloud versions. They are now deprecated and available only for rare migration or compatibility scenarios.
 
 .. tip::
-    If you’re migrating old code, see `Hooks (Deprecated)`_ and `Public Emitters (Deprecated)`_ sections -- or refer to older documentation versions -- for more historical context helpful to transitioning, including some of the other ways of registering listeners.
+    If you’re migrating old code, see `Hooks`_ and `Public Emitters`_ sections -- or refer to older documentation versions -- for more historical context helpful to transitioning, including some of the other ways of registering listeners.
 
 OCP Event Dispatcher
 --------------------

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -519,7 +519,7 @@ This event is triggered when a user deletes a card in an address-book.
 
 This event is triggered when a user updates a card in an address-book.
 
-``OCA\DAV\Events\SabrePluginAddEvent``
+``\OCA\DAV\Events\SabrePluginAddEvent``
 **************************************
 
 .. versionadded:: 28
@@ -552,7 +552,7 @@ This event is triggered when a user deletes a calendar-subscription.
 
 .. versionadded:: 20
 
-This event is triggered when a user deletes a calendar-subscription.
+This event is triggered when a user updates a calendar-subscription.
 
 ``\OCA\FederatedFileSharing\Events\FederatedShareAddedEvent``
 *************************************************************
@@ -580,7 +580,7 @@ Emitted before the rendering step of the public share page happens. The event ho
 
 .. versionadded:: 28
 
-Emitted after a file or folder is moved to the trashbin.
+Emitted before a file or folder is moved to the trashbin. Allow other apps to disable the trash bin for specific files.
 
 ``\OCA\Settings\Events\BeforeTemplateRenderedEvent``
 ********************************************************

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -96,7 +96,6 @@ This event simply signals that *something happened*. In many cases, you want to 
     namespace OCA\MyApp\Events;
 
     use OCP\EventDispatcher\Event;
-    use OCP\EventDispatcher\IEventListener;
     use OCP\IUser;
 
     /**
@@ -121,7 +120,8 @@ You may never need to write your own event, as many `Public Events <Available Pu
     Don't get too hung up regarding data transportation at the moment if you're unfamiliar  with the topic. We'll return to the ``UserCreatedEvent`` and DTO in the context of a fuller example later on. For now, let's return to the simpler ``AddEvent``, which merely fires ("this happened"), without transporting any data to our listener.
 
 .. note::
-    You may see older code that calls the parent constructor (i.e. ``parent::__construct();``) in its Event class. This is no longer necessary; it won't hurt anything in existing code, but is a no-op.
+   You might notice code calling the parent constructor in the Event class.
+   This is an empty compatibility shim; calling it is safe, but it is not required.
 
 Writing Listeners
 `````````````````
@@ -731,9 +731,17 @@ Filesystem scanner hooks available in scope **\\OC\\Files\\Utils\\Scanner**:
 * **postScanFile** (string $absolutePath)
 * **postScanFolder** (string $absolutePath)
 
+Deprecated
+----------
 
-Public emitters (Deprecated)
-----------------------------
+dispatch() - string-named
+`````````````````````````
+
+.. deprecated:: 21
+   Use ``dispatchType()`` instead.
+
+Public emitters
+```````````````
 
 .. deprecated:: 18
     Use the `OCP event dispatcher`_ instead.

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -512,7 +512,7 @@ This event is triggered when a user deletes a card in an address-book.
 This event is triggered when a user updates a card in an address-book.
 
 ``\OCA\DAV\Events\SabrePluginAddEvent``
-**************************************
+***************************************
 
 .. versionadded:: 28
 


### PR DESCRIPTION
### ☑️ Resolves

The existing Events chapter was showing its age and in need of a refactor.

It was a bit confusing in some spots, wasn't up-to-date with current best practices, and lacked coverage of the dispatcher.

This PR modernizes and expands the documentation for Nextcloud Events:

- adds emission/dispatch coverage
- clarifies listener registration / instantiation / handler execution lifecycle
- aligns docs/examples with current best practices - e.g.,
  - use the OCP Event Dispatcher and IBootstrap patterns
  - current PHP best practices
- adds additional code examples:
  - e.g., defining events, registering listeners, and emitting/dispatching events, usage of event payloads, and DI
- improves coverage of event payloads
- de-emphasize legacy approaches, referencing them only for migration purposes
  - e.g., hooks, public emitters, pre-IBootstrap listener patterns
- improves clarity throughout the documentation
  - e.g., correcting typos, clarifying ambiguous statements, and removing (most - *ahem*) informal phrasing
- new table of contents

These changes ensure app authors have clear, up-to-date, and actionable guidance for both consuming and producing events in Nextcloud apps.

### 🖼️ Screenshots

<img width="1080" height="32766" alt="image" src="https://github.com/user-attachments/assets/6e4b2bdf-063f-43e4-a05d-479a5cbdebc7" />

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
