### PR TITLE
fix(admin): prose quality fixes across admin manual (MED severity)

### DIFF
--- a/admin_manual/ai/app_context_agent.rst
+++ b/admin_manual/ai/app_context_agent.rst
@@ -441,7 +441,7 @@ Nextcloud customers should file bugs directly with our Support system.
 Known Limitations
 -----------------
 * Make sure to test the language model you are using in concert with this app for whether they meet the use-case's quality requirements
-* Most models have difficulties with languages other than English. Some sometimes answer in another language than used by the user. 
+* Most models have difficulties with languages other than English. Some models sometimes answer in a different language than the one used by the user.
 * Customer support is available upon request, however we can't solve false or problematic output, most performance issues, or other problems caused by the underlying model. 
   Support is thus limited only to bugs directly caused by the implementation of the app (connectors, API, front-end, AppAPI). We still try to optimize this as far as possible, so if you encounter any false or problematic output, you can report it `in a dedicated Github issue <https://github.com/nextcloud/context_agent/issues/51>`_ to help us improve this app. 
 * When multiple MCP services are configured that have tools with the same name undefined behavior will occur.

--- a/admin_manual/ai/eu_ai_act.rst
+++ b/admin_manual/ai/eu_ai_act.rst
@@ -36,7 +36,7 @@ This section describes the measures that ensure the software is interoperable.
 
 - We provide our AI features via an open API with publicly accessible `OpenAPI specs <https://docs.nextcloud.com/server/latest/developer_manual/_static/openapi.html#/>`_ which allows developers to build on top of our features.
 - As our software is fully open-source, anyone can adjust the software to meet their needs. For example, anyone can adjust the core code, adjust the code of existing applications, or develop a custom application for Nextcloud.
-- We implement integrations for the major model hosting providers and their protocols upon request of customers. We are interoperable with OpenAI and IBMwatsonX. As Nextcloud is an open app ecosystem, anyone can develop an integration with a model hosting provider on their own.
+- We implement integrations for the major model hosting providers and their protocols upon request of customers. We are interoperable with OpenAI and IBM watsonx. As Nextcloud is an open app ecosystem, anyone can develop an integration with a model hosting provider on their own.
 - We implement the agent interoperability protocol MCP both as a client and as a server to allow users to connect the AI Agent software to existing services and connect existing AI Agents to our software.
 - We implement a local model hosting mechanism that can be used to host GGUF models (most open weight models can be converted using an Open Source tool called llama.cpp).
 

--- a/admin_manual/configuration_files/external_storage/amazons3.rst
+++ b/admin_manual/configuration_files/external_storage/amazons3.rst
@@ -39,7 +39,7 @@ Setting :code:`Enable Path Style` to true configures the S3 client to make reque
 enable it if your in-house object store or service provider requires it over the default (v4) authentication.
 
 In the **Available for** field enter the users or groups who you want to give
-access your S3 mount.
+give access to your S3 mount.
 
 The ``Enable SSL`` checkbox enables HTTPS connections and generally preferred. It is the default unless 
 you disable it here.

--- a/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
+++ b/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
@@ -83,8 +83,7 @@ Considerations for shared storage
 ---------------------------------
 
 Every external storage, which is using user specific authentication, is connected individually.
-Even if several users connect to the same folder, the files are regarded as separate files per user.
-Nextcloud can not recognize if two users access the very same file if they follow individual connections. 
+Nextcloud cannot recognise shared file locks across individual connections, even when accessing the same file.
 
 This has an influence on e.g. file locking as a locked individual file is not shown as locked to other users or users cannot collaboratively edit documents.
 

--- a/admin_manual/configuration_server/logging_configuration.rst
+++ b/admin_manual/configuration_server/logging_configuration.rst
@@ -35,7 +35,7 @@ All log information will be sent to PHP ``error_log()``.
 
     "log_type" => "errorlog",
 
-.. warning:: Until version Nextcloud 25 log entries were prefixed with ``[owncloud]``. From 26 onwards messages start with ``[nextcloud]``.
+.. warning:: Until Nextcloud 25, log entries were prefixed with ``[owncloud]``. From 26 onwards, log entries start with ``[nextcloud]``.
 
 file
 ~~~~

--- a/admin_manual/configuration_server/oauth2.rst
+++ b/admin_manual/configuration_server/oauth2.rst
@@ -6,7 +6,7 @@ Nextcloud allows connecting external services (for example Moodle) to your Nextc
 This is done via ``OAuth2``. See `RFC6749 <https://tools.ietf.org/html/rfc6749>`_ for the
 OAuth2 specification.
 
-.. note:: Nextcloud does only support confidential clients.
+.. note:: Nextcloud supports only confidential clients.
 
 Add an OAuth2 Application
 -------------------------

--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -463,7 +463,7 @@ Email Field:
 
 User Home Folder Naming Rule:
   By default, the Nextcloud server creates the user directory in your Nextcloud
-  data directory and gives it the Nextcloud username, .e.g ``/var/www/nextcloud/data/alice``. You may want to override this setting and name it after an LDAP
+  data directory and gives it the Nextcloud username, e.g. ``/var/www/nextcloud/data/alice``. You may want to override this setting and name it after an LDAP
   attribute value. The attribute can also return an absolute path, e.g.
   ``/mnt/storage43/alice``. Leave it empty for default behavior.
 
@@ -483,7 +483,7 @@ User Profile attributes
 .. figure:: ../images/ldap-advanced-4-attributes.png
    :alt: User Profile Attributes.
 
-After configuring those attributes, the User Profile data will be overwritten with the according data from LDAP.  The checksum of data from LDAP will be stored in user settings ``user_ldap``, ``lastProfileChecksum`` and profile update is skipped as long as data from LDAP doesn't change.  If ``memcache.distributed`` is enabled in ``config.php`` the checksum will be cached and the checking will be skipped, as long as the cached value exists (expires after ``ldapCacheTTL`` seconds).
+After configuring those attributes, the User Profile data will be overwritten with the corresponding data from LDAP.  The checksum of data from LDAP will be stored in user settings ``user_ldap``, ``lastProfileChecksum`` and profile update is skipped as long as data from LDAP doesn't change.  If ``memcache.distributed`` is enabled in ``config.php`` the checksum will be cached and the checking will be skipped, as long as the cached value exists (expires after ``ldapCacheTTL`` seconds).
 
 Please be aware:
   - The user can change the data in profile, but it will get overwritten if changed in LDAP
@@ -570,7 +570,7 @@ Internal Username:
   The internal username is the identifier in Nextcloud for LDAP users. By default
   it will be created from the UUID attribute. The UUID attribute ensures that
   the username is unique, and that characters do not need to be converted. Only
-  these characters are allowed: [\a-\zA-\Z0-\9_.@-]. Other characters are
+  these characters are allowed: ``[a-zA-Z0-9_.@-]``. Other characters are
   replaced with their ASCII equivalents, or are simply omitted.
 
   The LDAP backend ensures that there are no duplicate internal usernames in

--- a/admin_manual/configuration_user/user_configuration.rst
+++ b/admin_manual/configuration_user/user_configuration.rst
@@ -68,7 +68,7 @@ User accounts have the following properties:
 
 *Quota*
   The maximum disk space assigned to each user. Any user that exceeds the quota
-  cannot upload or sync data. You have the the option to include external
+  cannot upload or sync data. You have the option to include external
   storage in user quotas.
 
 *Manager*
@@ -211,7 +211,7 @@ settings and files. The user can be activated any time again, without data-loss.
 Hover your cursor over their name on the **Users** page until the "..."-menu icon
 appears at the far right. After clicking on it, you will see the **Disable** option.
 
-The user will not longer be able to access their Nextcloud until you enable them again.
+The user will no longer be able to access their Nextcloud until you enable them again.
 Also all external shares, via public link or email, will not be accessible.
 Internal shares will still be working, so that other users on Nextcloud can continue working.
 

--- a/admin_manual/exapps_management/ManagingDeployDaemons.rst
+++ b/admin_manual/exapps_management/ManagingDeployDaemons.rst
@@ -51,7 +51,7 @@ Usage Examples
 
 		occ app_api:daemon:register harp_proxy_docker "Harp Proxy (Docker)" "docker-install" "http" "appapi-harp:8780" "http://nextcloud.local" --net nextcloud --harp --harp_frp_address "appapi-harp:8782" --harp_shared_key "some_very_secure_password" --set-default --compute_device=cuda
 
-* Register a HaRP deploy daemon with the ``localhost`` as the host and the ``localhost:8782`` as the FRP server address. This can be paired with a HaRP container running in the host network mode or has exposed the ports ``8780`` and ``8782`` to the host.
+* Register a HaRP deploy daemon with the ``localhost`` as the host and the ``localhost:8782`` as the FRP server address. This can be paired with a HaRP container running in the host network mode or that has exposed the ports ``8780`` and ``8782`` to the host.
 
 	.. code-block:: bash
 

--- a/admin_manual/installation/command_line_installation.rst
+++ b/admin_manual/installation/command_line_installation.rst
@@ -21,7 +21,7 @@ of running the graphical Installation Wizard::
  $ cd /var/www/nextcloud/
  $ sudo -E -u www-data php occ  maintenance:install \
  --database 'mysql' --database-name 'nextcloud' \
- --database-user 'root' --database-pass 'password' \
+ --database-user 'nextcloud' --database-pass 'password' \
  --admin-user 'admin' --admin-pass 'password'
  
 Note that you must change to the root Nextcloud directory, as in the example 

--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -31,8 +31,7 @@ Don't forget to change it back to ``false`` when you are finished.
 Backup folders
 --------------
 
-Simply copy your config, data and theme folders (or even your whole Nextcloud install and data folder) to a place outside of
-your Nextcloud environment. You could use this command::
+Copy your config, data, and theme directories to a location outside your Nextcloud environment. Alternatively, copy your entire Nextcloud installation directory (including the data directory). You could use this command::
 
     rsync -Aavx nextcloud/ nextcloud-dirbkp_`date +"%Y%m%d"`/
 

--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -10,8 +10,8 @@ restore:
 #. The database
 #. The theme directory
 
-.. note:: You must have both the database and data directory. You cannot
-   complete restoration unless you have both of these.
+.. note:: You must have the database, data directory, and configuration files.
+   You cannot complete restoration without all three.
 
 Restore folders
 ---------------

--- a/admin_manual/occ_ldap.rst
+++ b/admin_manual/occ_ldap.rst
@@ -166,7 +166,7 @@ Tests user-related LDAP settings::
 ldap\:show-remnants
 ^^^^^^^^^^^^^^^^^^^
 
-Used to cleaning up the LDAP mappings table, and is
+Used to clean up the LDAP mappings table, and is
 documented in :doc:`../configuration_user/user_auth_ldap_cleanup`.
 
 

--- a/admin_manual/office/example-docker.rst
+++ b/admin_manual/office/example-docker.rst
@@ -40,7 +40,7 @@ On a recent Ubuntu or Debian this should be possible using:
     apt-get install apache2
     a2enmod proxy proxy_wstunnel proxy_http ssl
 
-Afterward, configure one VirtualHost properly to proxy the traffic. For security reason we recommend to use a subdomain such as office.example.com instead of running on the same domain. An example config can be found below::
+Afterward, configure one VirtualHost properly to proxy the traffic. For security reasons, we recommend using a subdomain such as office.example.com instead of running on the same domain. An example config can be found below::
 
     ########################################
     # Reverse proxy for Collabora Online

--- a/admin_manual/office/installation.rst
+++ b/admin_manual/office/installation.rst
@@ -9,7 +9,7 @@ Nextcloud Office is built on Collabora Online which requires a dedicated service
 For manual installations there are multiple options to get Nextcloud Office deployed:
 
 - **Installation through distribution packages**
-    There are packages for all major Linux distributions available which allow deploying a Collabora Online server through installing it through the regular package management. For an example installation guide on Ubuntu, see see: :doc:`example-ubuntu`
+    There are packages for all major Linux distributions available which allow deploying a Collabora Online server through installing it through the regular package management. For an example installation guide on Ubuntu, see: :doc:`example-ubuntu`
 
     .. seealso::
         https://www.collaboraoffice.com/code/linux-packages/ 

--- a/admin_manual/windmill_workflows/index.rst
+++ b/admin_manual/windmill_workflows/index.rst
@@ -2,7 +2,7 @@
 Windmill Workflows
 ==================
 
-Nextcloud integrates the `Windmill workflow engine <https://www.windmill.dev/>` to allow advanced custom workflows interacting with your Nextcloud instance.
+Nextcloud integrates the `Windmill workflow engine <https://www.windmill.dev/>`_ to allow advanced custom workflows interacting with your Nextcloud instance.
 
 Installation
 ------------
@@ -126,7 +126,7 @@ The :code:`data` variable receives the response of the HTTP request, so any data
 Authentication
 ~~~~~~~~~~~~~~
 
-All the scripts we provide one input parameter in common: *nextcloud* needs to be an object of the type "Nextcloud" and contain what is necessary to authenticate against Nextcloud:
+All the scripts we provide have one input parameter in common: *nextcloud* needs to be an object of the type "Nextcloud" and contain what is necessary to authenticate against Nextcloud:
 
 * baseUrl: the URL your instance is reachable at, e.g. :code:`https://example.cloud`
 * userId: the user id of the user the script should authenticate with


### PR DESCRIPTION
Sixteen targeted prose fixes across the admin manual: corrected grammar, clearer                                                                                                            
  phrasing, fixed a malformed RST link, and improved technical accuracy.
                                                                                                                                                                                              
  **Changes by area:**                                                                                                                                                                        
  
  - **installation/**: `command_line_installation` (use dedicated DB user in example), `restore` (add config files to required restore items), `backup` (separate two backup approaches       
  clearly)                                                  
  - **configuration_server/**: `oauth2` (word order: "does only support" → "supports only"), `logging_configuration` (standardise "messages" → "log entries")                                 
  - **configuration_files/**: `auth_mechanisms` (rewrite misleading per-user file locking sentence), `amazons3` (missing "to" in "give access your S3 mount")                                 
  - **configuration_user/**: `user_configuration` ("have the the option", "will not longer"), `user_auth_ldap` (".e.g" → "e.g.", "according data" → "corresponding data", invalid regex 
  `[\a-\zA-\Z0-\9_.@-]` → `[a-zA-Z0-9_.@-]`)                                                                                                                                                  
  - **occ/**: `occ_ldap` ("Used to cleaning up" → "Used to clean up")                                                                                                                         
  - **ai/**: `app_context_agent` (clarify language caveat), `eu_ai_act` ("IBMwatsonX" → "IBM watsonx")                                                                                        
  - **misc**: `windmill_workflows/index` (malformed RST link + missing verb "have"), `ManagingDeployDaemons` ("or has exposed" → "or that has exposed"), `office/installation` (duplicate "see
   see"), `office/example-docker` ("For security reason" → "For security reasons,") 

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
