### PR TITLE
fix(adminmanual): correct critical errors

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -219,7 +219,7 @@ Here is a reference table for common occ commands:
    * - occ encryption:enable-master-key
      - Enable master key mode
    * - occ encryption:disable-master-key
-     - Enable user key mode
+     - Disable master key mode
    * - occ encryption:fix-encrypted-version
      - Fix bad signature errors
    * - occ encryption:fix-key-location [user]

--- a/admin_manual/configuration_server/dashboard_configuration.rst
+++ b/admin_manual/configuration_server/dashboard_configuration.rst
@@ -11,7 +11,7 @@ The Dashboard App is shipped and enabled by default. If it is not enabled
 simply go to your Nextcloud Apps page to enable it.
 
 Configuring your Nextcloud for the dashboard app
------------------------------------------------
+-------------------------------------------------
 
 The dashboard widgets are provided by apps and have a unique identifier. This can be used to customize the default layout of the dashboard as an administrator. The layout is stored as a comma-separated list of widget identifiers.
 

--- a/admin_manual/configuration_server/dashboard_configuration.rst
+++ b/admin_manual/configuration_server/dashboard_configuration.rst
@@ -10,7 +10,7 @@ Enabling the dashboard app
 The Dashboard App is shipped and enabled by default. If it is not enabled
 simply go to your Nextcloud Apps page to enable it.
 
-Configuring your Nextcloud for the activity app
+Configuring your Nextcloud for the dashboard app
 -----------------------------------------------
 
 The dashboard widgets are provided by apps and have a unique identifier. This can be used to customize the default layout of the dashboard as an administrator. The layout is stored as a comma-separated list of widget identifiers.

--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -52,7 +52,7 @@ connect Nextcloud to a remote SMTP server:
 
 .. warning:: There were changes to the 3rd party mailer library in Nextcloud 26:
     
-    * STARTTLS cannot be enforced. It will be used automatically if the mail server supports it. The encryption type should be set to 'None/STARTTLS' in this case. See :ref:`here<TLSPeerVerification>` for an example on how to configure self signed certificates.
+    * STARTTLS cannot be enforced; it is used automatically if the mail server supports it. Set the encryption type to **None/STARTTLS** to allow this automatic upgrade. See :ref:`here<TLSPeerVerification>` for an example on how to configure self-signed certificates.
     * NTLM authentication for Microsoft Exchange is not supported by the new mailer library. Try using `basic authentication <https://learn.microsoft.com/en-us/exchange/client-developer/exchange-web-services/authentication-and-ews-in-exchange#basic-authentication>`_ instead.
     * Outlook and Microsoft Exchange have discontinued support for Basic authentication. It is no longer possible to use their services as your default email handler.
 

--- a/admin_manual/configuration_user/user_provisioning_api.rst
+++ b/admin_manual/configuration_user/user_provisioning_api.rst
@@ -11,7 +11,7 @@ info, and to enable or disable an app remotely. HTTP
 requests can be used via a Basic Auth header to perform any of the functions 
 listed above. The Provisioning API app is enabled by default.
 
-The base URL for all calls to the share API is ``https://cloud.example.com/ocs/v1.php/cloud``.
+The base URL for all calls to the Provisioning API is ``https://cloud.example.com/ocs/v1.php/cloud``.
 
 All calls to OCS endpoints require the ``OCS-APIRequest`` header to be set to ``true``.
 

--- a/admin_manual/desktop/troubleshooting.rst
+++ b/admin_manual/desktop/troubleshooting.rst
@@ -278,11 +278,8 @@ you set it to a verbose level like ``Debug`` or ``Info``.
 You can view the server log file using the web interface or you can open it
 directly from the file system in the Nextcloud server data directory.
 
-.. todo:: Need more information on this.  How is the log file accessed?
-   Need to explore procedural steps in access and in saving this file ... similar
-   to how the log file is managed for the client.  Perhaps it is detailed in the
-   Admin Guide and a link should be provided from here.  I will look into that
-   when I begin heavily editing the Admin Guide.
+See :doc:`/configuration_server/logging_configuration` in the admin manual for
+details on configuring log levels and log file locations.
 
 Webserver Log Files
 ~~~~~~~~~~~~~~~~~~~

--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -2,6 +2,12 @@
 
 Example installation on CentOS 8
 ================================
+
+.. warning::
+   CentOS 8 reached end-of-life on December 31, 2021 and no longer receives
+   security updates. This guide is preserved for reference only. For current
+   RHEL-based deployments, use CentOS Stream, AlmaLinux, or Rocky Linux instead.
+
 In this install tutorial we will be deploying CentOS 8, PHP 7.4, MariaDB, Redis as memcache and Nextcloud running on Apache.
 
 Start off by installing a CentOS 8 minimal install. This should provide a sufficient platform to run a successful Nextcloud instance.

--- a/admin_manual/installation/example_centos.rst
+++ b/admin_manual/installation/example_centos.rst
@@ -5,8 +5,9 @@ Example installation on CentOS 8
 
 .. warning::
    CentOS 8 reached end-of-life on December 31, 2021 and no longer receives
-   security updates. This guide is preserved for reference only. For current
-   RHEL-based deployments, use CentOS Stream, AlmaLinux, or Rocky Linux instead.
+   security updates. This guide is preserved for reference only and may be
+   outdated. For production deployments, use a currently supported Linux
+   distribution.
 
 In this install tutorial we will be deploying CentOS 8, PHP 7.4, MariaDB, Redis as memcache and Nextcloud running on Apache.
 

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -19,7 +19,7 @@ If you prefer an automated installation, you have the option to:
 In case you prefer installing from the source tarball, you can setup Nextcloud
 from scratch using a classic LAMP stack (Linux, Apache, MySQL/MariaDB, PHP).
 This document provides a complete walk-through for installing Nextcloud on
-Ubuntu 18.04 LTS Server with Apache and MariaDB, using `the Nextcloud .tar
+Ubuntu 24.04 LTS Server with Apache and MariaDB, using `the Nextcloud .tar
 archive <https://nextcloud.com/install/>`_. This method is recommended to install Nextcloud.
 
 This installation guide is giving a general overview of required dependencies and their configuration. For a distribution specific setup guide have a look at the :doc:`./example_ubuntu` and :doc:`./example_centos`.

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -48,7 +48,7 @@ To ensure the full functionality of your Nextcloud, please make sure that the se
 
 CPU Architecture and OS
 ^^^^^^^^^^^^^^^^^^^^^^^
-A 64-bit CPU, OS and PHP is required for Nextcloud to run well.
+A 64-bit CPU, OS and PHP is strongly recommended for Nextcloud.
 
 32-bit systems are supported, with the following known limitations:
 


### PR DESCRIPTION
### Summary

 - encryption_configuration.rst — encryption:disable-master-key was described  
  as "Enable user key mode" — the inverse of what the command does. An admin
  consulting this table could run the wrong command.                            
  - system_requirements.rst — Said 64-bit "is required" then immediately stated
  32-bit is supported. Changed to "strongly recommended".                       
  - dashboard_configuration.rst — Section heading said "Configuring your
  Nextcloud for the activity app" on the dashboard page (copy-paste error).     
  - email_configuration.rst — STARTTLS note was contradictory: said it "cannot
  be enforced" then told admins to "set" it. Reworded to clarify it upgrades    
  automatically when the server supports it.                
  - user_provisioning_api.rst — Base URL description said "share API" instead of
   "Provisioning API".                                                          
  - source_installation.rst — Walk-through referenced Ubuntu 18.04 (EOL
  April 2023). Updated to 24.04.                                                
  - example_centos.rst — CentOS 8 guide had no warning despite reaching EOL
  December 2021. Added a warning directing users to a supported distribution.   
  - desktop/troubleshooting.rst — An unresolved .. todo:: comment had been
  published in the output for an unknown length of time. Replaced with a        
  cross-reference to the logging configuration page.  

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
