### PR TITLE
build: Downgrade sphinx-reredirects to an older version again and pin…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,11 +27,11 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-mermaid==1.2.3
-sphinx-notfound-page
+sphinx-notfound-page==1.1.0
 sphinxcontrib-phpdomain==0.13.2
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 sphinx-toolbox==4.1.1
-sphinx-reredirects==1.1.0 
+sphinx-reredirects==0.1.6
 urllib3==2.6.2
 zipp==3.23.0


### PR DESCRIPTION
… notfound-page dep

Currently prod fails:
```
ERROR: Could not find a version that satisfies the requirement sphinx-reredirects==1.1.0 (from versions: 0.0.0, 0.0.1, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6)
ERROR: No matching distribution found for sphinx-reredirects==1.1.0
/bin/sh: 1: sphinx-build: not found
make: *** [Makefile:55: html-com] Error 127
cp: cannot stat '/build/documentation/admin_manual/_build/html/com/': No such file or directory
make: sphinx-build: No such file or directory
make: *** [Makefile:61: html-lang-en] Error 127
cp: cannot stat '/build/documentation/user_manual/_build/html/': No such file or directory
make: sphinx-build: No such file or directory
make: *** [Makefile:131: latexpdf] Error 127
cp: cannot stat '/build/documentation/user_manual/_build/latex/Nextcloud_User_Manual.pdf': No such file or directory
stopped: return value was non-zero: 1
```