### PR TITLE
docs(dev): expand occ command coverage in developer manual

### DIFF
--- a/developer_manual/basics/routing.rst
+++ b/developer_manual/basics/routing.rst
@@ -238,3 +238,40 @@ If you use a CamelCase name as *myCamelCaseApp*,
 
     <?php
     $route = 'myCamelCaseApp.author_api.do_something';
+
+
+Console commands
+----------------
+
+Two ``occ`` commands help inspect and debug the routing table::
+
+ router
+  router:list   list routes, optionally filtered by app
+  router:match  match a URL path to a route
+
+router\:list
+^^^^^^^^^^^^^
+
+List all registered routes. Optionally filter to one or more apps::
+
+ sudo -E -u www-data php occ router:list
+ sudo -E -u www-data php occ router:list myapp
+
+Use ``--ocs`` to show only OCS API routes, or ``--index`` to show only
+``index.php`` routes::
+
+ sudo -E -u www-data php occ router:list --ocs
+ sudo -E -u www-data php occ router:list myapp --index
+
+router\:match
+^^^^^^^^^^^^^^
+
+Match a URL path against the routing table and show which route and controller
+it resolves to. Useful for debugging why a request is landing in the wrong
+place::
+
+ sudo -E -u www-data php occ router:match /apps/myapp/authors/3
+
+Use ``--method`` to match against a specific HTTP verb (default: ``GET``)::
+
+ sudo -E -u www-data php occ router:match /apps/myapp/authors/3 --method=POST

--- a/developer_manual/basics/storage/migrations.rst
+++ b/developer_manual/basics/storage/migrations.rst
@@ -151,28 +151,73 @@ List of available Migration Attributes:
 Console commands
 ----------------
 
-There are some console commands, which should help developers to create or deal
-with migrations, which are only available if you are running your
-Nextcloud **in debug mode**:
+The following ``occ`` commands help you create and manage migrations::
 
-* `migrations:execute`: Executes a single migration version manually.
-  The version argument is the class name of the migration, without the
-  "Version" prefix. For example if your migration was named
-  `Version2404Date20220903071748` the version would be `2404Date20220903071748`.
-* `migrations:generate`:
-  This is needed to create a new migration file. This takes 2 arguments,
-  first one is the `appid`, the second one should be the `version`of your
-  app as an integer. We recommend to use the major and minor digits of your apps
-  version for that. This allows you to introduce a new migration in your branch
-  for a Nextcloud version if there is already a migration path for a newer one
-  in another branch. Since you can’t change this retroactive, we recommend to
-  leave enough space in between and therefore map the numbers to 3 digits:
-  `1.0.x => 1000`, `2.34.x => 2034`, etc.
-* `migrations:migrate`: Execute a migration to a specified or the latest available version.
-* `migrations:status`: View the status of a set of migrations.
+ migrations
+  migrations:execute  execute a single migration version manually
+  migrations:generate generate a new migration file for an app
+  migrations:migrate  execute migrations to a specified or the latest version
+  migrations:preview  preview available DB migrations before an upgrade
+  migrations:status   view the status of migrations for an app
 
-.. note:: After generating a migration, you might need to run `composer dump-autoload`
-   to be able to execute it.
+migrations\:execute
+^^^^^^^^^^^^^^^^^^^^
+
+Execute a single migration version manually. The ``version`` argument is the
+migration class name without the ``Version`` prefix — for example, if your
+migration is named ``Version2404Date20220903071748``, the version is
+``2404Date20220903071748``::
+
+ sudo -E -u www-data php occ migrations:execute myapp 2404Date20220903071748
+
+.. note::
+
+   Without debug mode enabled, ``migrations:execute`` will refuse to run a
+   version that has already been executed or that would roll back a previous
+   migration. Enable debug mode (``’debug’ => true`` in ``config.php``) to
+   override this restriction during development.
+
+migrations\:generate
+^^^^^^^^^^^^^^^^^^^^^
+
+Generate a new migration file for an app. The ``version`` argument is the
+major version of your app as an integer. Use the major and minor digits of
+your app version, mapped to 3 digits (``1.0.x => 1000``, ``2.34.x => 2034``),
+to leave room for parallel branch migrations::
+
+ sudo -E -u www-data php occ migrations:generate myapp 1000
+
+The generated file is placed in ``apps/myapp/lib/Migration/``.
+
+.. note::
+
+   After generating a migration you may need to run ``composer dump-autoload``
+   before it can be executed.
+
+migrations\:migrate
+^^^^^^^^^^^^^^^^^^^^
+
+Execute all pending migrations for an app, or migrate to a specific version.
+Accepts a version number (``YYYYMMDDHHMMSS``) or an alias (``first``,
+``prev``, ``next``, ``latest``)::
+
+ sudo -E -u www-data php occ migrations:migrate myapp
+ sudo -E -u www-data php occ migrations:migrate myapp prev
+
+migrations\:preview
+^^^^^^^^^^^^^^^^^^^^
+
+Preview the DB migrations that would be applied during an upgrade to a given
+version, without executing them::
+
+ sudo -E -u www-data php occ migrations:preview 30.0.0
+
+migrations\:status
+^^^^^^^^^^^^^^^^^^^
+
+Show which migrations have been executed and which are pending for an app::
+
+ sudo -E -u www-data php occ migrations:status myapp
 
 Adding indices
 --------------

--- a/developer_manual/basics/translations.rst
+++ b/developer_manual/basics/translations.rst
@@ -349,3 +349,25 @@ Testing translations
 --------------------
 
 You can use the query parameter ``forceLanguage`` to force a specific language for a web request (API or frontend). See :ref:`Forcing language for a given call<api-force-language>`.
+
+Console commands
+----------------
+
+l10n\:createjs
+^^^^^^^^^^^^^^
+
+Generate JavaScript translation files for an app from its ``l10n/`` source
+files. Pass the app ID and optionally a specific language code::
+
+ sudo -E -u www-data php occ l10n:createjs myapp
+ sudo -E -u www-data php occ l10n:createjs myapp de
+
+When no language is specified, JavaScript files are generated for all
+available languages. The output files are written to the app's ``l10n/``
+directory as ``<lang>.js`` and ``<lang>.json``.
+
+.. note::
+
+   This command is intended for development and CI pipelines. In production,
+   JavaScript translation files are generated automatically during app
+   installation and updates.

--- a/developer_manual/digging_deeper/snowflake_ids.rst
+++ b/developer_manual/digging_deeper/snowflake_ids.rst
@@ -73,9 +73,22 @@ To generate a new ID, call ``nextId`` function on the generator:
 Decode a Snowflake ID
 ---------------------
 
-IDs can be decoded with ``occ snowflake:decode <id>`` command.
+Use the ``occ snowflake:decode`` command to inspect a Snowflake ID from the
+command line::
 
-It’s also possible to decode IDs in your code, for example to get creation time of your object:
+ sudo -E -u www-data php occ snowflake:decode 6768789079123765868
+ +--------------------+-------------------------+
+ | Snowflake ID       | 6768789079123765868     |
+ | Seconds            | 1575981518              |
+ | Milliseconds       | 50                      |
+ | Created from CLI   | no                      |
+ | Server ID          | 441                     |
+ | Sequence ID        | 12                      |
+ | Creation timestamp | 1575981518.050          |
+ | Creation date      | 2019-12-10 13:38:38.050 |
+ +--------------------+-------------------------+
+
+It’s also possible to decode IDs in your code, for example to get the creation time of your object:
 
 
 .. code-block:: php


### PR DESCRIPTION
**basics/storage/migrations.rst:**
Rewrote the Console commands section. Replaced inaccurate bullet list with per-command subheadings and actual occ syntax for all five commands: migrations:execute, migrations:generate, migrations:migrate, migrations:preview (was undocumented), migrations:status. Corrected the claim that all commands require debug mode — only migrations:execute restricts rolling back without it.

**basics/routing.rst:**
Added Console commands section documenting router:list (with --ocs and --index filters) and router:match (with --method option).

**basics/translations.rst:**
Added Console commands section documenting l10n:createjs, including the optional language argument and output location.

**digging_deeper/snowflake_ids.rst:**
Expanded the one-line occ mention into a proper example with full command output.

AI-Assisted-By: claude-sonnet-4-6 <noreply@anthropic.com>

### 🖼️ Screenshots
<img width="1920" height="2319" alt="screencapture-file-home-anna-Documents-documentation-developer-manual-build-html-com-digging-deeper-snowflake-ids-html-2026-04-25-16_02_48" src="https://github.com/user-attachments/assets/84c5da37-79e8-4a4e-ad14-694ced500525" />
<img width="939" height="584" alt="Screenshot from 2026-04-25 16-02-18" src="https://github.com/user-attachments/assets/215f7bbd-57cf-463e-b88c-6c3aeb9aeb25" />
<img width="951" height="907" alt="Screenshot from 2026-04-25 16-01-48" src="https://github.com/user-attachments/assets/c6c22e5c-1abf-4da9-8afc-a17a855d764e" />
<img width="951" height="907" alt="Screenshot from 2026-04-25 16-01-23" src="https://github.com/user-attachments/assets/89a319a9-8637-4495-ad81-0f30c2a0e173" />
<img width="960" height="612" alt="Screenshot from 2026-04-25 16-01-11" src="https://github.com/user-attachments/assets/807046ea-f911-405e-b1f0-ac22a1afb0fd" />


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
