### PR TITLE
Feat/default none phone region

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -567,6 +567,7 @@ without the country code (e.g., +49 for Germany).
 If the user base is truly international and there is no default that would make sense, the phone region can be set to none:
 
 ::
+	
 	'default_phone_region' => 'none',
 
 

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -564,6 +564,12 @@ using ISO 3166-1 country codes such as ``DE`` for Germany, ``FR`` for France, â€
 It is required to allow inserting phone numbers in the user profiles starting
 without the country code (e.g., +49 for Germany).
 
+If the user base is truly international and there is no default that would make sense, the phone region can be set to none:
+
+::
+	'default_phone_region' => 'none',
+
+
 No default value!
 
 force_locale


### PR DESCRIPTION
### ☑️ Resolves

This was requested in the server as a documentation extension. Where the user base has no default phone region, none can be provided.

* Fix https://github.com/nextcloud/server/issues/49460

### 🖼️ Screenshots

<img width="944" height="944" alt="Screenshot" src="https://github.com/user-attachments/assets/a71d4b47-7b97-4fbd-a699-fadaccd96396" />
