### PR TITLE
Update instructions for iOS sync

### DIFF
--- a/user_manual/groupware/sync_ios.rst
+++ b/user_manual/groupware/sync_ios.rst
@@ -16,7 +16,7 @@ Calendar
 #. Enter your user name and password.
 #. Select Next.
 #. Open Advanced Settings
-#. For server, type the domain name of your server and username, i.e., ``example.com/remote.php/dav/principals/users/username/``.
+#. For server, type the domain name of your server and path, i.e., ``example.com/remote.php/dav/principals/users/username/`` (replace **example.com** and **username**).
 #. Close Advanced Settings
 
 Your calendar will now be visible in the Calendar application.
@@ -41,7 +41,7 @@ Contacts
 #. Select Add Account.
 #. Select Other as account type.
 #. Select Add CardDAV account.
-#. For server, type the domain name of your server i.e. ``example.com``.
+#. For server, type the domain name of your server and path, i.e., ``example.com/remote.php/dav/principals/users/username/`` (replace **example.com** and **username**).
 #. Enter your user name and password.
 #. Select Next.
 


### PR DESCRIPTION
Clarify that the path is needed for both calendar and contacts, and which parts needs to be replaced.

iOS gives terrible feedback when the path is missing, so I found help at https://help.nextcloud.com/t/ios-caldav-client-not-syncing/155018/2. This was tested yesterday.

### ☑️ Resolves

* Makes the documentation for iOS sync actually work.

### 🖼️ Screenshots

I have none. This is only a text change.
