### PR TITLE
feat(devmanual): draft critical changes for apps in 34

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_34.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_34.rst
@@ -8,11 +8,23 @@ Upgrade to Nextcloud 34
     Add one section for each change.
     Only list changes absolutely necessary to keep an app running. Use the dedicated deprecation and new features pages for optional changes and announcements.
 
-Front-end changes
------------------
+    The sections are somewhat ordered so changes affecting most apps come first, and more specific ones come later.
 
-Removed APIs
-^^^^^^^^^^^^
+info.xml requirements
+---------------------
+
+Update info.xml to add Nextcloud 34 to the support range:
+
+.. code-block:: xml
+
+  <dependencies>
+    <nextcloud min-version="33" max-version="33" />
+  </dependencies>
+
+To allow installation on older versions too, just keep the previous min-version.
+
+Removed front-end APIs and libraries
+------------------------------------
 
 - ``OC.Dialogs.fileexists`` was deprecated and is now removed.
   Use the conflict picker from the ``@nextcloud/dialogs`` library instead.
@@ -35,11 +47,48 @@ Removed APIs
   - ``OC.Files.Client`` as it was extending the ``Backbone``.
 
 
-Back-end changes
-----------------
-
-Removed APIs
-^^^^^^^^^^^^
+Removed back-end APIs
+---------------------
 
 - ``\OCP\Share_Backend``, ``\OCP\Share_Backend_Collection``, ``\OCP\Share_Backend_File_Dependent`` were removed. This old
   share backend was replaced in Nextcloud 9 with a new backend system based on ``IShareProvider``.
+
+
+Unified sharing
+---------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+Changes to sharing APIs and user interface are planned. This includes both a new general API for sharing of entities and updates to the sharing user interface. See `nextcloud/server#51803 <https://github.com/nextcloud/server/issues/51803>`_ for details and mockups.
+
+
+Navigation styling revisions
+----------------------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+Styling of navigation components will be revised. See `nextcloud-libraries/nextcloud-vue#7222 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7222>`_ for details.
+
+
+Sidebar tabs redesign
+---------------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+Sidebar tab components will be redesigned. See `nextcloud-libraries/nextcloud-vue#7520 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7520>`_ for details.
+
+
+Settings title left-alignment
+-----------------------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+The title alignment of settings pages will be changed to left-aligned. See `nextcloud-libraries/nextcloud-vue#7641 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7641>`_ for details.


### PR DESCRIPTION
### ☑️ Resolves

* Adds a section for the version ranges that need to be touched by every app
* Adds draft sections for the upcoming changes communicated by @AndyScherzinger

### 🖼️ Screenshots

<img width="1216" height="2301" alt="Screenshot 2026-04-24 at 10-15-34 Upgrade to Nextcloud 34 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/5a28836b-81d2-4c6a-bb30-6a352deabd5b" />

