### PR TITLE
docs(desktop): improve installation guide structure and desktop client index

### DIFF
--- a/user_manual/desktop/index.rst
+++ b/user_manual/desktop/index.rst
@@ -1,15 +1,9 @@
-===============
-Desktop Clients
-===============
+==============
+Desktop Client
+==============
 
-Available for Windows, macOS, and various Linux distributions, the Nextcloud
-Desktop Sync client enables you to:
-
-- Specify one or more directories on your computer that you want to synchronize
-  to the Nextcloud server.
-- Always have the latest files synchronized, wherever they are located.
-
-Your files are always automatically synchronized between your Nextcloud server, computer and mobile device.
+The Nextcloud desktop client for Windows, macOS, and Linux keeps files
+synchronized between your computer and your Nextcloud server.
 
 .. toctree::
    :maxdepth: 1
@@ -23,7 +17,7 @@ Your files are always automatically synchronized between your Nextcloud server, 
    conflicts
    faq
 
-You can find additional information here:
+For additional information, see:
 
 * `Admin manual`_
 * `Developer manual`_

--- a/user_manual/desktop/installation.rst
+++ b/user_manual/desktop/installation.rst
@@ -2,192 +2,89 @@
 Installation
 ============
 
-You can download the latest version of the Nextcloud Desktop Synchronization
-Client from the `Nextcloud download page`_.
-There are clients for Linux, macOS, and Microsoft Windows.
+Download
+--------
 
-The currently supported server releases are the latest three stable versions
-at time of publication. It means that the |version| release series is supporting
-stable server major versions.
-See https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule for
-supported major versions.
-  
-Installation on macOS and Windows is the same as for any software
-application: download the program and then double-click it to launch the
-installation, and then follow the installation wizard. After it is installed and
-configured the sync client will automatically keep itself updated; see
-:doc:`autoupdate` for more information.
-
-Linux users must follow the instructions on the download page to add the
-appropriate repository for their Linux distribution, install the signing key,
-and then use their package managers to install the desktop sync client. Linux
-users will also update their sync clients via package manager, and the client
-will display a notification when an update is available.
-
-Linux users must also have a password manager enabled, such as GNOME Keyring or
-KWallet, so that the sync client can login automatically.
+You can download the latest version of the Nextcloud Desktop Synchronization Client
+from the `Nextcloud download page`_. Clients are available for Linux, macOS, and
+Microsoft Windows.
 
 You will also find links to source code archives and older versions on the
 download page.
 
+Supported server versions
+-------------------------
+
+Each desktop client release supports the latest three stable Nextcloud server
+major versions at the time of release. See the `Nextcloud Server release schedule`_
+for supported major versions.
+
 System Requirements
-----------------------------------
+-------------------
 
 - Windows 10+ (64-bits only)
 - macOS 12.0+ (64-bits only)
 - Linux (Ubuntu 24.04 or openSUSE 15.5 or Alma 8 or ...) (64-bits only)
-    For Linux distributions, we support, if technically feasible, the current LTS releases.
-    For BSD, we support them if technically feasible but we do not test.
+
+  For Linux distributions, we support, if technically feasible, the current
+  LTS releases. For BSD, we support them if technically feasible, but we do not
+  test them.
 
 .. note::
-   We do not support Citrix. 
+   We do not support Citrix.
 
-   - We will do our best to advise Citrix users from the desktop client point of view. 
-   - We will fix issues that are also reproducible on the standard supported systems. 
+   - We will do our best to advise Citrix users from the desktop client point of view.
+   - We will fix issues that are also reproducible on the standard supported systems.
    - Everything else is outside of our scope.
 
-Customizing the Windows Installation
-------------------------------------
+Install on macOS and Windows
+----------------------------
 
-If you just want to install Nextcloud Desktop Synchronization Client on your local
-system, you can simply launch the `.msi` file and configure it in the wizard
-that pops up.
+Installation on macOS and Windows is the same as for any other software
+application: download the program and then double-click it to launch the
+installation, and then follow the installation wizard. After it is installed and
+configured the desktop client will automatically keep itself updated; see
+:doc:`autoupdate` for more information.
 
-Features
-^^^^^^^^
+For advanced Windows deployment and MSI customization options, see
+:ref:`customizing-windows-installation`.
 
-The MSI installer provides several features that can be installed or removed
-individually, which you can also control via command-line, if you are automating
-the installation, then run the following command::
+Install on Linux
+----------------
 
-   msiexec /passive /i Nextcloud-x.y.z-x64.msi
+For Linux, Nextcloud officially provides the desktop client as an AppImage on
+the `Nextcloud download page`_.
 
-The command will install the Nextcloud Desktop Synchronization Client into the default location
-with the default features enabled.
-If you want to disable, e.g., desktop shortcut icons you can simply change the above command to the following::
+Some Linux distributions also provide the Nextcloud desktop client through their
+package managers. These packages are maintained by the distribution or community,
+not by Nextcloud. If you prefer a package-managed installation, refer to your
+distribution's documentation.
 
-   msiexec /passive /i Nextcloud-x.y.z-x64.msi REMOVE=DesktopShortcut
+Linux users must also have a password manager enabled, such as GNOME Keyring or
+KWallet, so that the desktop client can log in automatically.
 
-See the following table for a list of available features:
+Initial Setup
+-------------
 
-+--------------------+--------------------+-----------------------------------+---------------------------+
-| Feature            | Enabled by default | Description                       |Property to disable        |
-+====================+====================+===================================+===========================+
-| Client             | Yes, required      | The actual client                 |                           |
-+--------------------+--------------------+-----------------------------------+---------------------------+
-| DesktopShortcut    | Yes                | Adds a shortcut to the desktop    |``NO_DESKTOP_SHORTCUT``    |
-+--------------------+--------------------+-----------------------------------+---------------------------+
-| StartMenuShortcuts | Yes                | Adds a shortcut to the start menu |``NO_START_MENU_SHORTCUTS``|
-+--------------------+--------------------+-----------------------------------+---------------------------+
-| ShellExtensions    | Yes                | Adds Explorer integration         |``NO_SHELL_EXTENSIONS``    |
-+--------------------+--------------------+-----------------------------------+---------------------------+
+After installation, the initial setup wizard is triggered. In the setup wizard,
+you can log in to your server, create an account with a provider, and configure
+which folders to sync. The wizard will guide you step-by-step through the
+essential configuration options and basic account setup.
 
-Installation
-^^^^^^^^^^^^
-
-You can also choose to only install the client itself by using the following command::
-
-  msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT=Client
-
-If you for instance want to install everything but the ``DesktopShortcut`` and the ``ShellExtensions`` feature, you have two possibilities:
-
-1. You explicitly name all the features you actually want to install (whitelist) where ``Client`` is always installed anyway::
-
-    msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT=StartMenuShortcuts
-
-2. You pass the ``NO_DESKTOP_SHORTCUT`` and ``NO_SHELL_EXTENSIONS`` properties::
-
-    msiexec /passive /i Nextcloud-x.y.z-x64.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
-
-.. NOTE::
-    The Nextcloud ``.msi`` remembers these properties, so you don't need to specify them on upgrades.
-
-.. NOTE::
-    You cannot use these to change the installed features, if you want to do that, see the next section.
-
-Changing Installed Features
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can change the installed features later by using ``REMOVE`` and ``ADDDEFAULT`` properties.
-
-1. If you want to add the desktop shortcut later, run the following command::
-
-    msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT="DesktopShortcut"
-
-2. If you want to remove it, simply run the following command::
-
-    msiexec /passive /i Nextcloud-x.y.z-x64.msi REMOVE="DesktopShortcut"
-
-Windows keeps track of the installed features and using ``REMOVE`` or ``ADDDEFAULT`` will only affect the mentioned features.
-
-Compare `REMOVE <https://msdn.microsoft.com/en-us/library/windows/desktop/aa371194(v=vs.85).aspx>`_
-and `ADDDEFAULT <https://msdn.microsoft.com/en-us/library/windows/desktop/aa367518(v=vs.85).aspx>`_
-on the Windows Installer Guide.
-
-.. NOTE::
-    You cannot specify ``REMOVE`` on initial installation as it will disable all features.
-
-Installation Folder
-^^^^^^^^^^^^^^^^^^^
-
-You can adjust the installation folder by specifying the ``INSTALLDIR``
-property like this::
-
-  msiexec /passive /i Nextcloud-x.y.z-x64.msi INSTALLDIR="C:\Program Files\Non Standard Nextcloud Client Folder"
-
-Be careful when using PowerShell instead of ``cmd.exe``, it can be tricky to get
-the whitespace escaping right there.
-Specifying the ``INSTALLDIR`` like this only works on first installation, you cannot simply re-invoke the ``.msi`` with a different path. If you still need to change it, uninstall it first and reinstall it with the new path.
-
-Disabling Automatic Updates
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To disable automatic updates, you can pass the ``SKIPAUTOUPDATE`` property.::
-
-    msiexec /passive /i Nextcloud-x.y.z-x64.msi SKIPAUTOUPDATE="1"
-
-Launch After Installation
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To launch the client automatically after installation, you can pass the ``LAUNCH`` property.::
-
-    msiexec /i Nextcloud-x.y.z-x64.msi LAUNCH="1"
-
-This option also removes the checkbox to let users decide if they want to launch the client
-for non passive/quiet mode.
-
-.. NOTE::
-    This option does not have any effect without GUI.
-
-No Reboot After Installation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Nextcloud Client schedules a reboot after installation to make sure the Explorer extension is correctly (un)loaded.
-If you're taking care of the reboot yourself, you can set the ``REBOOT`` property::
-
-    msiexec /i Nextcloud-x.y.z-x64.msi REBOOT=ReallySuppress
-
-This will make ``msiexec`` exit with error ``ERROR_SUCCESS_REBOOT_REQUIRED`` (3010).
-If your deployment tooling interprets this as an actual error and you want to avoid that, you may want to set the ``DO_NOT_SCHEDULE_REBOOT`` instead::
-
-    msiexec /i Nextcloud-x.y.z-x64.msi DO_NOT_SCHEDULE_REBOOT="1"
-
-Installation Wizard
--------------------
-
-The installation wizard takes you step-by-step through configuration options and
-account setup. First, you need to enter the URL of your Nextcloud server.
+First, you need to enter the URL of your Nextcloud server.
 
 .. image:: images/wizard_welcome.png
    :alt: form for choosing between login and registering
 
-If you already have an account on a Nextcloud instance, you want to
-press the button ``Login to your Nextcloud``. If you don't have a
-Nextcloud instance and an account there, you might want to register an
-account with a provider. Press ``Create account with Provider`` in
-that case. Please keep in mind that the desktop client might have
-built without provider support. In that case, you won't see this
-page. Instead, you will be prompted with the next page.
+If you already have an account on a Nextcloud instance, click ``Login to your
+Nextcloud``. If you do not yet have a Nextcloud instance or an account, you may
+need to create one first. Alternatively, you might want to register an account
+with a provider. Press ``Create account with Provider`` in that case.
+
+.. note::
+   The desktop client build you are using may have been built without provider
+   support. In that case, you won't see this page and will immediately see the
+   next page.
 
 .. image:: images/wizard_setup.png
    :alt: form for entering Nextcloud server URL
@@ -199,11 +96,14 @@ instance.
 .. image:: images/wizard_flow2.png
    :alt: form waiting for authorization
 
-Now your web browser should open and prompt you to login into your
+Now your web browser should open and prompt you to log in to your
 Nextcloud instance. Enter your username and password in your web
-browser and grant access. After you did that, go back to the
-wizard. Please keep in mind that you might not need to enter your
-username and password if you are already logged in to your browser.
+browser and click *Grant access* when prompted. After you do that,
+go back to the wizard.
+
+.. note::
+   You might not need to enter your username and password if you are
+   already logged in to your web browser.
 
 .. image:: images/wizard_advanced.png
    :alt: Select which remote folders to sync, and which local folder to store
@@ -214,12 +114,162 @@ the Nextcloud server, or select individual folders. The default local
 sync folder is ``Nextcloud``, in your home directory. You may change
 this as well.
 
-When you have completed selecting your sync folders, click the Connect
+When you have completed selecting your sync folders, click the *Connect*
 button at the bottom right. The client will attempt to connect to your
-Nextcloud server, and when it is successful, the wizard closes
-itself. You can now observe the sync activity if you open the main
-dialogue by clicking on the tray icon.
+Nextcloud server. If it is successful, the wizard will close itself. You
+can then observe the sync activity and open the main dialog by clicking
+on the tray icon.
+
+For advanced Windows deployment and MSI configuration options, see the
+following section.
+
+.. _customizing-windows-installation:
+
+Advanced Windows Deployment Options
+-----------------------------------
+
+If you just want to install the desktop client on your local system, simply
+launch the ``.msi`` file and follow the installation wizard.
+
+The following options are intended for advanced Windows installations, for
+example when automating deployment or customizing installed features.
+
+Features
+^^^^^^^^
+
+The MSI installer provides several features that can be installed or removed
+individually, which you can also control via the command line. If you are
+automating the installation, run the following command::
+
+   msiexec /passive /i Nextcloud-x.y.z-x64.msi
+
+The command will install the client into the default location with the default
+features enabled.
+
+If you want to disable, e.g., desktop shortcut icons you can simply change the
+above command to the following::
+
+   msiexec /passive /i Nextcloud-x.y.z-x64.msi REMOVE=DesktopShortcut
+
+See the following table for a list of available features:
+
++--------------------+--------------------+-----------------------------------+-----------------------------+
+| Feature            | Enabled by default | Description                       | Property to disable         |
++====================+====================+===================================+=============================+
+| Client             | Yes, required      | The actual client                 |                             |
++--------------------+--------------------+-----------------------------------+-----------------------------+
+| DesktopShortcut    | Yes                | Adds a shortcut to the desktop    | ``NO_DESKTOP_SHORTCUT``     |
++--------------------+--------------------+-----------------------------------+-----------------------------+
+| StartMenuShortcuts | Yes                | Adds a shortcut to the start menu | ``NO_START_MENU_SHORTCUTS`` |
++--------------------+--------------------+-----------------------------------+-----------------------------+
+| ShellExtensions    | Yes                | Adds Explorer integration         | ``NO_SHELL_EXTENSIONS``     |
++--------------------+--------------------+-----------------------------------+-----------------------------+
+
+Installation
+^^^^^^^^^^^^
+
+You can also choose to only install the client itself by using the following command::
+
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT=Client
+
+For example, if you want to install everything except the ``DesktopShortcut`` and the
+``ShellExtensions`` feature, you have two possibilities:
+
+1. Explicitly name all the features you actually want to install (whitelist)
+   where ``Client`` is always installed anyway::
+
+    msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT=StartMenuShortcuts
+
+2. Pass the ``NO_DESKTOP_SHORTCUT`` and ``NO_SHELL_EXTENSIONS`` properties::
+
+    msiexec /passive /i Nextcloud-x.y.z-x64.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
+
+.. note::
+   The Nextcloud ``.msi`` remembers these properties, so you don't need to specify
+   them on upgrades.
+
+.. note::
+   You cannot use these to change the installed features. If you want to do that,
+   see the next section.
+
+Changing Installed Features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can change the installed features later by using ``REMOVE`` and ``ADDDEFAULT``
+properties.
+
+1. To add the desktop shortcut later, run the following command::
+
+    msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT="DesktopShortcut"
+
+2. To remove it, simply run the following command::
+
+    msiexec /passive /i Nextcloud-x.y.z-x64.msi REMOVE="DesktopShortcut"
+
+Windows keeps track of the installed features, and ``REMOVE`` or ``ADDDEFAULT``
+will affect only the specified features.
+
+Compare `REMOVE <https://msdn.microsoft.com/en-us/library/windows/desktop/aa371194(v=vs.85).aspx>`_
+and `ADDDEFAULT <https://msdn.microsoft.com/en-us/library/windows/desktop/aa367518(v=vs.85).aspx>`_
+on the Windows Installer Guide.
+
+.. note::
+   You cannot specify ``REMOVE`` on initial installation as it will disable all features.
+
+Installation Folder
+^^^^^^^^^^^^^^^^^^^
+
+You can adjust the installation folder by specifying the ``INSTALLDIR``
+property like this::
+
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi INSTALLDIR="C:\Program Files\Non Standard Nextcloud Client Folder"
+
+Be careful when using PowerShell instead of ``cmd.exe``, it can be tricky to get
+the whitespace escaping right there.
+
+Specifying ``INSTALLDIR`` like this only works on first installation; you cannot
+simply re-run the ``.msi`` with a different path. If you still need to change
+it, uninstall the client first and then reinstall it to the new location.
+
+Disabling Automatic Updates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To disable automatic updates, pass the ``SKIPAUTOUPDATE`` property::
+
+    msiexec /passive /i Nextcloud-x.y.z-x64.msi SKIPAUTOUPDATE="1"
+
+Launch After Installation
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To launch the client automatically after installation, pass the ``LAUNCH``
+property::
+
+    msiexec /i Nextcloud-x.y.z-x64.msi LAUNCH="1"
+
+This option also removes the checkbox that lets users decide whether to launch
+the client during non-passive or non-quiet installations.
+
+.. note::
+   This option does not have any effect without a GUI.
+
+No Reboot After Installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The client schedules a reboot after installation to make sure the Explorer
+extension is correctly (un)loaded. If you're taking care of the reboot
+yourself, you can set the ``REBOOT`` property::
+
+    msiexec /i Nextcloud-x.y.z-x64.msi REBOOT=ReallySuppress
+
+This will make ``msiexec`` exit with error ``ERROR_SUCCESS_REBOOT_REQUIRED``
+(3010). If your deployment tooling interprets this as an actual error and you
+want to avoid that, you may want to set the ``DO_NOT_SCHEDULE_REBOOT`` instead::
+
+    msiexec /i Nextcloud-x.y.z-x64.msi DO_NOT_SCHEDULE_REBOOT="1"
 
 .. Links
 
 .. _Nextcloud download page: https://nextcloud.com/download/#install-clients
+
+.. _Nextcloud Server release schedule: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
+


### PR DESCRIPTION
### ☑️ Resolves

This PR refreshes the desktop client user docs with a clearer structure and more consistent wording.

The main focus is the installation guide, which has been reorganized so that the common user path comes first and advanced Windows deployment details appear later in the chapter. I also cleaned up the desktop client index page to make the section landing page shorter, clearer, and more consistent with the updated installation docs.

## What changed

### `user_manual/desktop/installation.rst`:

- split the opening section into clearer subsections to make the page easier to scan
- moved advanced Windows MSI/deployment details to the end of the chapter
- added cross-references so the advanced Windows section remains easy to find
- renamed the setup-focused section to **Initial Setup**
- updated the Linux installation wording to reflect the current AppImage-based
  official distribution model
- clarified the supported server versions wording
- improved wording, flow, and readability throughout
- cleaned up some reStructuredText formatting and indentation

### `user_manual/desktop/index.rst`:

- simplified the intro text
- removed repetitive wording
- aligned terminology with the rest of the desktop client docs

## Why

The previous installation page mixed together:

- general download information
- platform-specific installation notes
- initial setup steps
- advanced Windows deployment details

That made the chapter harder to scan, especially for regular users who just want to install the client and complete the first-time setup.

This revision tries to make the structure more intuitive:

- general information first
- platform-specific install notes next
- initial setup flow after installation
- advanced Windows deployment options last

## Notes for reviewers

- I tried to keep the actual content intact where possible and focus mainly on structure, wording, and discoverability. Content changes were to address actual errors or clearly outdated information (i.e. Linux download/installation guidance).
- The Windows deployment section is still linked from earlier in the chapter so admin/enterprise readers can find it quickly.

### 🖼️ Screenshots

<img width="1132" height="8554" alt="image" src="https://github.com/user-attachments/assets/5aa1eeb9-022e-46d3-91e0-47e2fad854c8" />

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
