### PR TITLE
fix(developer): document removal of the "whats new" feature

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_33.rst
@@ -96,6 +96,7 @@ Removed APIs
 
 - The global ``md5`` implementation is removed. It was deprecated since Nextcloud 20 and not used by Nextcloud anymore.
   If you still need a ``md5`` implementation you can just use some external package like `crypto-browserify <https://www.npmjs.com/package/crypto-browserify>`_.
+- ``OCP.WhatsNew`` was removed.
 - ``OC.AppConfig`` was deprecated since Nextcloud 16 and was now removed. Instead use ``OCP.AppConfig``.
 - The ``OC.Settings.UserSettings`` api was removed.
 - The ``OC.SystemTags`` api was removed. If you need to get the list of system tags,
@@ -253,3 +254,6 @@ Should be replaced by the following code:
     }
 
 - The ``\OCP\Files::buildNotExistingFileName`` and related private helper ``\OC_Helper::buildNotExistingFileName`` were deprecated since Nextcloud 14 and were now removed. Use ``\OCP\Files\Folder::getNonExistingName`` instead.
+
+- The ``WhatsNew`` feature was removed as such the ``OC\Updater\ChangesCheck`` class and related APIs.
+  This also includes the ``whats_new`` database table and the ``WhatsNewController`` class which was serving the now removed ``/core/whatsnew`` endpoint.


### PR DESCRIPTION
### ☑️ Resolves

* for https://github.com/nextcloud/server/pull/57583

It was used for Nextcloud changes, but we did not use it since Nextcloud 20 and now use the firstrunwizard and the update_notification.

### 🖼️ Screenshots

<img width="2560" height="5515" alt="Screenshot 2026-01-28 at 14-49-50 Upgrade to Nextcloud 33 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/6ee1143e-67b9-47fa-87a3-dc0e929f334f" />

