### PR TITLE
fix(developer-manual): add missing alt text to image and figure directives

### DIFF
--- a/developer_manual/design/foundations.rst
+++ b/developer_manual/design/foundations.rst
@@ -17,7 +17,7 @@ Primary color
 .. figure:: ../images/colour-primary.svg
    :alt: Nextcloud primary color swatch showing blue #0082C9
 
-		#0082C9
+   #0082C9
 
 While this is the primary color associated with Nextcloud and can be used to draw attention to an element, it is best to limit the usage of this to primary actions and other important elements.
 

--- a/developer_manual/design/foundations.rst
+++ b/developer_manual/design/foundations.rst
@@ -15,7 +15,8 @@ Primary color
 ^^^^^^^^^^^^^
 
 .. figure:: ../images/colour-primary.svg
-	 	
+   :alt: Nextcloud primary color swatch showing blue #0082C9
+
 		#0082C9
 
 While this is the primary color associated with Nextcloud and can be used to draw attention to an element, it is best to limit the usage of this to primary actions and other important elements.
@@ -34,10 +35,12 @@ Background color
 .. list-table::
 
     * - .. figure:: ../images/colour-main-background.svg
+           :alt: Light theme background color swatch showing white #FFFFFF
 
            Background for light theme: #FFFFFF
 
       - .. figure:: ../images/colour-dark-theme-main-backgroud.svg
+           :alt: Dark theme background color swatch showing dark grey #181818
 
            Background for dark theme: #181818
 
@@ -55,10 +58,12 @@ Text color
 .. list-table::
 
     * - .. figure:: ../images/colour-main-text.svg
+           :alt: Light theme text color swatch showing near-black #222222
 
            Text in light theme: #222222
 
       - .. figure:: ../images/colour-dark-theme-main-text.svg
+           :alt: Dark theme text color swatch showing light grey #D8D8D8
 
            Text in dark theme: #D8D8D8
 
@@ -73,10 +78,12 @@ This is the main color for the text in light theme, and in dark theme.
 .. list-table::
 
     * - .. figure:: ../images/colour-text-maxcontrast.svg
+           :alt: Light theme secondary text color swatch showing grey #767676
 
            Secondary text in light theme: #767676
 
       - .. figure:: ../images/colour-dark-theme-text-maxcontrast.svg
+           :alt: Dark theme secondary text color swatch showing medium grey #8C8C8C
 
            Secondary text in dark theme: #8C8C8C
 
@@ -95,18 +102,22 @@ Status and indicators
 .. list-table::
 
     * - .. figure:: ../images/color-info.svg
+           :alt: Info status color swatch showing blue #006AA3
 
            Info: #006AA3
 
       - .. figure:: ../images/color-success.svg
+           :alt: Success status color swatch showing green #46BA61
 
            Success: #46BA61
 
       - .. figure:: ../images/color-error.svg
+           :alt: Error status color swatch showing red #E9322D
 
            Error: #E9322D
 
       - .. figure:: ../images/color-warning.svg
+           :alt: Warning status color swatch showing amber #ECA700
 
            Warning: #ECA700
 

--- a/developer_manual/digging_deeper/dashboard.rst
+++ b/developer_manual/digging_deeper/dashboard.rst
@@ -338,6 +338,7 @@ render the widget. Its constructor is:
   following example from the Talk app:
 
 .. figure:: ../images/talk-widget-half-empty-content.png
+   :alt: Talk dashboard widget showing half empty content state with a message displayed above a short item list
    :width: 40%
 
 Here is a full example of a widget that implements the `OCP\\Dashboard\\IAPIWidgetV2` interface:

--- a/developer_manual/digging_deeper/profiler.rst
+++ b/developer_manual/digging_deeper/profiler.rst
@@ -54,6 +54,7 @@ run, how many database and LDAP requests it did, how often did the cache hit and
 the toolbar track the XHR requests created by the JavaScript frontend.
 
 .. image:: ../images/profiler-toolbar.png
+   :alt: Nextcloud profiler toolbar showing request timing, database queries, LDAP requests, and cache statistics
 
 You can hover on top of the toolbar information to show more detailed information and also
 click on the toolbar to show all the information collected.
@@ -71,6 +72,7 @@ The General Request and Response View
 .....................................
 
 .. image:: ../images/profiler-request.png
+   :alt: Profiler general request and response view showing controller, response headers, and request parameters
 
 This view gives you general information about the request. For example,
 which Controller and method was used, what where the response headers, the
@@ -85,6 +87,7 @@ the query to see if an index was used and also see the backtrace to better under
 why the query was executed.
 
 .. image:: ../images/profiler-database.png
+   :alt: Profiler database queries view listing executed queries with execution time and explain options
 
 It's important to keep the number of queries executed to a minimum since the database
 is often a limiting factor in a Nextcloud installation. In particular try to avoid the
@@ -105,6 +108,7 @@ This view display all the logged events and allow you to determine in which part
 programe the more time is spent.
 
 .. image:: ../images/profiler-event.png
+   :alt: Profiler event view displaying logged events and time spent in each part of the program
 
 The Cache View
 ..............
@@ -113,6 +117,7 @@ This view display all the access to the cache. It allows to detect cache hits an
 as well as getting an idea of the time spent on Redis.
 
 .. image:: ../images/profiler-cache.png
+   :alt: Profiler cache view showing cache hits, misses, and time spent on Redis operations
 
 Contributing
 ------------

--- a/developer_manual/html_css_design/popovermenu.rst
+++ b/developer_manual/html_css_design/popovermenu.rst
@@ -96,6 +96,7 @@ Technical details
 * Supported inputs are all text based ones and buttons type ones
 
 .. image:: ../images/popover-position.png
+   :alt: Diagram showing required 14px right distance for popover menu positioning relative to the three-dot icon
 
 Alignment
 ---------

--- a/developer_manual/prologue/bugtracker/triaging.rst
+++ b/developer_manual/prologue/bugtracker/triaging.rst
@@ -68,6 +68,7 @@ Much content from https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging
 The goal of triaging is to have only useful bug reports for the developers. And you don't have to know much to be able to judge at least some bug reports to be less than useful. There are duplications, incomplete reports and so on. Here is the work flow for each bug:
 
 .. figure:: ../../images/triageworkflow.png
+   :alt: Bug triage workflow diagram showing steps to evaluate and categorize issue reports
    :scale: 50
 
 Let's go over each step.


### PR DESCRIPTION
Add descriptive :alt: attributes to 20 images across 5 files for improved accessibility: profiler views, design color swatches, dashboard widget, popover position diagram, and triage workflow.

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>