### PR TITLE
fix(developer-manual): correct typos in flow and ExApp docs

### DIFF
--- a/developer_manual/digging_deeper/flow.rst
+++ b/developer_manual/digging_deeper/flow.rst
@@ -51,6 +51,6 @@ For the configuration component, We create a new JavaScript bundle ::
         color: '#dc5047'
     })
 
-In the ``RegisterOperationsEvent`` listener we need to registere the above JS bundle.
+In the ``RegisterOperationsEvent`` listener we need to register the above JS bundle.
 
 The ``OCA.WorkflowEngine.registerOperator`` function tells Nextcloud about your operation, along with the color, and the component that contains configuration specific to your flow.

--- a/developer_manual/exapp_development/development_overview/ExAppDevelopmentSteps.rst
+++ b/developer_manual/exapp_development/development_overview/ExAppDevelopmentSteps.rst
@@ -49,7 +49,7 @@ More details are available in the :ref:`ExAppOverview` section.
 3. Development
 --------------
 
-The basic development process contains from the following steps:
+The basic development process consists of the following steps:
 
 - Implement the ExApp <-> Nextcloud :ref:`lifecycle methods <ex_app_lifecycle_methods>`:
 	#. ``/heartbeat``: ExApp heartbeat method


### PR DESCRIPTION
- Fix "registere" → "register" in digging_deeper/flow.rst
- Fix "contains from" → "consists of" in ExAppDevelopmentSteps.rst

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>