### PR TITLE
Improve the description of the cookies.

### DIFF
--- a/admin_manual/gdpr/cookies.rst
+++ b/admin_manual/gdpr/cookies.rst
@@ -13,20 +13,20 @@ Nextcloud only stores cookies needed for Nextcloud to work properly. All cookies
 Cookies stored by Nextcloud
 ===========================
 
-====================  ====================================  ================
- Cookie               Data Stored                             Lifetime
-====================  ====================================  ================
- Session cookie        - session ID                          24 minutes
-                       - secret token (used to decrypt 
-                         the session on the server)
- Same-site cookies     no user-related data are stored,      forever
-                       all same-site cookies are the same
-                       for all users on all Nextcloud 
-                       instances
- Remember-me cookie    - user id                             15 days (can be
-                       - original session id                 configured)
-                       - remember token                       
-====================  ====================================  ================
+=====================  ======================================  ==============================  =================================  =============================  =======================================
+ Type                   Name                                    Value                           Purpose                            Creation                      Lifetime
+=====================  ======================================  ==============================  =================================  =============================  =======================================
+ Session cookie         ``<instance_id>``                       A random PHP session ID.        | Used to identify the user        At first load.                 At the end of the browser's session.
+                                                                                                | on the server.
+ Session cookie         ``oc_sessionPassphrase``                A random token.                 | Used to decrypt the session's    At first load.                 At the end of the browser's session.
+                                                                                                | data on the server.
+ Same-site cookies      ``__Host-nc_sameSiteCookiestrict``      ``true``                        See note below for the purpose.    At first load.                 Forever.
+ Same-site cookies      ``__Host-nc_sameSiteCookielax``         ``true``                        See note below for the purpose.    At first load.                 Forever.
+ Remember-me cookies    - ``nc_username``                       - The user id                                                      | At login if the              | Defaults to 15 days.
+                        - ``nc_token``                          - A random remember me token                                       | user selected the            | Can be configured by setting:
+                        - ``nc_session_id``                     - The original session id                                          | Remember-me checkbox.        | ``remember_login_cookie_lifetime``.
+ Download helper        ``ocDownloadStarted``                   A random token.                 Help to manage file download.      When a download is started.    20 seconds.
+=====================  ======================================  ==============================  =================================  =============================  =======================================
 
 The same-site cookies are used to determine how a request reaches the Nextcloud server. We use them to prevent CSRF attacks. No identifiable information is stored in those.
 The rest of the cookies are strictly used to identify the user to the system.


### PR DESCRIPTION
A few modifications:

1. Add the exact name of the cookie
2. Fix the lifetime of the session cookies
3. Mention exact setting name for the remember me cookie lifetime: `remember_login_cookie_lifetime`
4. Add `ocDownloadStarted`
5. Add when the cookie is created


| Before | After |
|--------|--------|
| <img width="956" height="377" alt="Screenshot From 2026-02-27 12-12-44" src="https://github.com/user-attachments/assets/45099c6d-1560-4c1c-8f68-5bbbb46d5abc" /> | <img width="956" height="618" alt="Screenshot From 2026-02-27 12-12-33" src="https://github.com/user-attachments/assets/1cb1cd1f-f35f-4e41-a5e2-6f71d7fab5e4" /> |
| <img width="956" height="377" alt="Screenshot From 2026-02-27 12-12-47" src="https://github.com/user-attachments/assets/09b46096-92d1-404a-bd8a-3ac8ba6ae740" /> | <img width="941" height="608" alt="image" src="https://github.com/user-attachments/assets/8542257a-dabd-4ca9-84b4-0827aa2a9739" />| 



