### PR TITLE
feat(devmanual): clean up the new release notes

### DIFF
--- a/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
+++ b/developer_manual/app_publishing_maintenance/app_upgrade_guide/index.rst
@@ -6,12 +6,15 @@ App upgrade guide
 
 Once you've created and published the first version of your app, you will want to keep it up to date with the latest Nextcloud features.
 
+.. note::
+
+   For the latest release notes, see the :doc:`Release Notes </release_notes/index>`.
+
 These sub pages will cover the most important changes in Nextcloud, as well as some guides on how to upgrade existing apps.
 
 .. toctree::
    :maxdepth: 1
 
-   upgrade_to_34.rst
    upgrade_to_33.rst
    upgrade_to_32.rst
    upgrade_to_31.rst

--- a/developer_manual/conf.py
+++ b/developer_manual/conf.py
@@ -177,4 +177,6 @@ redirects = {
     "digging_deeper/changelog": "../app_publishing_maintenance/app_upgrade_guide/index.html",
     # Removed 2025-04
     "basics/front-end/l10n": "../translations.html",
+    # Moved 2026-04 - Upgrade to 34 moved to release notes
+    "app_publishing_maintenance/app_upgrade_guide/upgrade_to_34": "../../release_notes/critical_changes.html",
 }

--- a/developer_manual/release_notes/critical_changes.rst
+++ b/developer_manual/release_notes/critical_changes.rst
@@ -1,8 +1,8 @@
-.. _upgrade_to_34:
+.. _critical-changes:
 
-=======================
-Upgrade to Nextcloud 34
-=======================
+================
+Critical changes
+================
 
 ..
     Add one section for each change.
@@ -18,7 +18,7 @@ Update info.xml to add Nextcloud 34 to the support range:
 .. code-block:: xml
 
   <dependencies>
-    <nextcloud min-version="33" max-version="33" />
+    <nextcloud min-version="34" max-version="34" />
   </dependencies>
 
 To allow installation on older versions too, just keep the previous min-version.

--- a/developer_manual/release_notes/deprecations.rst
+++ b/developer_manual/release_notes/deprecations.rst
@@ -4,15 +4,28 @@
 Deprecations
 ============
 
-In order to improve our platform we are phasing out some APIs. Deprecated APIs are not removed before ???,
-unless the breakage can not be avoided.
+In order to improve our platform we are phasing out some APIs. Deprecated APIs are kept for at least
+three years before removal, unless the breakage can not be avoided.
 
 We highly recommend using the `Nextcloud Rector <https://packagist.org/packages/nextcloud/rector>`_
 rules, which can fix some API changes automatically.
+
+New deprecations
+----------------
 
 ..
     Add one section for each group of deprecations (e.g. group files api changes, authentication changes).
     Also deprecate the feature at their dedicated documentation page.
     After branch-off the contents below will be cleared.
 
+.. todo:: This page needs a section for every new deprecation.
 
+Older deprecations
+------------------
+
+You find all current deprecations in this section.
+
+..
+    This is where we will move the deprecations after the branch off. Enties will stay until actual removal.
+
+Also see the older :ref:`app-upgrade-guide` for deprecations.

--- a/developer_manual/release_notes/index.rst
+++ b/developer_manual/release_notes/index.rst
@@ -2,13 +2,18 @@
 Release notes
 =============
 
-This section is for developers and maintainers who are familiar with an earlier version of the documentation.
+Welcome to the release notes. This section is for developers and app maintainers upgrading from earlier versions.
 
-Here we try to summarize what's new. You will find the breaking changes at :ref:`upgrade_to_34`, new deprecations at :ref:`deprecated-apis` and new API features at :ref:`new-apis`.
+On this page you will find:
+
+- :ref:`critical-changes` - Critical changes that must be addressed for app compatibility
+- :ref:`new-apis` - New developer APIs and features
+- :ref:`deprecated-apis` - Deprecated APIs and their removal timeline
 
 .. toctree::
    :maxdepth: 3
+   :hidden:
 
+   critical_changes
    new
    deprecations
-   ../app_publishing_maintenance/app_upgrade_guide/upgrade_to_34


### PR DESCRIPTION
### ☑️ Resolves

Follow-up to https://github.com/nextcloud/documentation/pull/14183 and https://github.com/nextcloud/documentation/pull/14565

This brings the *Release notes* into the final structure I had in mind with https://github.com/nextcloud/documentation/pull/14180

* There is one very prominent entrypoint for changes in this release
* There is one dedicated page for *critical changes*. 
  * These *have to be addressed*. It's cleared after branch-off because afterwards it is no longer relevant.
* There is one dedicated page for *new APIS*.
  * These are nice-to-have for devs, nothing terrible happens if that page is not read.
  * The APIs will have their main documentation on a persistent page. This is just an overview here.
  * It's cleared after branch-off because afterwards it is no longer relevant.
* There is one collecting page for *deprecations*.
  * These are nice-to-have for devs, nothing terrible happens if that page is not read.
  * They stay there as long as they are relevant, so until they are removed.

The old upgrade guides stay for now and will phase out. Maybe we hand-pick the deprecations and move them to the new file. I'm too lazy for that right now.
There is a redirect rule to send anyone from the 34 page to the new pages.

### 🖼️ Screenshots

| Entry point | Critical | New | Deprecated | Legacy |
|--------|--------|--------|--------|--------|
| <img width="1216" height="966" alt="Screenshot 2026-04-24 at 13-47-10 Release notes — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/2caea52d-7478-4a4b-92da-b670c5820e28" /> | <img width="1216" height="2301" alt="Screenshot 2026-04-24 at 13-47-19 Critical changes — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/c5d2bba3-4ea8-4032-9a30-229152b578df" /> | <img width="1216" height="966" alt="Screenshot 2026-04-24 at 13-47-29 New in this release — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/6517b04b-ae5b-4355-89d7-8920a571e4a6" /> | <img width="1216" height="966" alt="Screenshot 2026-04-24 at 13-47-36 Deprecations — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/66308e4b-9741-4679-b3c5-24b5a6b78806" /> | <img width="1216" height="1096" alt="Screenshot 2026-04-24 at 13-47-53 App upgrade guide — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/4b9ce788-7d37-435a-b67c-a743e6b927f1" /> | 






