### PR TITLE
fix(dev): correct code errors in developer manual examples

### DIFF
--- a/developer_manual/basics/public_share_template.rst
+++ b/developer_manual/basics/public_share_template.rst
@@ -64,19 +64,37 @@ It is possible to override the default public share view. This is possible by im
             ...; // More initial state that you might need in your view.
 
             // OpenGraph Support: http://ogp.me/
-            Util::addHeader('meta', ['property' => "og:title", 'content' => $this->l10n->t("Encrypted share")]);
-            Util::addHeader('meta', ['property' => "og:description", 'content' => $this->defaults->getName() . ($this->defaults->getSlogan() !== '' ? ' - ' . $this->defaults->getSlogan() : '')]);
-            Util::addHeader('meta', ['property' => "og:site_name", 'content' => $this->defaults->getName()]);
-            Util::addHeader('meta', ['property' => "og:url", 'content' => $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $token])]);
-            Util::addHeader('meta', ['property' => "og:type", 'content' => "object"]);
-
-            $csp->addAllowedFrameDomain('\'self\'');
-            $response->setContentSecurityPolicy($csp);
+            Util::addHeader('meta', [
+                'property' => "og:title",
+                'content' => $this->l10n->t("Encrypted share"),
+            ]);
+            Util::addHeader('meta', [
+                'property' => "og:description",
+                'content' => $this->defaults->getName()
+                    . ($this->defaults->getSlogan() !== '' ? ' - ' . $this->defaults->getSlogan() : ''),
+            ]);
+            Util::addHeader('meta', [
+                'property' => "og:site_name",
+                'content' => $this->defaults->getName(),
+            ]);
+            Util::addHeader('meta', [
+                'property' => "og:url",
+                'content' => $this->urlGenerator->linkToRouteAbsolute(
+                    'files_sharing.sharecontroller.showShare',
+                    ['token' => $token]
+                ),
+            ]);
+            Util::addHeader('meta', [
+                'property' => "og:type",
+                'content' => "object",
+            ]);
 
             $response = new PublicTemplateResponse(Application::APP_ID, 'myCustomTemplateFileName', []);
             $response->setHeaderTitle($this->l10n->t("My custom title"));
 
             $csp = new ContentSecurityPolicy();
+            $csp->addAllowedFrameDomain('\'self\'');
+            $response->setContentSecurityPolicy($csp);
 
             return $response;
         }

--- a/developer_manual/basics/storage/database.rst
+++ b/developer_manual/basics/storage/database.rst
@@ -172,7 +172,7 @@ To create a mapper, inherit from the mapper base class and call the parent const
                ->setMaxResults($limit)
                ->setFirstResult($offset);
 
-            return $this->findEntities($sql);
+            return $this->findEntities($qb);
         }
 
 

--- a/developer_manual/digging_deeper/projects.rst
+++ b/developer_manual/digging_deeper/projects.rst
@@ -58,7 +58,7 @@ In order to add your own resource type, we need to create a class implementing t
                 'id' => $resource->getId(),
                 'name' => $item->getTitle(),
                 'link' => $resourceUrl,
-                'iconUrl' => $favicon,
+                'iconUrl' => $icon,
             ];
         }
 

--- a/developer_manual/digging_deeper/users.rst
+++ b/developer_manual/digging_deeper/users.rst
@@ -218,10 +218,10 @@ Nextcloud users can be defined as managers of other users. This is an informatio
             $managers = array_map(function(string $uid) {
                 return $this->userManager->get($uid);
             }, $managerUids));
-            // Remove and managers that no longer exist as user
+            // Remove any managers that no longer exist as users
             $existingManagers = array_filter($managers);
             $user->setManagerUids(array_map(function(IUser $admin) {
-                return $user->getUID();
+                return $admin->getUID();
             }, $existingManagers));
         }
     }


### PR DESCRIPTION
### Summary:

Four code examples contained bugs that would produce broken or incorrect code  if copied:                                                                    
   
  - basics/storage/database.rst — findAll() passed undefined $sql to findEntities(); fixed to $qb                              
  - basics/public_share_template.rst — $csp and $response used before being instantiated; reordered correctly and reformatted long Util::addHeader() calls to remove horizontal scrolling
  - digging_deeper/users.rst — array_map callback iterated over managers as $admin but returned $user->getUID(), mapping every manager to the same UID; fixed to $admin->getUID(); also fixed comment grammar
  - digging_deeper/projects.rst — getResourceRichObject() returned undefined $favicon; fixed to $icon 

### 🖼️ Screenshots
<img width="934" height="844" alt="image" src="https://github.com/user-attachments/assets/75a74eba-9906-4c2a-a248-d452f3da48ac" />

<img width="459" height="94" alt="Screenshot from 2026-04-26 13-13-06" src="https://github.com/user-attachments/assets/428255fd-5752-421c-8113-bfe875962f9e" />

<img width="479" height="203" alt="Screenshot from 2026-04-26 13-08-07" src="https://github.com/user-attachments/assets/e5aa1fa9-1d35-44ae-afbd-85475fc33938" />

<img width="277" height="135" alt="image" src="https://github.com/user-attachments/assets/b9ba549c-704a-4c65-9a46-dda1dd55f8d7" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
