### PR TITLE
fix(admin): fix high-severity prose errors across admin manual 

### DIFF
--- a/admin_manual/ai/app_context_agent.rst
+++ b/admin_manual/ai/app_context_agent.rst
@@ -165,7 +165,7 @@ Deck tools
 
 * Add a label to a card
 
-  * Example prompt: *"Can you add the label 'Urget' to the 'repair kitchen sink' card in my personal deck board?"*
+  * Example prompt: *"Can you add the label 'Urgent' to the 'repair kitchen sink' card in my personal deck board?"*
 
 * Assign a card to a user
 

--- a/admin_manual/ai/app_stt_whisper2.rst
+++ b/admin_manual/ai/app_stt_whisper2.rst
@@ -4,7 +4,7 @@ App: Local Whisper Speech-To-Text (stt_whisper2)
 
 .. _ai-app-stt_whisper2:
 
-The *stt_whisper2* app is one of the apps that provide Speech-To-Text functionality in Nextcloud and act as a media transcription backend for the :ref:`Nextcloud Assistant app<ai-app-assistant>`, the *talk* app and :ref:`other apps making use of the core Translation API<stt-consumer-apps>`. The *stt_whisper2* app specifically runs only open source models and does so entirely on-premises. Nextcloud can provide customer support upon request, please talk to your account manager for the possibilities.
+The *stt_whisper2* app is one of the apps that provide Speech-To-Text functionality in Nextcloud and act as a media transcription backend for the :ref:`Nextcloud Assistant app<ai-app-assistant>`, the *talk* app and :ref:`other apps making use of the core Speech-To-Text API<stt-consumer-apps>`. The *stt_whisper2* app specifically runs only open source models and does so entirely on-premises. Nextcloud can provide customer support upon request, please talk to your account manager for the possibilities.
 
 This app supports input and output in languages other than English if the underlying model supports the language.
 

--- a/admin_manual/ai/overview.rst
+++ b/admin_manual/ai/overview.rst
@@ -4,7 +4,7 @@ Overview
 
 
 We strive to bring Artificial Intelligence features to Nextcloud. This section highlights these features, how they work and where to find them.
-All of these features are completely optional. If you want to have them on your server, you need install them via separate Nextcloud Apps.
+All of these features are completely optional. If you want to have them on your server, you need to install them via separate Nextcloud Apps.
 
 Overview of AI features
 -----------------------
@@ -312,7 +312,7 @@ Provider apps
 
 Live transcription
 ^^^^^^^^^^^^^^^^^^
-Since Hub 25 Autumn you can let Nextcloud automatically generate produce subtitles for video and audio calls in Nextcloud Talk.
+Since Hub 25 Autumn you can let Nextcloud automatically generate subtitles for video and audio calls in Nextcloud Talk.
 
 Frontend apps
 ~~~~~~~~~~~~~

--- a/admin_manual/configuration_user/reset_user_password.rst
+++ b/admin_manual/configuration_user/reset_user_password.rst
@@ -7,7 +7,7 @@ after a user enters an incorrect password, and then Nextcloud automatically
 resets their password. However, if you are using a read-only authentication 
 backend such as LDAP or Active Directory, this will not work. In this case you 
 may specify a custom URL in your ``config.php`` file to direct your user to a 
-server than can handle an automatic reset::
+server that can handle an automatic reset::
 
  'lost_password_link' => 'https://example.org/link/to/password/reset',
  

--- a/admin_manual/configuration_user/two_factor-auth.rst
+++ b/admin_manual/configuration_user/two_factor-auth.rst
@@ -5,7 +5,7 @@ Two-factor authentication
 =========================
 
 Two-factor authentication adds an additional layer of security to user accounts. In order to log
-in on an account when two-factor authentication (2FA) enabled, you must provide both the
+in on an account when two-factor authentication (2FA) is enabled, you must provide both the
 login password and another factor. 
 
 To use 2FA two things must happen:
@@ -36,9 +36,9 @@ types of factors. Three providers are automatically installed (but may need to b
 
 **Two-Factor Backup Codes**
 
-- A special 2FA factor provider enables users to generate backup codes provider.
-- Facilitates recovery of access if a a 2FA device is unavailable (i.e. gets stolen or is not working).
-- Generates ten backup codes (which can, of course, only be use once).
+- A special 2FA factor provider enables users to generate backup codes.
+- Facilitates recovery of access if a 2FA device is unavailable (i.e. gets stolen or is not working).
+- Generates ten backup codes (which can, of course, only be used once).
 - Always enabled.
 
 Other 2FA providers may be found in the App Store. 

--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -545,7 +545,7 @@ Headline Field:
   The LDAP attribute holding the users headline.
 
 Biography Field:
-  The LDAP attribute holding the users about i.e. short biography.
+  The LDAP attribute holding the user's biography (short description).
   Multi line value with unix LF line ending.
   Windows CRLF and Macintosh CR line endings will be replaced with unix LF line ending.
 

--- a/admin_manual/configuration_user/user_configuration.rst
+++ b/admin_manual/configuration_user/user_configuration.rst
@@ -99,8 +99,8 @@ Nextcloud will automatically send them a notification with their new login
 information. You may edit this email using the email template editor on your
 Admin page (see :doc:`../configuration_server/email_configuration`).
 
-Set the **Send email to new user**-checkbox allows you to leave the **Password**
-field empty. The user will get an activation-email to set their own password.
+If you check the **Send email to new user** checkbox, you can leave the **Password**
+field empty. The user will receive an activation email to set their own password.
 
 Reset a user's password
 -----------------------

--- a/admin_manual/desktop/troubleshooting.rst
+++ b/admin_manual/desktop/troubleshooting.rst
@@ -184,7 +184,7 @@ The Save Log File window opens.
 .. figure:: images/save_log_file.png
    :alt: Save logfile
 
-4. Migrate to a location on your system where you want to save your log file.
+4. Navigate to a location on your system where you want to save your log file.
 
 5. Name the log file and click the 'Save' button.
 

--- a/admin_manual/exapps_management/AppAPIAndExternalApps.rst
+++ b/admin_manual/exapps_management/AppAPIAndExternalApps.rst
@@ -118,7 +118,7 @@ Docker Socket Proxy vs HaRP
 | `FRP <https://github.com/fatedier/frp>`_ is used to create a tunnel between the ExApp and the HaRP container so there is no need for the ExApp containers to expose any ports to the host or to be reachable from the Nextcloud server.
 | The Nextcloud server can reach the ExApp containers through the HaRP container.
 
-HaRP has an additional benefit of being able to proxy requests coming from the Web interface or an API to the ExApp container without being proxies through the Nextcloud server, saving resources, improving performance and supporting additional protocols like WebSockets.
+HaRP has an additional benefit of being able to proxy requests coming from the Web interface or an API to the ExApp container without being proxied through the Nextcloud server, saving resources, improving performance and supporting additional protocols like WebSockets.
 
 HaRP is the recommended way to run ExApps, but if you are not able to use it, Docker Socket Proxy is still supported.
 

--- a/admin_manual/file_workflows/automated_tagging.rst
+++ b/admin_manual/file_workflows/automated_tagging.rst
@@ -13,7 +13,7 @@ restricted and invisible tags to files they upload.
 
 This is especially useful for retention and :doc:`access_control`, so people
 that got the files shared can not remove the tag to stop the retention or
-allow access against the owners will.
+allow access against the owner's will.
 
 Example
 -------
@@ -30,7 +30,7 @@ uploaded into a folder that is tagged with ``Protect content``. No user can
 remove the tag ``Protected file`` and therefore access control and retention
 both work fine without users being able to work around them.
 
-In this case folder will be also tagged with tag ``Protected file``, to avoid
+In this case the folder will also be tagged with tag ``Protected file``, to avoid
 this, simply modify the rule to exclude Directory ``httpd/unix-directory`` from it.
 
     .. figure:: images/automated_tagging_sample_rule_exclude_folder.png

--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -4,7 +4,7 @@ Hardening and security guidance
 
 Nextcloud aims to ship with secure defaults that do not need to get modified by 
 administrators. However, in some cases some additional security hardening can be 
-applied in scenarios were the administrator has complete control over 
+applied in scenarios where the administrator has complete control over 
 the Nextcloud instance. This page assumes that you run Nextcloud Server on Apache2 
 in a Linux environment.
 
@@ -392,7 +392,7 @@ you may do so by issuing::
 
   fail2ban-client unban 1.2.3.4
 
-There may be scenarios where you want to more permantently ban certain IP
+There may be scenarios where you want to more permanently ban certain IP
 addresses that repeatedly generate bad login attempts (or other attacks) by
 using fail2ban's ``recidive`` feature.
 

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -122,7 +122,7 @@ Additional Apache configurations
 
     a2enmod setenvif
 
-  and apply the following modifications the configuration::
+  and apply the following modifications to the configuration::
 
     ProxyFCGIBackendType FPM
     
@@ -270,7 +270,7 @@ problems, unexplained errors, and performance problems. It is a common cause
 of *Gateway Timeouts*. Having too high of a value in relation to available
 resources (such as memory), however, will also lead to problems. The default
 value is often ``5``. This greatly limits simultaneously connections to your
-Nextcloud instance and, unless you are severely resource constraints, will 
+Nextcloud instance and, unless you are under severe resource constraints, will 
 underutilize your hardware. Check the :doc:`../installation/server_tuning` 
 chapter for some guidance and resources for coming up with appropriate values,
 as well as other related parameters.

--- a/admin_manual/occ_apps.rst
+++ b/admin_manual/occ_apps.rst
@@ -165,7 +165,7 @@ You can list all configuration values with one command::
 
 By default, passwords and other sensitive data are omitted from the report, so
 the output can be posted publicly (e.g. as part of a bug report). In order to
-generate a full backport of all configuration values the ``--private`` flag
+generate a full export of all configuration values the ``--private`` flag
 needs to be set::
 
  sudo -E -u www-data php occ config:list --private
@@ -316,7 +316,6 @@ before. If you want to be notified in that case, set the
 
   sudo -E -u www-data php occ config:system:delete doesnotexist
   --error-if-not-exists
-  Config provisioning_api of app appname could not be deleted because it did not
-  exist
+  System config value doesnotexist could not be deleted because it did not exist
 
 

--- a/admin_manual/occ_users.rst
+++ b/admin_manual/occ_users.rst
@@ -54,9 +54,8 @@ Any groups that do not exist are created automatically::
 
 ``--password-from-env`` reads the password from the ``OC_PASS`` environment
 variable. This keeps the password out of the process list and allows scripting
-the creation of multiple users. Note that this requires running as the real
-``root`` user rather than ``sudo``, because ``sudo`` strips environment
-variables::
+the creation of multiple users. Note that ``sudo`` strips environment variables
+by default; the ``-E`` flag preserves them, as shown in the example below::
 
  export OC_PASS=newpassword
  sudo -E -u www-data php occ user:add --password-from-env \


### PR DESCRIPTION
### Summary                                                                                                                                                                                  
   
  Fixes 14 high-severity issues found during a full prose review of the admin manual.                                                                                                         
                                                            
  **Typos and grammar:**                                                                                                                                                                      
  - `installation/harden_server.rst` — "scenarios were the administrator" → "where"; "permantently" → "permanently"
  - `installation/source_installation.rst` — "modifications the configuration" → "modifications to the configuration"; "severely resource constraints" → "under severe resource constraints"  
  - `configuration_user/two_factor-auth.rst` — missing "is" in "2FA enabled"; double "a" before "2FA device"; "only be use once" → "only be used once"; trailing duplicate word "provider"    
  - `configuration_user/reset_user_password.rst` — "than can handle" → "that can handle"                                                                                                      
  - `ai/overview.rst` — "need install" → "need to install"; "generate produce subtitles" → "generate subtitles"                                                                               
  - `ai/app_context_agent.rst` — typo "Urget" → "Urgent" in example prompt                                                                                                                    
  - `exapps_management/AppAPIAndExternalApps.rst` — "being proxies through" → "being proxied through"                                                                                         
  - `file_workflows/automated_tagging.rst` — "against the owners will" → "owner's will"; "In this case folder will be also tagged" → "the folder will also be tagged"                         
  - `desktop/troubleshooting.rst` — "Migrate to a location" → "Navigate to a location"                                                                                                        
                                                                                                                                                                                              
  **Broken or misleading content:**                                                                                                                                                           
  - `configuration_user/user_configuration.rst` — "Set the Send email to new user-checkbox allows you to leave the Password field empty" was grammatically broken; rewritten as "If you check 
  the Send email to new user checkbox, you can leave the Password field empty."                                                                                                               
  - `configuration_user/user_auth_ldap.rst` — "holding the users about i.e. short biography" was unreadable; rewritten as "holding the user's biography (short description)"
  - `occ_apps.rst` — "generate a full backport of all configuration values" → "full export"; error output for `config:system:delete` showed wrong key name and wrong format (app config error 
  instead of system config error)                                                                                                                                                             
  - `occ_users.rst` — note said `--password-from-env` "requires running as the real root user rather than sudo", but the example immediately below uses `sudo -E`; clarified that `sudo -E`   
  preserves environment variables                                                                                                                                                             
  - `ai/app_stt_whisper2.rst` — cross-reference label said "Translation API" instead of "Speech-To-Text API"

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
