### PR TITLE
docs(dev/WebDAV): expand and correct basic operations reference

### DIFF
--- a/developer_manual/client_apis/WebDAV/basic.rst
+++ b/developer_manual/client_apis/WebDAV/basic.rst
@@ -30,6 +30,11 @@ If a password is set for the share then a basic auth header must be sent with ``
 
 .. note:: This endpoint for public shares is available since Nextcloud 29.
 
+.. warning::
+   For non-GET requests (e.g. PROPFIND, PUT) to ``/public.php/dav``, the request must include the header
+   ``X-Requested-With: XMLHttpRequest``, unless outgoing server-to-server sharing is enabled on the instance.
+   Without this header, the server will reject the request with a ``401 Not Authenticated`` response.
+
 Testing requests
 ----------------
 
@@ -241,8 +246,8 @@ Supported properties
 | <oc:permissions />            | | The permissions that the user has over the    | | ``S``: Shared                                                                      |
 |                               | | file or folder. The value is a string         | | ``R``: Shareable                                                                   |
 |                               | | containing letters for all available          | | ``M``: Mounted                                                                     |
-|                               | | permissions.                                  | | ``G``: Readable                                                                    |
-|                               |                                                 | | ``D``: Deletable                                                                   |
+|                               | | permissions. On public shares, ``S`` and      | | ``G``: Readable                                                                    |
+|                               | | ``M`` are stripped from the returned value.   | | ``D``: Deletable                                                                   |
 |                               |                                                 | | ``N``: Renameable                                                                  |
 |                               |                                                 | | ``V``: Moveable                                                                    |
 |                               |                                                 | | ``W``: Writable (file)                                                             |
@@ -263,7 +268,7 @@ Supported properties
 | <nc:is-encrypted />           | Whether the folder is end-to-end encrypted.     | | ``0`` for ``false``                                                                |
 |                               |                                                 | | ``1`` for ``true``                                                                 |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:is-mount-root>            | | This is a special property which is used to   | ``true`` or ``false``                                                                |
+| <nc:is-mount-root />          | | This is a special property which is used to   | ``true`` or ``false``                                                                |
 |                               | | determine if a node is a mount root or not,   |                                                                                      |
 |                               | | e.g. a shared folder. If so, then the node    |                                                                                      |
 |                               | | can only be unshared and not deleted.         |                                                                                      |
@@ -323,7 +328,7 @@ Supported properties
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:has-preview />            | Whether a preview of the file is available.     | ``true`` or ``false``                                                                |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:hidden>                   | | Defines if a file should be hidden            | ``true`` or ``false``                                                                |
+| <nc:hidden />                 | | Defines if a file should be hidden            | ``true`` or ``false``                                                                |
 |                               | | Currently only used for live photos           |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <oc:size />                   | | Unlike ``getcontentlength``, this property    | ``127815235``                                                                        |
@@ -391,6 +396,20 @@ Supported properties
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:version-author />         | The author's id of a specified file version.    | ``admin``, ``jane``, ``thisAuthorsID``                                               |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
+| <nc:is-federated />           | Whether the node originates from a              | ``true`` or ``false``                                                                |
+|                               | federated (server-to-server) share.             |                                                                                      |
++-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
+| <nc:metadata_etag />          | An etag representing the file's metadata state. |                                                                                      |
+|                               | Changes when metadata (not content) is updated. |                                                                                      |
++-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
+| <nc:download-url-expiration />| Expiration date/time of a direct download URL,  |                                                                                      |
+|                               | if one has been generated.                      |                                                                                      |
++-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
+
+.. note::
+   Properties prefixed with ``nc:metadata-`` (e.g. ``nc:metadata-blurhash``) are dynamic, app-registered
+   metadata properties. They are not listed individually here as they depend on which apps are enabled.
+   You can request them via PROPFIND like any other property.
 
 Listing folders (rfc4918_)
 --------------------------
@@ -444,6 +463,7 @@ Optionally it is possible to only include some files from the folder in the arch
 
 As setting headers is not possible with HTML links it is also possible to provide this both options as query parameters.
 In this case the :code:`Accept` header value must be passed as the :code:`accept` query parameter.
+Both full MIME types (:code:`application/zip`, :code:`application/x-tar`) and shorthand values (:code:`zip`, :code:`tar`) are accepted.
 The optional files list can be provided as a JSON encoded array through the :code:`files` query parameter.
 
 .. code::
@@ -568,13 +588,18 @@ You can set some special headers that Nextcloud will interpret.
 |                       | | if the mtime was accepted.                                    |                                          |
 +-----------------------+-----------------------------------------------------------------+------------------------------------------+
 | OC-Checksum           | | A checksum that will be stored in the DB.                     | ``md5:04c36b75222cd9fd47f2607333029106`` |
-|                       | | The server will not do any sort of  validation.               |                                          |
+|                       | | For regular ``PUT`` uploads, the server stores the value      |                                          |
+|                       | | without validation. During bulk uploads, the checksum         |                                          |
+|                       | | **is** validated against the uploaded content.                |                                          |
 |                       | | Currently used algorithms are ``MD5``, ``SHA1``, ``SHA256``,  |                                          |
 |                       | | ``SHA3-256``, ``Adler32``.                                    |                                          |
 +-----------------------+-----------------------------------------------------------------+------------------------------------------+
-| X-Hash                | | Allow to request the file's hash from the server.             | ``md5``, ``sha1``, or ``sha256``         |
-|                       | | The server will return the hash in a header named either:     |                                          |
-|                       | | ``X-Hash-MD5``, ``X-Hash-SHA1``, or ``X-Hash-SHA256``.        |                                          |
+| X-Hash                | | On ``PUT`` requests, instructs the server to compute a hash   | ``md5``, ``sha1``, ``sha256``,           |
+|                       | | of the uploaded file content during the write. The server     | or ``all``                               |
+|                       | | returns the hash(es) in response headers named                |                                          |
+|                       | | ``X-Hash-MD5``, ``X-Hash-SHA1``, and/or ``X-Hash-SHA256``.    |                                          |
+|                       | | Setting the value to ``all`` computes all three hashes.       |                                          |
+|                       | | Beware of performance implications!                           |                                          |
 +-----------------------+-----------------------------------------------------------------+------------------------------------------+
 | OC-Total-Length       | | Contains the total size of the file during a chunk upload.    | ``4052412``                              |
 |                       | | This allow the server to abort faster if the remaining        |                                          |
@@ -582,6 +607,7 @@ You can set some special headers that Nextcloud will interpret.
 +-----------------------+-----------------------------------------------------------------+------------------------------------------+
 | X-NC-WebDAV-AutoMkcol | | When set to ``1``, instructs the server to automatically      |                                          |
 |                       | | create any missing parent directories when uploading a file.  |                                          |
+|                       | | Available since Nextcloud 32.                                |                                          |
 +-----------------------+-----------------------------------------------------------------+------------------------------------------+
 | OC-Chunked            | | Used for legacy chunk upload to differentiate a regular       | Deprecated ⚠️                            |
 |                       | | upload from a chunked upload. It allowed checking for quota   |                                          |

--- a/developer_manual/client_apis/WebDAV/basic.rst
+++ b/developer_manual/client_apis/WebDAV/basic.rst
@@ -94,32 +94,32 @@ Quick method/header cheat sheet
 
 The table below summarizes common WebDAV methods used by Nextcloud and the most relevant headers.
 
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | Method     | Typical endpoint                          | Important request headers                    | Notes                                                       |
-+============+===========================================+=============================================+==============================================================+
++============+===========================================+==============================================+=============================================================+
 | PROPFIND   | ``/remote.php/dav/files/{user}/path``     | ``Depth: 0`` (properties of node only)       | Without ``Depth: 0``, folder listings include child entries.|
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | REPORT     | ``/remote.php/dav/files/{user}/path``     | (none required)                              | Used for filtered queries such as favorites.                |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | GET (file) | ``/remote.php/dav/files/{user}/file``     | (none required)                              | Downloads file content.                                     |
 +------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
 | GET (dir)  | ``/remote.php/dav/files/{user}/folder``   | ``Accept: application/zip`` or               | Nextcloud extension for folder archive download.            |
 |            |                                           | ``Accept: application/x-tar``                |                                                             |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | PUT        | ``/remote.php/dav/files/{user}/file``     | Optional: ``X-OC-MTime``, ``X-OC-CTime``,    | Uploads/overwrites file content.                            |
 |            |                                           | ``OC-Checksum``, ``OC-Total-Length``,        |                                                             |
 |            |                                           | ``X-NC-WebDAV-AutoMkcol``                    |                                                             |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | MKCOL      | ``/remote.php/dav/files/{user}/folder``   | (none required)                              | Creates a folder.                                           |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | DELETE     | ``/remote.php/dav/files/{user}/path``     | (none required)                              | Folder deletes are recursive.                               |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | MOVE       | ``/remote.php/dav/files/{user}/path``     | ``Destination: <full URL>``                  | Optional: ``Overwrite: T`` (default) or ``Overwrite: F``.   |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | COPY       | ``/remote.php/dav/files/{user}/path``     | ``Destination: <full URL>``                  | Optional: ``Overwrite: T`` (default) or ``Overwrite: F``.   |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | PROPPATCH  | ``/remote.php/dav/files/{user}/path``     | (none required)                              | Sets properties such as ``oc:favorite``.                    |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 
 Requesting properties
 ---------------------
@@ -262,8 +262,8 @@ Supported properties
 |                               |                                                 | | ``'external'`` = external storage                                                  |
 |                               |                                                 | | ``'external-session'`` = external storage                                          |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:hide-download />          | For shares this indicate if any download action | ``true`` or ``false``                                                                |
-|                               | should be hidden from the user or not.          |                                                                                      |
+| <nc:hide-download />          | | For shares, indicate if any download          | ``true`` or ``false``                                                                |
+|                               | | action should be hidden or not.               |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:is-encrypted />           | Whether the folder is end-to-end encrypted.     | | ``0`` for ``false``                                                                |
 |                               |                                                 | | ``1`` for ``true``                                                                 |
@@ -382,10 +382,11 @@ Supported properties
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:lock-owner-editor>        | App id of an app owned lock.                    |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:lock-time>                | Date when the lock was created as a timestamp.  | ``1675789581``                                                                       |
+| <nc:lock-time>                | | Date when the lock was created                | ``1675789581``                                                                       |
+|                               | | as a timestamp.                               |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:lock-timeout>             | TTL of the lock in seconds staring from the     | ``0`` = No timeout                                                                   |
-|                               | creation time.                                  |                                                                                      |
+| <nc:lock-timeout>             | | TTL of the lock in seconds starting           | ``0`` = No timeout                                                                   |
+|                               | | from the creation time.                       |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:lock-token>               | The token of the lock.                          | ``files_lock/0e53dfb6-61b4-46f0-b38e-d9a428292998``                                  |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
@@ -396,14 +397,14 @@ Supported properties
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:version-author />         | The author's id of a specified file version.    | ``admin``, ``jane``, ``thisAuthorsID``                                               |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:is-federated />           | Whether the node originates from a              | ``true`` or ``false``                                                                |
-|                               | federated (server-to-server) share.             |                                                                                      |
+| <nc:is-federated />           | | Whether the node originates from a            | ``true`` or ``false``                                                                |
+|                               | | federated (server-to-server) share.           |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:metadata_etag />          | An etag representing the file's metadata state. |                                                                                      |
-|                               | Changes when metadata (not content) is updated. |                                                                                      |
+| <nc:metadata_etag />          | | An etag covering the file's metadata. Changes |                                                                                      |
+|                               | | when metadata (not content), is updated.      |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:download-url-expiration />| Expiration date/time of a direct download URL,  |                                                                                      |
-|                               | if one has been generated.                      |                                                                                      |
+| <nc:download-url-expiration />| | Expiration date/time of a direct download     |                                                                                      |
+|                               | | URL (if one has been generated).              |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 
 .. note::
@@ -576,44 +577,44 @@ Request Headers
 
 You can set some special headers that Nextcloud will interpret.
 
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
-|        Header         |                           Description                           |                 Example                  |
-+=======================+=================================================================+==========================================+
-| X-OC-MTime            | | Allow to specify a modification time.                         | ``1675789581``                           |
-|                       | | The response will contain the header ``X-OC-MTime: accepted`` |                                          |
-|                       | | if the mtime was accepted.                                    |                                          |
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
-| X-OC-CTime            | | Allow to specify a creation time.                             | ``1675789581``                           |
-|                       | | The response will contain the header ``X-OC-CTime: accepted`` |                                          |
-|                       | | if the mtime was accepted.                                    |                                          |
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
-| OC-Checksum           | | A checksum that will be stored in the DB.                     | ``md5:04c36b75222cd9fd47f2607333029106`` |
-|                       | | For regular ``PUT`` uploads, the server stores the value      |                                          |
-|                       | | without validation. During bulk uploads, the checksum         |                                          |
-|                       | | **is** validated against the uploaded content.                |                                          |
-|                       | | Currently used algorithms are ``MD5``, ``SHA1``, ``SHA256``,  |                                          |
-|                       | | ``SHA3-256``, ``Adler32``.                                    |                                          |
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
-| X-Hash                | | On ``PUT`` requests, instructs the server to compute a hash   | ``md5``, ``sha1``, ``sha256``,           |
-|                       | | of the uploaded file content during the write. The server     | or ``all``                               |
-|                       | | returns the hash(es) in response headers named                |                                          |
-|                       | | ``X-Hash-MD5``, ``X-Hash-SHA1``, and/or ``X-Hash-SHA256``.    |                                          |
-|                       | | Setting the value to ``all`` computes all three hashes.       |                                          |
-|                       | | Beware of performance implications!                           |                                          |
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
-| OC-Total-Length       | | Contains the total size of the file during a chunk upload.    | ``4052412``                              |
-|                       | | This allow the server to abort faster if the remaining        |                                          |
-|                       | | user's quota is not enough.                                   |                                          |
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
-| X-NC-WebDAV-AutoMkcol | | When set to ``1``, instructs the server to automatically      |                                          |
-|                       | | create any missing parent directories when uploading a file.  |                                          |
-|                       | | Available since Nextcloud 32.                                |                                          |
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
-| OC-Chunked            | | Used for legacy chunk upload to differentiate a regular       | Deprecated ⚠️                            |
-|                       | | upload from a chunked upload. It allowed checking for quota   |                                          |
-| (deprecated)          | | and various other things. Nowadays, you need to provide the   | You do not have to provide this anymore  |
-|                       | | ``OC-Total-Length`` header on the ``PUT`` requests instead.   |                                          |
-+-----------------------+-----------------------------------------------------------------+------------------------------------------+
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
+|        Header         |                           Description                           |                 Example                    |
++=======================+=================================================================+============================================+
+| X-OC-MTime            | | Allow to specify a modification time.                         | ``1675789581``                             |
+|                       | | The response will contain the header ``X-OC-MTime: accepted`` |                                            |
+|                       | | if the mtime was accepted.                                    |                                            |
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
+| X-OC-CTime            | | Allow to specify a creation time.                             | ``1675789581``                             |
+|                       | | The response will contain the header ``X-OC-CTime: accepted`` |                                            |
+|                       | | if the mtime was accepted.                                    |                                            |
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
+| OC-Checksum           | | A checksum that will be stored in the DB.                     | ``md5:04c36b75222cd9fd47f2607333029106``   |
+|                       | | For regular ``PUT`` uploads, the server stores the value      |                                            |
+|                       | | without validation. During bulk uploads, the checksum         |                                            |
+|                       | | **is** validated against the uploaded content.                |                                            |
+|                       | | Currently used algorithms are ``MD5``, ``SHA1``, ``SHA256``,  |                                            |
+|                       | | ``SHA3-256``, ``Adler32``.                                    |                                            |
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
+| X-Hash                | | On ``PUT`` requests, instructs the server to compute a hash   | ``md5``, ``sha1``, ``sha256``,             |
+|                       | | of the uploaded file content during the write. The server     | or ``all``                                 |
+|                       | | returns the hash(es) in response headers named                |                                            |
+|                       | | ``X-Hash-MD5``, ``X-Hash-SHA1``, and/or ``X-Hash-SHA256``.    |                                            |
+|                       | | Setting the value to ``all`` computes all three hashes.       |                                            |
+|                       | | Beware of performance implications!                           |                                            |
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
+| OC-Total-Length       | | Contains the total size of the file during a chunk upload.    | ``4052412``                                |
+|                       | | This allow the server to abort faster if the remaining        |                                            |
+|                       | | user's quota is not enough.                                   |                                            |
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
+| X-NC-WebDAV-AutoMkcol | | When set to ``1``, instructs the server to automatically      |                                            |
+|                       | | create any missing parent directories when uploading a file.  |                                            |
+|                       | | Available since Nextcloud 32.                                 |                                            |
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
+| OC-Chunked            | | Used for legacy chunk upload to differentiate a regular       | Deprecated                                 |
+|                       | | upload from a chunked upload. It allowed checking for quota   |                                            |
+| (deprecated)          | | and various other things. Nowadays, you need to provide the   | You do not have to provide                 |
+|                       | | ``OC-Total-Length`` header on the ``PUT`` requests instead.   | this anymore                               |
++-----------------------+-----------------------------------------------------------------+--------------------------------------------+
 
 Response Headers
 ----------------

--- a/developer_manual/client_apis/WebDAV/basic.rst
+++ b/developer_manual/client_apis/WebDAV/basic.rst
@@ -1,8 +1,8 @@
 .. _webdavindex:
 
-==========
-Basic APIs
-==========
+==============================
+Basic File & Folder Operations
+==============================
 
 This document provides a quick overview of the WebDAV operations supported in Nextcloud, to keep things readable it won't go into many details
 for each operation, further information for each operation can be found in the corresponding RFC where applicable.
@@ -10,11 +10,13 @@ for each operation, further information for each operation can be found in the c
 WebDAV basics
 -------------
 
-The base url for all (authenticated) WebDAV operations for a Nextcloud instance is :code:`/remote.php/dav`.
+The base url for all (authenticated) WebDAV operations for a Nextcloud instance is :code:`/remote.php/dav`. For file operations, this usually
+means paths below :code:`/remote.php/dav/files/{user}/...`.
 
 All requests need to provide authentication information, either as a basic auth header or by passing a set of valid session cookies.
 
-If your Nextcloud installation uses an external auth provider (such as an OIDC server) you may have to create an app password.
+If your Nextcloud installation uses an external auth provider (such as an OIDC server) or enforces policies like 2FA, you may need to create an
+app password for WebDAV clients and scripts.
 To do that, go to your personal security settings and create one. It will provide a username and password which you can use within the Basic Auth header.
 
 Public shares
@@ -82,12 +84,45 @@ Here is a JavaScript code sample to get you started:
 			</d:propfind>`,
 	})
 
+Quick method/header cheat sheet
+-------------------------------
+
+The table below summarizes common WebDAV methods used by Nextcloud and the most relevant headers.
+
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| Method     | Typical endpoint                          | Important request headers                    | Notes                                                       |
++============+===========================================+=============================================+==============================================================+
+| PROPFIND   | ``/remote.php/dav/files/{user}/path``     | ``Depth: 0`` (properties of node only)       | Without ``Depth: 0``, folder listings include child entries.|
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| REPORT     | ``/remote.php/dav/files/{user}/path``     | (none required)                              | Used for filtered queries such as favorites.                |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| GET (file) | ``/remote.php/dav/files/{user}/file``     | (none required)                              | Downloads file content.                                     |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| GET (dir)  | ``/remote.php/dav/files/{user}/folder``   | ``Accept: application/zip`` or               | Nextcloud extension for folder archive download.            |
+|            |                                           | ``Accept: application/x-tar``                |                                                             |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| PUT        | ``/remote.php/dav/files/{user}/file``     | Optional: ``X-OC-MTime``, ``X-OC-CTime``,    | Uploads/overwrites file content.                            |
+|            |                                           | ``OC-Checksum``, ``OC-Total-Length``,        |                                                             |
+|            |                                           | ``X-NC-WebDAV-AutoMkcol``                    |                                                             |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| MKCOL      | ``/remote.php/dav/files/{user}/folder``   | (none required)                              | Creates a folder.                                           |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| DELETE     | ``/remote.php/dav/files/{user}/path``     | (none required)                              | Folder deletes are recursive.                               |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| MOVE       | ``/remote.php/dav/files/{user}/path``     | ``Destination: <full URL>``                  | Optional: ``Overwrite: T`` (default) or ``Overwrite: F``.   |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| COPY       | ``/remote.php/dav/files/{user}/path``     | ``Destination: <full URL>``                  | Optional: ``Overwrite: T`` (default) or ``Overwrite: F``.   |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+| PROPPATCH  | ``/remote.php/dav/files/{user}/path``     | (none required)                              | Sets properties such as ``oc:favorite``.                    |
++------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
+
 Requesting properties
 ---------------------
 
 By default, a :code:`PROPFIND` request will only return a small number of properties for each file: last modified date, file size, whether it's a folder, etag and mime type.
 
 You can request additional properties by sending a request body with the :code:`PROPFIND` request that lists all requested properties.
+If a property is not supported for a resource, the server will report it as not found in the multi-status response for that property.
 
 .. code-block:: xml
 
@@ -135,16 +170,21 @@ And here is how it should look in your DAV request:
 .. code-block:: xml
 
 	<?xml version="1.0"?>
-		<d:propfind
-			xmlns:d="DAV:"
-			xmlns:oc="http://owncloud.org/ns"
-			xmlns:nc="http://nextcloud.org/ns"
-			xmlns:ocs="http://open-collaboration-services.org/ns">
-			xmlns:ocm="http://open-cloud-mesh.org/ns">
+	<d:propfind
+		xmlns:d="DAV:"
+		xmlns:oc="http://owncloud.org/ns"
+		xmlns:nc="http://nextcloud.org/ns"
+		xmlns:ocs="http://open-collaboration-services.org/ns"
+		xmlns:ocm="http://open-cloud-mesh.org/ns">
 		...
+	</d:propfind>
 
 Supported properties
 ^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+   Properties in the ``d:`` namespace are standard WebDAV properties (RFC 4918).
+   Most properties in ``oc:``, ``nc:``, ``ocs:``, and ``ocm:`` are Nextcloud-specific extensions.
 
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 |           Property            |                   Description                   |                                 Example                                              |
@@ -410,6 +450,8 @@ The optional files list can be provided as a JSON encoded array through the :cod
 
 	GET remote.php/dav/files/user/path/to/folder?accept=zip&files=["image.png","document.txt"]
 
+When using query parameters, ensure values are URL-encoded. In particular, :code:`files` must be a URL-encoded JSON array.
+
 Uploading files
 ---------------
 
@@ -451,7 +493,7 @@ A file or folder can be moved by sending a :code:`MOVE` request to the file or f
 	MOVE remote.php/dav/files/user/path/to/file
 	Destination: https://cloud.example/remote.php/dav/files/user/new/location
 
-The overwrite behavior of the move can be controlled by setting the :code:`Overwrite` head to :code:`T` or :code:`F` to enable or disable overwriting respectively.
+The overwrite behavior of the move can be controlled by setting the :code:`Overwrite` header to :code:`T` or :code:`F` to enable or disable overwriting respectively.
 
 Copying files and folders (rfc4918_)
 ------------------------------------
@@ -463,12 +505,12 @@ A file or folder can be copied by sending a :code:`COPY` request to the file or 
 	COPY remote.php/dav/files/user/path/to/file
 	Destination: https://cloud.example/remote.php/dav/files/user/new/location
 
-The overwrite behavior of the copy can be controlled by setting the :code:`Overwrite` head to :code:`T` or :code:`F` to enable or disable overwriting respectively.
+The overwrite behavior of the copy can be controlled by setting the :code:`Overwrite` header to :code:`T` or :code:`F` to enable or disable overwriting respectively.
 
 Settings favorites
 ------------------
 
-A file or folder can be marked as favorite by sending a :code:`PROPPATCH` request to the file or folder and setting the :code:`oc-favorite` property
+A file or folder can be marked as favorite by sending a :code:`PROPPATCH` request to the file or folder and setting the :code:`oc:favorite` property.
 
 .. code-block:: xml
 
@@ -487,7 +529,7 @@ Setting the :code:`oc:favorite` property to ``1`` marks a file as favorite, sett
 Listing favorites
 -----------------
 
-Favorites for a user can be retrieved by sending a :code:`REPORT` request and specifying :code:`oc:favorite` as a filter
+Favorites for a user can be retrieved by sending a :code:`REPORT` request and specifying :code:`oc:favorite` as a filter.
 
 .. code-block:: xml
 

--- a/developer_manual/client_apis/WebDAV/basic.rst
+++ b/developer_manual/client_apis/WebDAV/basic.rst
@@ -102,7 +102,7 @@ The table below summarizes common WebDAV methods used by Nextcloud and the most 
 | REPORT     | ``/remote.php/dav/files/{user}/path``     | (none required)                              | Used for filtered queries such as favorites.                |
 +------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | GET (file) | ``/remote.php/dav/files/{user}/file``     | (none required)                              | Downloads file content.                                     |
-+------------+-------------------------------------------+---------------------------------------------+--------------------------------------------------------------+
++------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+
 | GET (dir)  | ``/remote.php/dav/files/{user}/folder``   | ``Accept: application/zip`` or               | Nextcloud extension for folder archive download.            |
 |            |                                           | ``Accept: application/x-tar``                |                                                             |
 +------------+-------------------------------------------+----------------------------------------------+-------------------------------------------------------------+

--- a/developer_manual/client_apis/WebDAV/index.rst
+++ b/developer_manual/client_apis/WebDAV/index.rst
@@ -1,16 +1,16 @@
 .. _webdavapiindex:
 
 ======
-Webdav
+WebDAV
 ======
 
 .. toctree::
     :maxdepth: 2
 
     basic
-    search
-    trashbin
-    versions
     chunking
     bulkupload
+    trashbin
+    versions
+    search
     comments


### PR DESCRIPTION
### ☑️ Resolves

Overhauls the WebDAV basic operations page in the developer manual.

New content:

* Quick method/header cheat sheet table
* Missing properties: nc:is-federated, nc:metadata_etag, nc:download-url-expiration, dynamic nc:metadata-*
* X-Requested-With requirement for non-GET requests on public share endpoints
* X-Hash: all option, OC-Checksum bulk upload validation behavior, X-NC-WebDAV-AutoMkcol availability note (NC 32+)
* Shorthand zip/tar values for folder download accept parameter

Clarifications:

* Renamed page: "Basic APIs" to "Basic File & Folder Operations"
* Expanded intro with file path pattern and 2FA app-password guidance
* Noted oc:permissions S/M flag stripping on public shares
* Added URL-encoding reminder for query-parameter folder downloads
* Added note distinguishing standard WebDAV vs Nextcloud-specific property namespaces

Changes:

* Typos: "head" > "header", oc-favorite > oc:favorite, missing periods
* Broken XML: corrected `ocm` namespace url syntax, fixed indentation and missing </d:propfind> closing tag
* Self-closing tag syntax: <nc:is-mount-root>, <nc:hidden>
* Improved the *Supported properties* table layout: column widths

### 🖼️ Screenshots

<img width="1610" height="14446" alt="image" src="https://github.com/user-attachments/assets/8e07fa89-309e-472b-9379-fe73674ade8d" />

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
