### PR TITLE
fix(user): fix high-severity prose errors across user manual

### DIFF
--- a/user_manual/desktop/conflicts.rst
+++ b/user_manual/desktop/conflicts.rst
@@ -14,7 +14,7 @@ notify the user that a conflict occurred which needs attention.
 Example
 -------
 
-Imagine there is a file called ``mydata.txt`` your synchronized folder. It has
+Imagine there is a file called ``mydata.txt`` in your synchronized folder. It has
 not changed for a while and contains the text "contents" locally and remotely.
 Now, nearly at the same time you update it locally to say "local contents" while
 the file on the server gets updated to contain "remote contents" by someone else.

--- a/user_manual/desktop/usage.rst
+++ b/user_manual/desktop/usage.rst
@@ -191,7 +191,7 @@ depending on the used file manager. Available are e.g. ``nautilus-nextcloud``
 Nextcloud users the same way as in your Nextcloud Web interface.
 
 In your file explorer, click on a file and in the context menu go to
-**Nextcloud** and then lick on **Share options** to bring up the Share
+**Nextcloud** and then click on **Share options** to bring up the Share
 dialog.
 
 .. figure:: images/share_context_menu.png

--- a/user_manual/groupware/absence.rst
+++ b/user_manual/groupware/absence.rst
@@ -9,6 +9,6 @@ If you are absent for vacation, sick leave or similar, you can add an out-of-off
 The interface asks for the time of absence, a short and a long message and an optional replacement user. This data is used for the following purposes:
 
 1) Your user status will change to the short message when your absence starts and reset when it ends.
-2) And event with status *busy* will be created in your personal calendar. This allows others to see that you are not available when they use the free/busy feature.
+2) An event with status *busy* will be created in your personal calendar. This allows others to see that you are not available when they use the free/busy feature.
 3) If enabled, the Mail app will apply an autoresponder using the long message.
 4) The Talk app will show the long out-of-office message to others when they try to reach you in a 1:1 chat during your absence as well as the replacement user if set.

--- a/user_manual/groupware/calendar.rst
+++ b/user_manual/groupware/calendar.rst
@@ -62,13 +62,12 @@ instance, importing is the best way to do so.
 Import an Event/Add .ics Event
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In many places, you can download event details as an .ics file, or via a button saying "ical", "Apple Calendar" or "Outlook".
-
+Individual events are often distributed as ``.ics`` files (sometimes via a button labelled "iCal", "Apple Calendar" or "Outlook"). You can import them into Nextcloud Calendar using the same import flow as a full calendar.
 
 1. Click on the settings-icon labeled with ``Calendar settings`` at the bottom-left.
 
-2. After clicking on ``Import calendar`` you can select one or more calendar files
-   from your local device to upload.
+2. After clicking on ``Import calendar`` you can select one or more ``.ics`` files
+   from your local device to upload. Single-event files are added to the calendar you select.
 
 3. Select a ``Calendar to import into``.
 

--- a/user_manual/groupware/sync_android.rst
+++ b/user_manual/groupware/sync_android.rst
@@ -75,6 +75,8 @@ steps are required:
 .. note:: Using user name and password will not work if 2-Factor-Authentication
    is enabled and will throw a generic "Unknown resource" error.
    Use a :ref:`dedicated App password <managing_devices>` instead.
+   If you enabled 2FA after already configuring DAVx⁵, update your DAVx⁵ account
+   to replace your login password with an app password.
 
 
 .. tip:: DAVx⁵ lists the calendar subscriptions made through the Nextcloud Calendar app, but you need to install the `ICSx⁵ (formerly known as ICSDroid) <https://icsx5.bitfire.at/>`__ app on your Android device, `from the Google Play Store <https://play.google.com/store/apps/details?id=at.bitfire.icsdroid>`__ or `from F-Droid <https://f-droid.org/packages/at.bitfire.icsdroid/>`__ to sync them.

--- a/user_manual/talk/breakout_rooms.rst
+++ b/user_manual/talk/breakout_rooms.rst
@@ -20,7 +20,7 @@ You have three options:
 
 - **Automatically assign participants**: Talk will automatically assign participants to the rooms.
 - **Manually assign participants**: You'll go through a participants editor where you can assign participants to rooms.
-- **Allow participants choose**: Participants will be able to join breakout rooms themselves.
+- **Allow participants to choose**: Participants will be able to join breakout rooms themselves.
 
 .. image:: images/talk-breakout-rooms-setup-dialog.png
     :width: 500px

--- a/user_manual/talk/conversations.rst
+++ b/user_manual/talk/conversations.rst
@@ -193,7 +193,7 @@ By default, Nextcloud Talk will notify you about:
 
 You can change this behavior in the conversation settings. Additionally, you can configure:
 
-- **Important conversations**: you will be always notificed about new messages, even if you are in "Do Not Disturb" mode;
+- **Important conversations**: you will be always notified about new messages, even if you are in "Do Not Disturb" mode;
 - **Sensitive conversations**: content of messages will not be shown in the conversation list and obscured from notifications.
 
 .. image:: images/conversation-notifications.png


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  Fixes 8 high-severity issues found during a full prose review of the user manual.                                                                                                           
                                                                                                                                                                                              
  - `talk/conversations.rst` — typo "notificed" → "notified"                                                                                                                                  
  - `talk/breakout_rooms.rst` — missing "to": "Allow participants choose" → "Allow participants to choose"                                                                                    
  - `desktop/usage.rst` — missing "C": "lick on Share options" → "Click on Share options"                                                                                                     
  - `desktop/conflicts.rst` — missing "in": "mydata.txt your synchronized folder" → "in your synchronized folder"                                                                             
  - `groupware/absence.rst` — "And event with status busy" → "An event with status busy"                                                                                                    
  - `groupware/calendar.rst` — "Import an Event" section had near-identical steps to "Import a Calendar" with no explanation of the difference; clarified that single-event .ics files use the
   same import dialog                                                                                                                                                                         
  - `groupware/sync_android.rst` — 2FA note told users to use an app password but gave no guidance for the case where 2FA was enabled after DAVx⁵ was already configured; added explicit      
  instruction to update the DAVx⁵ account password  

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
