### PR TITLE
fix(dev): fix high-severity prose and code errors in developer manual

### DIFF
--- a/developer_manual/app_development/translation.rst
+++ b/developer_manual/app_development/translation.rst
@@ -53,7 +53,7 @@ empty folder which later holds the translations.
 Branch selection ``.tx/backport``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The bot will run every night and only push commits to the following branches branch once there is an update to the translation:
+The bot will run every night and only push commits to the following branches once there is an update to the translation:
 
 * main
 * master

--- a/developer_manual/basics/backgroundjobs.rst
+++ b/developer_manual/basics/backgroundjobs.rst
@@ -143,7 +143,7 @@ For example you could add or remove a certain job based on some controller:
 
     class SomeController extends Controller {
 
-        private IJobList $jobList
+        private IJobList $jobList;
 
         public function __construct(string $appName, IRequest $request, IJobList $jobList) {
             parent::__construct($appName, $request);

--- a/developer_manual/basics/controllers.rst
+++ b/developer_manual/basics/controllers.rst
@@ -440,7 +440,7 @@ class implementing the ``OCP\\AppFramework\\Http\\Template\\IMenuAction`` interf
 
 As the public template is also some HTML template, the same argumentation as for :ref:`regular templates<controller_template>` regarding the CSRF checks hold true:
 The usage of ``#[NoCSRFRequired]`` for public pages is considered acceptable for some pages:
-Each page that the user should be able to directly access (by typing/pastig the URL in the browser or clicking on a link in a mail) should have this attribute set.
+Each page that the user should be able to directly access (by typing/pasting the URL in the browser or clicking on a link in a mail) should have this attribute set.
 For multi-page forms in the second and later stages, this should **not** be set as the user should follow the series of pages.
 
 Data-based responses

--- a/developer_manual/basics/dependency_injection.rst
+++ b/developer_manual/basics/dependency_injection.rst
@@ -187,7 +187,7 @@ The container works in the following way:
 
 * **AuthorMapper** is queried::
 
-    $container->registerService(AuthorMappers::class, function(ContainerInterface $c): AuthorMapper {
+    $container->registerService(AuthorMapper::class, function(ContainerInterface $c): AuthorMapper {
       return new AuthorService(
         $c->get(IDBConnection::class)
       );

--- a/developer_manual/basics/events.rst
+++ b/developer_manual/basics/events.rst
@@ -333,7 +333,7 @@ This event is triggered when a user deletes a calendar-subscription.
 
 .. versionadded:: 20
 
-This event is triggered when a user deletes a calendar-subscription.
+This event is triggered when a user updates a calendar subscription.
 
 ``\OCA\FederatedFileSharing\Events\FederatedShareAddedEvent``
 *************************************************************

--- a/developer_manual/basics/storage/filesystem.rst
+++ b/developer_manual/basics/storage/filesystem.rst
@@ -32,7 +32,7 @@ From the root folder you can either access a user's home folder or access a file
         private IUserSession $userSession;
         private IRootFolder $rootFolder;
 
-        public function __constructor(IUserSession $userSession, IRootFolder $rootFolder) {
+        public function __construct(IUserSession $userSession, IRootFolder $rootFolder) {
             $this->userSession = $userSession;
             $this->rootFolder = $rootFolder;
         }

--- a/developer_manual/digging_deeper/reference.rst
+++ b/developer_manual/digging_deeper/reference.rst
@@ -658,7 +658,7 @@ in a custom fashion:
         <div v-if="richObject">
             <div>
                 <label>
-                    {{ t('myapp', 'Title' }}
+                    {{ t('myapp', 'Title') }}
                 </label>
                 <span>
                     {{ richObject.title }}
@@ -666,7 +666,7 @@ in a custom fashion:
             <div>
             <div>
                 <label>
-                    {{ t('myapp', 'Extra info' }}
+                    {{ t('myapp', 'Extra info') }}
                 </label>
                 <span>
                     {{ richObject.extra_info }}

--- a/developer_manual/digging_deeper/rest_apis.rst
+++ b/developer_manual/digging_deeper/rest_apis.rst
@@ -101,7 +101,7 @@ The following combinations of attributes might be relevant for various scenarios
 #. OCS route with CORS enabled: ``OCSController`` class and ``#[CORS]`` attribute on the method
 
 .. warning::
-  Adding the ``#[NoCRSFRequired]`` attribute imposes a security risk.
+  Adding the ``#[NoCSRFRequired]`` attribute imposes a security risk.
   You should not add this to your controller methods unless you understand the implications and be sure that you absolutely need the attribute.
   Typically, you can use the ``OCS-APIRequest`` header for data requests instead, in order to satisfy the CSRF checks in your API requests.
 

--- a/developer_manual/getting_started/coding_standards/php.rst
+++ b/developer_manual/getting_started/coding_standards/php.rst
@@ -41,7 +41,7 @@ Use *UpperCamelCase* for Objects, *lowerCamelCase* for functions and variables. 
 a default function/method parameter, do not use spaces. Do not prepend private
 class members with underscores.
 
-.. code-block:: javascript
+.. code-block:: php
 
   class MyClass {
 

--- a/developer_manual/getting_started/development_process.rst
+++ b/developer_manual/getting_started/development_process.rst
@@ -51,7 +51,7 @@ Here are some things to consider:
 
 - Any major release that has not reached end-of-life status usually receives these backported fixes.
 - Backporting even the simplest changes has some level of risk.
-- Differences among stable branches - including of shipped and third-pary apps - means there are additional variables outside of the main branch (or even versus the latest stable).
+- Differences among stable branches - including of shipped and third-party apps - means there are additional variables outside of the main branch (or even versus the latest stable).
 - Fixes often do not have a lot of time in the field (< 4 weeks and it's possible no one has directly interacted with the new code outside of the original developer).
 
 Showstoppers (never backport things that cause these):

--- a/developer_manual/prologue/security.rst
+++ b/developer_manual/prologue/security.rst
@@ -98,7 +98,7 @@ An even better way to make your app safer is to use the jQuery built-in function
 
   messageTd.text(username);
 
-It may also be wise to choose a proper JavaScript framework like AngularJS which automatically  handles the JavaScript escaping for you.
+It may also be wise to choose a proper JavaScript framework like Vue.js which automatically handles the JavaScript escaping for you.
 
 Clickjacking
 ------------


### PR DESCRIPTION
### Summary                                                                    
                                         
Fixes 10 high-severity issues found during a full prose review of the developer manual.
**Code example errors:**                                  
- `basics/storage/filesystem.rst` — `__constructor()` → `__construct()` (invalid PHP method name)                                                     
- `basics/backgroundjobs.rst` — missing semicolon after property declaration
- `basics/dependency_injection.rst` — `AuthorMappers::class` → `AuthorMapper::class` (wrong plural)                      
- `basics/controllers.rst` — typo "typing/pastig" → "typing/pasting"
- `basics/events.rst` — `SubscriptionUpdatedEvent` described as triggered on "deletes"; corrected to "updates"
- `digging_deeper/rest_apis.rst` — `#[NoCRSFRequired]` → `#[NoCSRFRequired]` (letters transposed)                                                          
- `digging_deeper/reference.rst` — missing closing `)` in two `{{ t('myapp', '…' }}` template expressions                                                  
                                                            
**Prose and content errors:**                                                 
- `getting_started/development_process.rst` — typo "third-pary" → "third-party"
- `app_development/translation.rst` — double word "branches branch" → "branches"
- `prologue/security.rst` — AngularJS (EOL December 2021) recommended as JS framework; replaced with Vue.js, which Nextcloud actually uses
- `getting_started/coding_standards/php.rst` — code block labelled `javascript` but contains PHP syntax; corrected to `php`                      
                                                            
  ## Test plan                                                                  
- [x] Clean Sphinx build with no warnings (`sphinx-build -W -b html -D
  language=en`)

AI-Assisted-By: Claude Sonnet 4.6

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
