### PR TITLE
docs(user/talk): rewrite bots and commands page

### DIFF
--- a/user_manual/talk/bots.rst
+++ b/user_manual/talk/bots.rst
@@ -1,10 +1,24 @@
 Bots and commands
 =================
 
-.. FIXME Replace with bots as commands are removed, or remove?
+Bots
+----
+
+Bots can respond to chat messages, provide automated replies, and integrate with external services. Your administrator can enable bots for your Talk instance.
+
+Some examples of available bots:
+
+- **Call summary** — Posts an overview message after a call ends, listing all participants and outlining any tasks that were mentioned.
+- **Agenda bot** — Helps manage meeting agendas with time monitoring and permission-based access control.
+- **Roll a dice** — Type ``/roll`` in a conversation to roll dice.
+
+A full list of available bots and installation instructions can be found in the `Talk administration documentation <https://nextcloud-talk.readthedocs.io/en/latest/bot-list/>`_.
 
 Commands
 --------
+
+.. warning::
+   Commands have been removed in favor of Bots.
 
 Nextcloud allows users to execute actions using commands. A command typically looks like:
 
@@ -16,5 +30,3 @@ Administrators can configure, enable and disable commands. Users can use the ``h
 
 .. image:: images/command-help.png
     :width: 600px
-
-Find more information in the `administrative documentation for Talk. <https://nextcloud-talk.readthedocs.io/en/stable/commands/>`_


### PR DESCRIPTION
Add a Bots section with descriptions of popular bots (call summary, agenda bot, roll a dice) and a link to the Talk admin documentation. Mark the Commands section as removed in favor of Bots.

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

<img width="1185" height="808" alt="image" src="https://github.com/user-attachments/assets/4842e949-c6df-4bed-811b-5caea270cbe9" />

