### PR TITLE
fix: remove `TODO ON RELEASE` leftovers

### DIFF
--- a/admin_manual/webhook_listeners/index.rst
+++ b/admin_manual/webhook_listeners/index.rst
@@ -42,8 +42,6 @@ Listening to events
 You can use the OCS API to add webhooks for specific events. See:
 `Register a new webhook <https://docs.nextcloud.com/server/latest/developer_manual/_static/openapi.html#/operations/webhook_listeners-webhooks-index>`_.
 
-.. TODO ON RELEASE: Update version number above upon release.
-
 Note: When authenticating with the OCS API to register webhooks, the account you
 use must have administrator rights or delegated administrator rights.
 

--- a/user_manual/groupware/sync_gnome.rst
+++ b/user_manual/groupware/sync_gnome.rst
@@ -17,8 +17,6 @@ This can be done by following these steps:
    `doesn't support Nextcloud's WebFlow login yet <https://gitlab.gnome.org/GNOME/gnome-online-accounts/issues/81>`_
    (:ref:`Learn more <managing_devices>`):
 
-   .. TODO ON RELEASE: Update version number above on release
-
    .. image:: ../images/goa-add-nextcloud-account.png
 
 #. In the next window, select which resources GNOME should access and


### PR DESCRIPTION
Since we have an automated replacement in place, we don't need those warning anymore