### PR TITLE
fix(developer_manual/database): Port away from createFunction

### DIFF
--- a/developer_manual/basics/storage/database.rst
+++ b/developer_manual/basics/storage/database.rst
@@ -177,7 +177,7 @@ To create a mapper, inherit from the mapper base class and call the parent const
         public function authorNameCount($name) {
             $qb = $this->db->getQueryBuilder();
 
-            $qb->selectAlias($qb->createFunction('COUNT(*)'), 'count')
+            $qb->select($qb->func()->count('*', 'count'))
                ->from('myapp_authors')
                ->where(
                    $qb->expr()->eq('name', $qb->createNamedParameter($name, IQueryBuilder::PARAM_STR))


### PR DESCRIPTION
### ☑️ Resolves

This function is a bit harder to use correctly than IFunctionBuilder, so use IFunctionBuilder instead.
