### PR TITLE
[stable33] fix: remove PHP cache validation disabling example

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -174,13 +174,7 @@ To change the default from ``2`` and check for changes on disk at most every ``6
 
   opcache.revalidate_freq = 60
 
-Alternatively, you can disable the revalidation completely:
-
-.. code:: ini
-
-  opcache.validate_timestamps = 0
-
-Any server or app upgrades, or changes to ``config.php``, will then require restarting PHP (or otherwise manually clearing the cache or invalidating this particular script).
+Any Server/app upgrades or changes to ``config.php`` will then require restarting PHP (or otherwise manually clearing the cache or invalidating this particular script).
 
 .. warning::
    Please do not report bugs or odd behavior after upgrading Nextcloud or Nextcloud apps until after you've 


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/documentation/pull/12079
