### PR TITLE
(occ command) Adds apc.enable_cli instructions

### DIFF
--- a/admin_manual/occ_command.rst
+++ b/admin_manual/occ_command.rst
@@ -29,15 +29,16 @@ The HTTP user is different on the various Linux distributions:
 * The HTTP user and group in Arch Linux is http.
 * The HTTP user in openSUSE is wwwrun, and the HTTP group is www.
 
-.. note:: 
-  Since APCu is disabled by default for the command-line mode of PHP, it can cause issues with Nextcloud's ``occ`` command. Please make sure you set the ``apc.enable_cli`` parameter to ``1`` in your PHP CLI's ``php.ini`` configuration file or append ``--define apc.enable_cli=1`` each time you invoke ``occ`` - e.g.::
+.. note::
 
-    sudo -u www-data php --define apc.enable_cli=1 occ config:list system
+   APCu is disabled by default for the command-line mode of PHP, which can cause issues with Nextcloud's ``occ`` command. Please make sure you set the ``apc.enable_cli`` parameter to ``1`` in your PHP CLI's ``php.ini`` configuration file or append ``--define apc.enable_cli=1`` each time you invoke ``occ`` - e.g.::
 
-  If you fail to do this, you will receive output such as the following:: 
+     sudo -u www-data php --define apc.enable_cli=1 occ config:list system
 
-    An unhandled exception has been thrown:
-    OCP\\HintException: [0]: Memcache \\OC\\Memcache\\APCu not available for local cache (Is the matching PHP module installed and enabled?)
+   If you fail to do this, you will receive output such as the following::
+
+     An unhandled exception has been thrown:
+     OCP\HintException: [0]: Memcache \OC\Memcache\APCu not available for local cache (Is the matching PHP module installed and enabled?)
 
 If your HTTP server is configured to use a different PHP version than the
 default (/usr/bin/php), ``occ`` should be run with the same version. For

--- a/admin_manual/occ_command.rst
+++ b/admin_manual/occ_command.rst
@@ -29,6 +29,16 @@ The HTTP user is different on the various Linux distributions:
 * The HTTP user and group in Arch Linux is http.
 * The HTTP user in openSUSE is wwwrun, and the HTTP group is www.
 
+.. note:: 
+  Since APCu is disabled by default for the command-line mode of PHP, it can cause issues with Nextcloud's ``occ`` command. Please make sure you set the ``apc.enable_cli`` parameter to ``1`` in your PHP CLI's ``php.ini`` configuration file or append ``--define apc.enable_cli=1`` each time you invoke ``occ`` - e.g.::
+
+    sudo -u www-data php --define apc.enable_cli=1 occ config:list system
+
+  If you fail to do this, you will receive output such as the following:: 
+
+    An unhandled exception has been thrown:
+    OCP\\HintException: [0]: Memcache \\OC\\Memcache\\APCu not available for local cache (Is the matching PHP module installed and enabled?)
+
 If your HTTP server is configured to use a different PHP version than the
 default (/usr/bin/php), ``occ`` should be run with the same version. For
 example, in CentOS 6.5 with SCL-PHP70 installed, the command looks like this::


### PR DESCRIPTION
The proper setup of `apc.enable_cli` is mentioned elsewhere in the manual (for cron and the updater), but not mentioned in the occ command section. Since this triggers an exception, let's help people solve the problem themselves.

### Resolves
* Fix for recurring issue in various repos and Help Forums

This documentation helps users understand why they get APCu memcache errors when running occ commands and how to resolve them.

Revives #10670 originally by @joshtrichards