### PR TITLE
fix(ChunkedUpload): Remove note regarding chunked upload not being used on file drop shares

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -159,8 +159,6 @@ Put in a value in bytes (in this example, 20MB). Set ``--value 0`` for no chunki
 
 Default is ``104857600`` (100 MiB).
 
-.. note:: Changing ``files.chunked_upload.max_size`` will not have any performance impact on files uploaded through File Drop shares as unauthenticated file uploads are not chunked.
-
 Large file upload on object storage
 -----------------------------------
 


### PR DESCRIPTION
File drop shares do support chunked uploads since Nextcloud 32 (see https://github.com/nextcloud/server/pull/52182). Therefore, the note should be removed for Nextcloud 34 / 33 / 32.

### 🖼️ Screenshots

Section without the note on the bottom being removed:

<img width="1880" height="852" alt="image" src="https://github.com/user-attachments/assets/1e3fed4f-998a-4429-a2a7-704beba7078a" />

