### PR TITLE
fix(user): remove contradictory sentence from encryption docs

### DIFF
--- a/user_manual/files/encrypting_files.rst
+++ b/user_manual/files/encrypting_files.rst
@@ -129,9 +129,6 @@ structures. These files are never encrypted:
 - The search index from the full text search app.
 - Third-party app data
 
-Only those files that are shared with third-party storage providers can
-be encrypted, the rest of the files may not be encrypted.
-
 Change private key password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
"Only those files shared with third-party storage providers can be encrypted" contradicts the rest of the page, which correctly explains that server-side encryption applies to all files. The "Files not encrypted" list already covers the actual exceptions.

AI-Assisted-By: claude-sonnet-4-6 <noreply@anthropic.com>

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
