### PR TITLE
Strengthen smb backend's PHP smbclient recommendation (#9428)

### DIFF
--- a/admin_manual/configuration_files/external_storage/smb.rst
+++ b/admin_manual/configuration_files/external_storage/smb.rst
@@ -6,9 +6,14 @@ Nextcloud can connect to Windows file servers or other SMB-compatible servers
 with the SMB/CIFS backend.
 
 .. note:: The SMB/CIFS backend requires ``smbclient`` or
-   the PHP smbclient module to be installed on the Nextcloud server. The PHP
-   smbclient module is preferred, but either will work. These
-   should be included in any Linux distribution. (See `PECL smbclient
+   the PHP smbclient module (``php-smbclient`` / ``libsmbclient-php``) to be
+   installed on the Nextcloud server. The PHP smbclient module is **strongly
+   preferred** — without it, the backend falls back to spawning the
+   ``smbclient`` binary, which has known limitations (notably, downloads of
+   files larger than ~512 MB from external SMB shares can fail; see
+   `nextcloud/server#31308
+   <https://github.com/nextcloud/server/issues/31308>`_). These should be
+   included in any Linux distribution. (See `PECL smbclient
    <https://pecl.php.net/package/smbclient>`_ if your distro does not include
    them.)
 


### PR DESCRIPTION
Closes #9428.

The current SMB/CIFS prerequisite note says "PHP smbclient module is preferred, but either will work." The linked upstream report (nextcloud/server#31308) is admins repeatedly running into a 512 MB download cliff on external SMB shares because they did not install the PHP module — \`smbclient\` alone does not handle that path well. The note as written underplays that.

This PR makes three small improvements to that one note in \`admin_manual/configuration_files/external_storage/smb.rst\`:

1. **Names the actual package** (\`php-smbclient\` / \`libsmbclient-php\`) — current text says "the PHP smbclient module" without the install name, so admins have to guess what to apt/yum install.
2. **Explains _why_ the PHP module is preferred.** Strengthens "preferred" to "strongly preferred" and notes the concrete failure mode (downloads of files larger than ~512 MB can fail).
3. **Links the upstream issue** so an admin who lands on nextcloud/server#31308 from a search engine can find this advice.

Leaves the second "improved reliability and performance" note further down the page alone — it sits in the configuration-options section and reads fine in that context.