### PR TITLE
fix: Remove unused sections from versions.html

### DIFF
--- a/user_manual/_templates/versions.html
+++ b/user_manual/_templates/versions.html
@@ -95,22 +95,6 @@
           </dd>
         {% endfor %}
       </dl>
-      <dl>
-        <dt>{{ _('Downloads') }}</dt>
-        {% for type, url in downloads %}
-          <dd><a href="{{ url }}">{{ type }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        {# Translators: The phrase "Read the Docs" is not translated #}
-        <dt>{{ _('On Read the Docs') }}</dt>
-        <dd>
-          <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
-        </dd>
-        <dd>
-          <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
-        </dd>
-      </dl>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
It generates invalid links on the docs
<img width="900" height="582" alt="image" src="https://github.com/user-attachments/assets/446eb09f-7a56-4207-ab63-03602e6be7c8" />

Been there since we introduced the multi lang 6 years ago :see_no_evil: 