### PR TITLE
fix(groupware): Add separate section for mail troubleshooting, remove mail shortcuts and re-sort some things

### DIFF
--- a/admin_manual/groupware/mail.rst
+++ b/admin_manual/groupware/mail.rst
@@ -5,15 +5,30 @@ Mail
 Configuration
 -------------
 
-Local IMAP and SMTP servers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Anti-abuse alerts
+^^^^^^^^^^^^^^^^^
 
-By default, Nextcloud does not allow local hostnames and IP addresses as remote servers. This includes IMAP, SMTP and Sieve servers
-like ``localhost``, ``mx.local`` and ``10.0.0.3``. This check can be disabled with via ``config/config.php``.
+The app can write alerts to the logs when users send messages to a high number of recipients or sends a high number of messages for a short period of time. These events might indicate that the account is abused for sending spam messages.
+
+To enable anti-abuse alerts, you'll have to set a few configuration options :doc:`via occ  <../occ_command>` .
 
 ::
 
-    'allow_local_remote_servers' => true,
+    # Turn alerts on
+    occ config:app:set mail abuse_detection --value=on
+    # Turn alerts off
+    occ config:app:set mail abuse_detection --value=off
+
+    # Alert when 50 or more recipients are used for one single message
+    occ config:app:set mail abuse_number_of_recipients_per_message_threshold --value=50
+
+    # Alerts can be configured for three intervals: 15m, 1h and 1d
+    # Alert when more than 10 messages are sent in 15 minutes
+    occ config:app:set mail abuse_number_of_messages_per_15m --value=10
+    # Alert when more than 30 messages are sent in one hour
+    occ config:app:set mail abuse_number_of_messages_per_1h --value=30
+    # Alert when more than 100 messages are sent in one day
+    occ config:app:set mail abuse_number_of_messages_per_1d --value=100
 
 Attachment size limit
 ^^^^^^^^^^^^^^^^^^^^^
@@ -25,6 +40,42 @@ Admins can prevent users from attaching large attachments to their emails. Users
     'app.mail.attachment-size-limit' => 3*1024*1024,
 
 The unit is bytes. The example about with limit to 3MB attachments. The default is 0 bytes which means no upload limit.
+
+Background sync interval
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Configure how often Mail keeps users' mailboxes updated in the background in seconds. Defaults to 3600, minimum 300.
+
+::
+
+    'app.mail.background-sync-interval' => 7200,
+
+Disable TLS verification for IMAP/SMTP
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Turn off TLS verification for IMAP/SMTP. This happens globally for all accounts and is only needed in edge cases like with email servers that have a self-signed certificate.
+
+::
+
+    'app.mail.verify-tls-peer' => false
+
+Google OAuth
+^^^^^^^^^^^^
+
+This app can allow users to connect their Google accounts with OAuth. This makes it possible to use accounts without 2FA or app password.
+
+1. `Create authorization credentials <https://developers.google.com/identity/protocols/oauth2/web-server#prerequisites>`_. You will receive a client ID and a client secret.
+2. Open the Nextcloud settings page. Navigate to *Groupware* and scroll down to *Gmail integration*. Enter and save the client ID and client secret.
+
+Local IMAP and SMTP servers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, Nextcloud does not allow local hostnames and IP addresses as remote servers. This includes IMAP, SMTP and Sieve servers
+like ``localhost``, ``mx.local`` and ``10.0.0.3``. This check can be disabled with via ``config/config.php``.
+
+::
+
+    'allow_local_remote_servers' => true,
 
 Timeouts
 ^^^^^^^^
@@ -53,15 +104,6 @@ Sieve timeout
 
     'app.mail.sieve.timeout' => 5
 
-Background sync interval
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Configure how often Mail keeps users' mailboxes updated in the background in seconds. Defaults to 3600, minimum 300.
-
-::
-
-    'app.mail.background-sync-interval' => 7200,
-
 Use php-mail for sending mail
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -72,49 +114,6 @@ You can use the php-mail function to send mails. This is needed for some web hos
 ::
 
     'app.mail.transport' => 'php-mail'
-
-Disable TLS verification for IMAP/SMTP
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Turn off TLS verification for IMAP/SMTP. This happens globally for all accounts and is only needed in edge cases like with email servers that have a self-signed certificate.
-
-::
-
-    'app.mail.verify-tls-peer' => false
-
-Anti-abuse alerts
-^^^^^^^^^^^^^^^^^
-
-The app can write alerts to the logs when users send messages to a high number of recipients or sends a high number of messages for a short period of time. These events might indicate that the account is abused for sending spam messages.
-
-To enable anti-abuse alerts, you'll have to set a few configuration options :doc:`via occ  <../occ_command>` .
-
-::
-
-    # Turn alerts on
-    occ config:app:set mail abuse_detection --value=on
-    # Turn alerts off
-    occ config:app:set mail abuse_detection --value=off
-
-    # Alert when 50 or more recipients are used for one single message
-    occ config:app:set mail abuse_number_of_recipients_per_message_threshold --value=50
-
-    # Alerts can be configured for three intervals: 15m, 1h and 1d
-    # Alert when more than 10 messages are sent in 15 minutes
-    occ config:app:set mail abuse_number_of_messages_per_15m --value=10
-    # Alert when more than 30 messages are sent in one hour
-    occ config:app:set mail abuse_number_of_messages_per_1h --value=30
-    # Alert when more than 100 messages are sent in one day
-    occ config:app:set mail abuse_number_of_messages_per_1d --value=100
-
-
-Google OAuth
-^^^^^^^^^^^^
-
-This app can allow users to connect their Google accounts with OAuth. This makes it possible to use accounts without 2FA or app password.
-
-1. `Create authorization credentials <https://developers.google.com/identity/protocols/oauth2/web-server#prerequisites>`_. You will receive a client ID and a client secret.
-2. Open the Nextcloud settings page. Navigate to *Groupware* and scroll down to *Gmail integration*. Enter and save the client ID and client secret.
 
 Account delegation
 ------------------

--- a/user_manual/groupware/mail.rst
+++ b/user_manual/groupware/mail.rst
@@ -543,18 +543,6 @@ These widgets utilize the emails from the email accounts that are set up for you
 Keyboard shortcuts
 ------------------
 
-Speed up your Mail experience by using keyboard shortcuts.
+The Mail app implements several keyboard shortcuts to speed up your experience.
 
-============== ===================================
-Action         Shortcut
-============== ===================================
-Newer message  ``K`` or ``←``
-Older message  ``J`` or ``→``
-Toggle star    ``S``
-Toggle unread  ``U``
-Archive        ``A``
-Delete         ``Del``
-Search         ``Ctrl`` + ``F``
-Send           ``Ctrl`` + ``↵``
-Refresh        ``R``
-============== ===================================
+For a full list of the supported shortcuts, check out the Mail settings in your instance.


### PR DESCRIPTION
### ☑️ Resolves

In #13993 , I've forgot to add a separate section for the mail app in the troubleshooting guide. This is being fixed with this change.

Additionally, I've implemented the feedback from there and removed the list of keyboard shortcuts from the documentation as well as some re-sorting.

### 🖼️ Screenshots

<img width="1920" height="1457" alt="Screenshot 2026-01-20 at 15-15-33 Mail — Nextcloud latest Administration Manual latest documentation" src="https://github.com/user-attachments/assets/dc592012-c87f-44d1-ae6e-d3d99a85930d" />

<img width="1920" height="1457" alt="Screenshot 2026-01-20 at 15-10-01 Troubleshooting — Nextcloud latest Administration Manual latest documentation" src="https://github.com/user-attachments/assets/0d231332-35fc-46dd-8e3f-7ded7aa474b1" />

<img width="1920" height="1457" alt="Screenshot 2026-01-20 at 13-48-36 Using the Mail app — Nextcloud latest User Manual latest documentation" src="https://github.com/user-attachments/assets/4ea91a95-3b52-4dfe-8466-c4906f788c3a" />
