### PR TITLE
fix(developer-manual): fix XML tag mismatch and broken link reference

### DIFF
--- a/developer_manual/app_publishing_maintenance/publishing.rst
+++ b/developer_manual/app_publishing_maintenance/publishing.rst
@@ -52,7 +52,7 @@ Be technically sound
 Respect the users
 ^^^^^^^^^^^^^^^^^
 
-* Apps have to follow design and `HTML/CSS layout guidelines <../app/css.html>`_.
+* Apps have to follow design and `HTML/CSS layout guidelines <../html_css_design/css.html>`_.
 * Apps correctly clean up after themselves on uninstall and correctly handle up- and downgrades.
 * Apps clearly communicate their intended purpose and active features, including features introduced through updates.
 * Apps respect the users' choices and do not make unexpected changes, or limit users' ability to revert them. For example, they do not remove other apps or disable settings.

--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -66,7 +66,7 @@ This request returns the available metadata of a user. Admin users can see the i
 			<storageLocation>/path/to/storage/location/userid</storageLocation>
 			<id>userid</id>
 			<lastLogin>1578283711000</lastLogin>
-			<backend>Database</database>
+			<backend>Database</backend>
 			<subadmin/>
 			<quota>
 				<free>20632824998</free>


### PR DESCRIPTION
- Fix </database> → </backend> closing tag in ocs-api-overview.rst
- Fix broken link to HTML/CSS guidelines in publishing.rst

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
