### PR TITLE
fix(user-manual/desktop): update registry keys for x64-only builds

### DIFF
--- a/admin_manual/desktop/troubleshooting.rst
+++ b/admin_manual/desktop/troubleshooting.rst
@@ -201,7 +201,7 @@ mentioned above to save the log to a file.
   .. note:: You can also open a log window for an already running session, by
      restarting the client using the following command:
 
-     * Windows: ``C:\Program Files (x86)\Nextcloud\nextcloud.exe --logwindow``
+     * Windows: ``C:\Program Files\Nextcloud\nextcloud.exe --logwindow``
      * macOS: ``/Applications/nextcloud.app/Contents/MacOS/nextcloud --logwindow``
      * Linux: ``nextcloud --logwindow``
 

--- a/user_manual/desktop/autoupdate.rst
+++ b/user_manual/desktop/autoupdate.rst
@@ -78,10 +78,9 @@ prevents any manual overrides.
 
 To prevent automatic updates, but allow manual overrides:
 
-1. Edit these Registry keys:
+1. Edit this Registry key:
 
-    a. (32-bit-Windows) ``HKEY_LOCAL_MACHINE\Software\Nextcloud\Nextcloud``
-    b. (64-bit-Windows) ``HKEY_LOCAL_MACHINE\Software\Wow6432Node\Nextcloud\Nextcloud``
+    ``HKEY_LOCAL_MACHINE\Software\Nextcloud GmbH\Nextcloud``
 
 2. Add the key ``skipUpdateCheck`` (of type DWORD).
 
@@ -102,7 +101,9 @@ To prevent automatic updates and disallow manual overrides:
 
 3. Specify a value of ``1`` to the machine.
 
-.. note:: branded clients have different key names
+.. note:: Branded clients use a different key in place of
+   ``Nextcloud GmbH\Nextcloud`` that matches the branded application vendor and
+   name.
 
 
 Preventing Automatic Updates in Linux Environments


### PR DESCRIPTION
The distinction between 32/64-bit keys was only relevant when we still shipped the 32-bit (x86) client.  Since v3.6.0 (September 2022) there were only new 64-bit (x64) releases of the desktop client.

Also clarify the note about branded clients, and update the path to `Program Files` in the admin manual.

### 🖼️ Screenshots

| before | after|
|-|-|
| <img width="1411" height="1079" alt="previous state mentioning the old and wrong registry keys" src="https://github.com/user-attachments/assets/b3241543-8e5d-41e1-a943-3871be510579" /> | <img width="1411" height="1079" alt="updated state, correcting the registry key and mentioning what to change for branded clients" src="https://github.com/user-attachments/assets/29c197dd-c0ad-421a-ba54-04a6b440607d" /> |
