### PR TITLE
nextcloud/app_api#727: Clarify optional status

### DIFF
--- a/admin_manual/exapps_management/AppAPIAndExternalApps.rst
+++ b/admin_manual/exapps_management/AppAPIAndExternalApps.rst
@@ -10,6 +10,9 @@ an ecosystem for **ExApps** (short for "External Apps") was introduced, allowing
 
 Most of our :doc:`Artificial Intelligence <../ai/index>` (AI) apps are developed as ExApps and thus may require some preparation of your Nextcloud instance before you can install them.
 
+.. tip::
+	AppAPI and ExApps are optional functionality. If you do not use any non-PHP applications then you may safely disable AppAPI by navigating to the Apps management page in your Nextcloud instance, going to "Your Apps" and clicking the "Disable" button next to AppAPI.
+
 Installing AppAPI
 -----------------
 


### PR DESCRIPTION
### ☑️ Resolves

* Improve documentation to go along with nextcloud/app_api#727 and make it clear that the AppAPI is entirely optional. This is most useful if further changes are made for that ticket to use the supplied URL and link users to the docs

### 🖼️ Screenshots

(Not sure how we're supposed to provide screenshots when GitHub doesn't render RST files!)
