### PR TITLE
fix(devcontainer): 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 as final
+FROM python:3.12 as final
 
 USER root
 


### PR DESCRIPTION
Upgrade to Python 3.12  in devcontainer to be able to install deps defined in requirements.txt

### ☑️ Resolves

* Fix #13958 

