### PR TITLE
docs(user_manual): add CalDAV/CardDAV URL formats to sync guides

### DIFF
--- a/user_manual/groupware/calendar.rst
+++ b/user_manual/groupware/calendar.rst
@@ -157,6 +157,17 @@ You can embed your calendars into supported apps like ``Talk``, ``Notes``, etc..
 by either sharing the public link to make the embed viewable (read-only) to all users
 or by using the internal link to make it private.
 
+Connecting external clients via CalDAV
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can access your Nextcloud calendars from external clients using the CalDAV protocol.
+
+To subscribe to all your calendars, use ``https://example.com/remote.php/dav/calendars/USERNAME/``
+
+To subscribe to a specific calendar, use ``https://example.com/remote.php/dav/calendars/USERNAME/CALENDAR-NAME/``
+
+.. tip:: You can find the URL for a specific calendar by clicking the pencil icon next to a calendar name in the left sidebar and copying the **Internal link**. This link can be used directly in external CalDAV clients.
+
 Subscribe to a Calendar
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/user_manual/groupware/sync_kde.rst
+++ b/user_manual/groupware/sync_kde.rst
@@ -42,6 +42,12 @@ In KOrganizer and Kalendar:
 
 .. image:: ../images/KOrganizer_server_address.png
 
+The CalDAV URL for all your calendars should be ``https://example.com/remote.php/dav/calendars/USERNAME/`` and for a specific calendar ``https://example.com/remote.php/dav/calendars/USERNAME/CALENDAR-NAME/``
+
+The CardDAV URL for all your address books should be ``https://example.com/remote.php/dav/addressbooks/users/USERNAME/`` and for a specific address book ``https://example.com/remote.php/dav/addressbooks/users/USERNAME/ADDRESS-BOOK-NAME/``
+
+Replace ``example.com`` with your Nextcloud server URL and ``USERNAME`` with your Nextcloud username. You can find the URL for a specific calendar in the Nextcloud Calendar web UI by clicking the pencil icon next to a calendar and copying the **Internal link**.
+
 6. You can now test the connection, which can take some time for the initial connection. If it does not work, you can go back and try to fix it with other settings:
 
 .. image:: ../images/KOrganizer_test1.png

--- a/user_manual/groupware/sync_osx.rst
+++ b/user_manual/groupware/sync_osx.rst
@@ -30,6 +30,16 @@ and **CardDAV** (Contacts) to your Nextcloud.
 
    **Server Address**: URL of your Nextcloud server (e.g. ``https://cloud.example.com``)
 
+   For **CalDAV**, to subscribe to all calendars use ``https://example.com/remote.php/dav/calendars/USERNAME/``
+
+   To subscribe to a specific calendar, use ``https://example.com/remote.php/dav/calendars/USERNAME/CALENDAR-NAME/``
+
+   For **CardDAV**, to subscribe to all address books use ``https://example.com/remote.php/dav/addressbooks/users/USERNAME/``
+
+   To subscribe to a specific address book, use ``https://example.com/remote.php/dav/addressbooks/users/USERNAME/ADDRESS-BOOK-NAME/``
+
+   Replace ``example.com`` with your Nextcloud server URL and ``USERNAME`` with your Nextcloud username. You can find the URL for a specific calendar in the Nextcloud Calendar web UI by clicking the pencil icon next to a calendar and copying the **Internal link**.
+
 .. figure:: ./images/macos_3.png
 
 5. Click on **Sign In**.

--- a/user_manual/groupware/sync_thunderbird.rst
+++ b/user_manual/groupware/sync_thunderbird.rst
@@ -16,6 +16,13 @@ Contacts
 
 #. On the address book view, click the down arrow near **New Address Book** and choose **Add CardDAV Address Book**.
 #. In the next window, type your **Username** and **Location** (Server URL).
+
+   To subscribe to all address books, use ``https://example.com/remote.php/dav/addressbooks/users/USERNAME/``
+
+   To subscribe to a specific address book, use ``https://example.com/remote.php/dav/addressbooks/users/USERNAME/ADDRESS-BOOK-NAME/``
+
+   Replace ``example.com`` with your Nextcloud server URL and ``USERNAME`` with your Nextcloud username.
+
 #. The next window will ask for your username and password for this account.
 #. The previous window will be refreshed and ask you which address books you wish to sync.
 #. Choose and then click **Continue**.
@@ -33,7 +40,15 @@ Calendars
 
    .. image:: ../images/new_calendar.png
 
-#. Type your **Username** and **Location** (Server URL), then click on **Find Calendars**.
+#. Type your **Username** and **Location** (Server URL), then click on
+   **Find Calendars**.
+
+   To discover all your calendars, use ``https://example.com/remote.php/dav/calendars/USERNAME/``
+
+   To subscribe to a specific calendar, use ``https://example.com/remote.php/dav/calendars/USERNAME/CALENDAR-NAME/``
+
+   Replace ``example.com`` with your Nextcloud server URL and ``USERNAME`` with your Nextcloud username. You can find the URL for a specific calendar in the Nextcloud Calendar web UI by clicking the pencil icon next to a calendar and copying the **Internal link**.
+
 #. Choose which calendars you want to add and click **Subscribe**
 
 Same thing here, if you later want to add more calendars, just redo the procedure.


### PR DESCRIPTION
### ☑️ Resolves

* Fix #14122

The sync guides for external calendar/contacts clients don't consistently document the actual CalDAV and CardDAV URL formats users need.

This adds the URL formats (both full subscription and specific-calendar variants) to:

- **Thunderbird** sync page
- **macOS** sync page
- **KDE** sync page (previously URLs were only visible in a screenshot, inaccessible to screen readers)
- **Calendar app** page (new section on connecting external clients via CalDAV, plus a tip about the "Internal link" in the calendar edit menu)

iOS and Windows 10 pages already had this info, so those are untouched.

### :memo: Note

This is my first PR to this repo, and it is unpolished and I probably missed a few things that I need to do. I saw that there are translations into many languages, and I will iterate on this to see what I need to do to get these changes translated.

I'll keep reading up on how to contribute properly. Let me know if you have suggestions, criticisms, or thoughts about the changes. :black_heart: 