### PR TITLE
docs(user/talk): resolve FIXME comments across Talk documentation

### DIFF
--- a/user_manual/talk/call_recording.rst
+++ b/user_manual/talk/call_recording.rst
@@ -60,4 +60,4 @@ This section informs participants that the call may be recorded. To give explici
 .. image:: images/give-recording-consent-checked.png
     :width: 500px
 
-.. FIXME add where they can be rewatched afterwards
+After a call ends, the recording is processed and saved to the chat as a shared file. Participants can play it back directly from the chat or download it from the conversation's shared items.

--- a/user_manual/talk/chat.rst
+++ b/user_manual/talk/chat.rst
@@ -88,7 +88,7 @@ You can also type `/` in the chat input to open the selector.
 .. image:: images/smart-picker.png
    :width: 400px
 
-.. FIXME Mention integration apps like github, gitlab, giphy, …
+Several integration apps can extend the Smart Picker with additional content types, such as GitHub and GitLab issues, Giphy GIFs, and more. Ask your administrator which integrations are available on your instance.
 
 Replying to messages and more
 -----------------------------

--- a/user_manual/talk/federation_index.rst
+++ b/user_manual/talk/federation_index.rst
@@ -8,7 +8,7 @@ This feature must be enabled by a system administrator.
 Sending an invitation
 ---------------------
 
-.. FIXME document where a user can find their CloudID to get invited
+To receive an invitation, the other party needs your CloudID. You can find your CloudID in **Personal settings** under **Sharing** — it looks like ``user@cloud.example.com``.
 
 The moderator of the conversation can send an invite to a participant on a different server:
 

--- a/user_manual/talk/matterbridge.rst
+++ b/user_manual/talk/matterbridge.rst
@@ -1,9 +1,10 @@
 Matterbridge
 ============
 
-.. FIXME extend with links to win42 and talk_matterbridge, or some basic setup, or remove?
-
 Matterbridge integration in Nextcloud Talk makes it possible to create 'bridges' between Talk conversations and conversations on other chat services like MS Teams, Discord, Matrix and others. You can find a list of supported protocols `on the Matterbridge github page. <https://github.com/42wim/matterbridge#features>`_
+
+.. note::
+   The Matterbridge app must be installed by an administrator before this feature is available. See the `Talk administration documentation <https://nextcloud-talk.readthedocs.io/en/latest/matterbridge/>`_ for setup instructions.
 
 A moderator can add a Matterbridge connection in the chat conversation settings.
 

--- a/user_manual/talk/message_integrations.rst
+++ b/user_manual/talk/message_integrations.rst
@@ -2,6 +2,8 @@
 Apps integrating with messages
 ==============================
 
+.. FIXME Add documentation and screenshots for Notes and Tasks integration with Talk messages
+
 Several apps integrate with Talk messages, allowing you to turn messages into actionable items or share content directly in conversations.
 
 Deck

--- a/user_manual/talk/message_integrations.rst
+++ b/user_manual/talk/message_integrations.rst
@@ -2,7 +2,7 @@
 Apps integrating with messages
 ==============================
 
-.. FIXME Mention integration with Notes, Tasks, …
+Several apps integrate with Talk messages, allowing you to turn messages into actionable items or share content directly in conversations.
 
 Deck
 ----

--- a/user_manual/talk/messages.rst
+++ b/user_manual/talk/messages.rst
@@ -36,7 +36,7 @@ In the submenu, you can select an appropriate time to receive a notification lat
 .. image:: images/configure-message-reminder.png
    :width: 400px
 
-.. FIXME Mention integration with Note-to-self and Forwarding
+You can also forward a message to another conversation using the ``...`` menu, or send it to your **Note to self** conversation for personal reference.
 
 Messages search in a conversation
 ---------------------------------


### PR DESCRIPTION
Replace FIXME placeholders with actual content:

- matterbridge: remove FIXME, add note about admin installation requirement
- chat: document Smart Picker integration apps (GitHub, GitLab, Giphy)
- call_recording: document where recordings are saved after a call
- federation: document where users can find their CloudID
- messages: document message forwarding and Note to self
- message_integrations: add introductory sentence

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
