### PR TITLE
feat(admin): add supported distributions

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -16,10 +16,13 @@ For best performance, stability and functionality we have documented some recomm
 +==================+=======================================================================+
 | Operating System | - **Ubuntu 24.04 LTS** (recommended)                                  |
 | (64-bit)         | - Ubuntu 22.04 LTS                                                    |
-|                  | - **Red Hat Enterprise Linux 9** (recommended)                        |
+|                  | - **Red Hat Enterprise Linux 10** (recommended)                       |
+|                  | - Red Hat Enterprise Linux 9                                          |
+|                  | - Debian 13 (Trixi)                                                   |
 |                  | - Debian 12 (Bookworm)                                                |
-|                  | - SUSE Linux Enterprise Server 15                                     |
-|                  | - openSUSE Leap 15.6                                                  |
+|                  | - SUSE Linux Enterprise Server 16                                     |
+|                  | - SUSE Linux Enterprise Server 15 SP6 (or later)                      |
+|                  | - openSUSE Leap 16                                                    |
 |                  | - CentOS Stream                                                       |
 |                  | - Alpine Linux                                                        |
 +------------------+-----------------------------------------------------------------------+
@@ -51,6 +54,7 @@ A 64-bit CPU, OS and PHP is required for Nextcloud to run well.
 
 - Dates before Unix Epoch (1970-01-01) are not supported
 - Dates after 2038 are not supported
+- Some external apps may not work with 32-bit systems
 
 Memory
 ^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

- We recommend RHEL 10
  - RHEL 9 is still supported until we drop PHP 8.2.
- We also support Debian 13
  - Debian 12 is also supported as long as we support PHP 8.2
- SLES 16 is now also supported as the current release
  - SLES 15 is still supported as long as we support PHP 8.2 but this requires SP6 or later (currently SP7 is available)
- openSUSE Leap 15 is not supported anymore, instead openSUSE Leap 16 was released and is the supported version.

### 🖼️ Screenshots

<img width="1427" height="1334" alt="Screenshot 2026-02-27 at 21-29-03 System requirements — Nextcloud latest Administration Manual latest documentation" src="https://github.com/user-attachments/assets/fc778556-a54f-4514-ac59-f3f7c1b94702" />
