### PR TITLE
fix(user-manual): correct typos and grammar errors

### DIFF
--- a/user_manual/desktop/installation.rst
+++ b/user_manual/desktop/installation.rst
@@ -110,7 +110,7 @@ Changing Installed Features
 
 You can change the installed features later by using ``REMOVE`` and ``ADDDEFAULT`` properties.
 
-1. If you want to add the the desktop shortcut later, run the following command::
+1. If you want to add the desktop shortcut later, run the following command::
 
     msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT="DesktopShortcut"
 

--- a/user_manual/groupware/calendar.rst
+++ b/user_manual/groupware/calendar.rst
@@ -85,7 +85,7 @@ Sometimes you may want to change the color or the entire name of a previous
 imported or created calendar. You may also want to export it to your local
 hard drive or delete it forever.
 
-.. note:: Please keep in mind that deleting a calendar is a irreversible action.
+.. note:: Please keep in mind that deleting a calendar is an irreversible action.
           After deletion, there is no way of restoring the calendar unless you
           have a local backup.
 

--- a/user_manual/session_management.rst
+++ b/user_manual/session_management.rst
@@ -43,7 +43,7 @@ those individually if necessary:
    enter the password on the new client immediately.
 
 
-.. note:: If you are :doc:`user_2fa` for your account,
+.. note:: If you use :doc:`user_2fa` for your account,
    device-specific passwords are the only way to configure clients. The
    server will deny connections of clients using your login password then.
 


### PR DESCRIPTION
- Remove duplicate "the" in desktop/installation.rst
- Fix "a irreversible" → "an irreversible" in groupware/calendar.rst
- Fix "you are" → "you use" in session_management.rst

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
