### PR TITLE
docs(cache): Add documentation for memcache_customprefix setting

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -49,7 +49,7 @@ Small/Private home server
 
 Only use APCu::
 
-    'l' => '\OC\Memcache\APCu',
+    'memcache.local' => '\OC\Memcache\APCu',
 
 Organizations with single-server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -187,7 +187,7 @@ The following options are available to configure when using a single redis serve
    'memcache.locking' => '\OC\Memcache\Redis',
    'memcache.distributed' => '\OC\Memcache\Redis',
    'memcache.local' =>'\OC\Memcache\Redis' ,
-   'memcache.customprefix' => 'mynextcloudprefix',
+   'memcache_customprefix' => 'mynextcloudprefix',
    'redis' => [
       // 'host'      => see connection parameters below
       // 'port'      => see connection parameters below
@@ -203,7 +203,7 @@ The following options are available to configure when using a redis cluster (all
    'memcache.locking' => '\OC\Memcache\Redis',
    'memcache.distributed' => '\OC\Memcache\Redis',
    'memcache.local' =>'\OC\Memcache\Redis' ,
-   'memcache.customprefix' => 'mynextcloudprefix',
+   'memcache_customprefix' => 'mynextcloudprefix',
    'redis.cluster' => [
       'seeds' => [ // provide some/all of the cluster servers to bootstrap discovery, port required
          'cache-cluster:7000',
@@ -385,7 +385,7 @@ collisions when using the same cache for multiple Nextcloud instances.
 If you want to make sure to prevent collisions alltogether, you can use the following
 setting to define your custom prefix::
 
-  'memcache.customprefix' => 'mynextcloudprefix',
+  'memcache_customprefix' => 'mynextcloudprefix',
 
 This also allows you to create ACLs in Redis and limit the keys specific users can access
 (e.g. if you want to isolate specific Nextcloud instances when using the same cache).

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -49,7 +49,7 @@ Small/Private home server
 
 Only use APCu::
 
-    'memcache.local' => '\OC\Memcache\APCu',
+    'l' => '\OC\Memcache\APCu',
 
 Organizations with single-server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,6 +187,7 @@ The following options are available to configure when using a single redis serve
    'memcache.locking' => '\OC\Memcache\Redis',
    'memcache.distributed' => '\OC\Memcache\Redis',
    'memcache.local' =>'\OC\Memcache\Redis' ,
+   'memcache.customprefix' => 'mynextcloudprefix',
    'redis' => [
       // 'host'      => see connection parameters below
       // 'port'      => see connection parameters below
@@ -202,6 +203,7 @@ The following options are available to configure when using a redis cluster (all
    'memcache.locking' => '\OC\Memcache\Redis',
    'memcache.distributed' => '\OC\Memcache\Redis',
    'memcache.local' =>'\OC\Memcache\Redis' ,
+   'memcache.customprefix' => 'mynextcloudprefix',
    'redis.cluster' => [
       'seeds' => [ // provide some/all of the cluster servers to bootstrap discovery, port required
          'cache-cluster:7000',
@@ -374,3 +376,17 @@ Cache Directory location
 The cache directory defaults to ``data/$user/cache`` where ``$user`` is the 
 current user. You may use the ``'cache_path'`` directive in ``config.php``
 (See :doc:`config_sample_php_parameters`) to select a different location.
+
+Cache Key Prefix for Redis or Memcached
+---------------------------------
+
+By default, Nextcloud generates a semi-unique prefix for cache keys using information like instance ID, version etc. to mitigate the problem of
+collisions when using the same cache for multiple Nextcloud instances.
+If you want to make sure to prevent collisions alltogether, you can use the following
+setting to define your custom prefix::
+
+  'memcache.customprefix' => 'mynextcloudprefix',
+
+This also allows you to create ACLs in Redis and limit the keys specific users can access
+(e.g. if you want to isolate specific Nextcloud instances when using the same cache).
+This may be security-relevant for you.

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -378,7 +378,7 @@ current user. You may use the ``'cache_path'`` directive in ``config.php``
 (See :doc:`config_sample_php_parameters`) to select a different location.
 
 Cache Key Prefix for Redis or Memcached
----------------------------------
+---------------------------------------
 
 By default, Nextcloud generates a semi-unique prefix for cache keys using information like instance ID, version etc. to mitigate the problem of
 collisions when using the same cache for multiple Nextcloud instances.

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -382,7 +382,7 @@ Cache Key Prefix for Redis or Memcached
 
 By default, Nextcloud generates a semi-unique prefix for cache keys using information like instance ID, version etc. to mitigate the problem of
 collisions when using the same cache for multiple Nextcloud instances.
-If you want to make sure to prevent collisions alltogether, you can use the following
+If you want to make sure to prevent collisions altogether, you can use the following
 setting to define your custom prefix::
 
   'memcache_customprefix' => 'mynextcloudprefix',

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -2717,6 +2717,21 @@ Memory caching backend for locally stored data
 
 Defaults to ``none``
 
+memcache.customprefix
+^^^^^^^^^^^^^^^^^^^^^
+
+
+::
+
+	'memcache.customprefix' => 'mynextcloudprefix',
+
+Custom cache key prefix for Redis or Memcached
+
+* Used for avoiding collisions in the cache system
+* May be used for ACL restrictions in Redis
+
+Defaults to an auto-generated, semi-unique ID
+
 memcache.distributed
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -2717,13 +2717,13 @@ Memory caching backend for locally stored data
 
 Defaults to ``none``
 
-memcache.customprefix
+memcache_customprefix
 ^^^^^^^^^^^^^^^^^^^^^
 
 
 ::
 
-	'memcache.customprefix' => 'mynextcloudprefix',
+	'memcache_customprefix' => 'mynextcloudprefix',
 
 Custom cache key prefix for Redis or Memcached
 

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -2717,20 +2717,6 @@ Memory caching backend for locally stored data
 
 Defaults to ``none``
 
-memcache_customprefix
-^^^^^^^^^^^^^^^^^^^^^
-
-
-::
-
-	'memcache_customprefix' => 'mynextcloudprefix',
-
-Custom cache key prefix for Redis or Memcached
-
-* Used for avoiding collisions in the cache system
-* May be used for ACL restrictions in Redis
-
-Defaults to an auto-generated, semi-unique ID
 
 memcache.distributed
 ^^^^^^^^^^^^^^^^^^^^

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -2717,7 +2717,6 @@ Memory caching backend for locally stored data
 
 Defaults to ``none``
 
-
 memcache.distributed
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -220,7 +220,7 @@ Example config::
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'memcache.local' => '\OC\Memcache\APCu',
-    'memcache.customprefix' => 'nextcloud_centos',
+    'memcache_customprefix' => 'nextcloud_centos',
     'redis' => array(
       'host' => 'localhost',
       'port' => 6379,

--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -220,6 +220,7 @@ Example config::
     'memcache.distributed' => '\OC\Memcache\Redis',
     'memcache.locking' => '\OC\Memcache\Redis',
     'memcache.local' => '\OC\Memcache\APCu',
+    'memcache.customprefix' => 'nextcloud_centos',
     'redis' => array(
       'host' => 'localhost',
       'port' => 6379,


### PR DESCRIPTION
### ☑️ Resolves

* Adds the documentation for PR https://github.com/nextcloud/server/pull/58334

### 🖼️ Screenshots

<img width="1094" height="308" alt="Screenshot from 2026-02-17 18-20-45" src="https://github.com/user-attachments/assets/c636cbbc-f31c-46e7-9b1b-54093f958656" />

<img width="1063" height="254" alt="Screenshot from 2026-02-17 18-24-27" src="https://github.com/user-attachments/assets/0e44d8d4-853f-4bf3-9880-39e0a81bfa4f" />
