### PR TITLE
Fix integration of code

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -136,7 +136,7 @@ Encrypting team folders
 -----------------------
 
 By default team folder are not encrypted. If you want to encrypt your team folders
-as well you need to run following occ command:
+as well you need to run following occ command::
 
  occ config:app:set groupfolders enable_encryption --value=true
 


### PR DESCRIPTION
Before, the two hyphens were replaced by a dash in the view presented on docs.nextcloud.com, resulting in an erroneous occ command (too many arguments to "config:app:set").

### ☑️ Resolves

* Fix wrong integration of occ code line

### 🖼️ Screenshots

<img width="1091" height="245" alt="grafik" src="https://github.com/user-attachments/assets/70a2192c-0c7d-4c0f-ad7b-8453100a00fd" />
