### PR TITLE
Document default mail server settings

### DIFF
--- a/admin_manual/groupware/mail.rst
+++ b/admin_manual/groupware/mail.rst
@@ -5,6 +5,8 @@ Mail
 Configuration
 -------------
 
+**Administration settings** →  **Groupware** -> **Mail app**
+
 Anti-abuse alerts
 ^^^^^^^^^^^^^^^^^
 
@@ -49,6 +51,22 @@ Configure how often Mail keeps users' mailboxes updated in the background in sec
 ::
 
     'app.mail.background-sync-interval' => 7200,
+
+
+Default mail server settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+  'app.mail.accounts.default' => [
+      'email' => '%USERID%@example.com', // %USERID% and %EMAIL% are placeholders
+      'imapHost' => 'imap.example.com',
+      'imapPort' => 993,
+      'imapSslMode' => 'ssl',
+      'smtpHost' => 'smtp.example.com',
+      'smtpPort' => 465,
+      'smtpSslMode' => 'ssl',
+  ],
 
 Disable TLS verification for IMAP/SMTP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

* Point to the admin config page
* Add docs to set a default mailserver voor de Mail app.

### 🖼️ Screenshots
<img width="459" height="224" alt="image" src="https://github.com/user-attachments/assets/e231360a-9bbe-4e52-8e54-0282007fcce2" />

<img width="644" height="252" alt="image" src="https://github.com/user-attachments/assets/d9df39ba-7093-4367-8d71-8191ff626db6" />

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
