### PR TITLE
fix(dev): prose quality fixes across developer manual (MED severity) 

### DIFF
--- a/developer_manual/app_development/init.rst
+++ b/developer_manual/app_development/init.rst
@@ -31,4 +31,4 @@ purpose there are several events emitted that an app can act upon.
 * ``OCP\AppFramework\Http\TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS`` (constant): loaded when a template response is finished
 * ``OCP\AppFramework\Http\TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN`` (constant): loaded when a template response is finished for a logged in user
 
-You can subscribe listeners to these events in the :ref:`bootstrapping code<Bootstrapping>` of the app. See the :ref:`events documentation<Events>` for more details on the event dispatcher and available events.
+You can register listeners for these events in the :ref:`bootstrapping code<Bootstrapping>` of the app. See the :ref:`events documentation<Events>` for more details on the event dispatcher and available events.

--- a/developer_manual/basics/backgroundjobs.rst
+++ b/developer_manual/basics/backgroundjobs.rst
@@ -16,7 +16,7 @@ and ``\OCP\BackgroundJob\TimedJob``.
 
 The ``QueuedJob`` is for one time jobs. This can for example be triggered by inserting
 a job because an event happened. The ``TimedJob`` has a method ``setInterval`` where
-you can set the time minimum time in seconds between the jobs (from the constructor).
+you can set the minimum time in seconds between the jobs (from the constructor).
 This is useful in case you want to have a job that is run at most once a day for example.
 
 Of course you can customize this all to your liking by just extending ``\OCP\BackgroundJob\Job``

--- a/developer_manual/basics/setting.rst
+++ b/developer_manual/basics/setting.rst
@@ -169,8 +169,7 @@ setting with attribute.
     }
 
 
-If you have several ``IDelegatedSettings`` classes that are needed for a function, simply add the annotation multiple times.
-them in the key "settings" and they must separate with semi-colons.
+If you have several ``IDelegatedSettings`` classes that are needed for a function, add multiple attributes and separate them with semicolons.
 
 .. note::
 

--- a/developer_manual/client_apis/general.rst
+++ b/developer_manual/client_apis/general.rst
@@ -7,7 +7,7 @@ Nextcloud's APIs are mainly available through :ref:`rest-apis`, :ref:`OCS <ocsap
 Generic Errors
 --------------
 
-Additional to specific errors of an API, there are a few generic errors Nextcloud might throw on web APIs.
+In addition to specific errors of an API, there are a few generic errors Nextcloud might throw on web APIs.
 
 Maintenance Mode
 ****************

--- a/developer_manual/digging_deeper/performance.rst
+++ b/developer_manual/digging_deeper/performance.rst
@@ -6,7 +6,7 @@ Performance considerations
 
 This document introduces some common considerations and tips on improving performance of Nextcloud. Speed of Nextcloud is important - nobody likes to wait and often, what is *just slow* for a small amount of data will become *unusable* with a large amount of data. Please keep these tips in mind when developing for Nextcloud and consider reviewing your app to make it faster.
 
-.. note::**Tips welcome**: More tips and ideas on performance are very welcome!
+.. note:: Tips welcome: More tips and ideas on performance are very welcome!
 
 PHP Performance
 ---------------

--- a/developer_manual/digging_deeper/status.rst
+++ b/developer_manual/digging_deeper/status.rst
@@ -42,8 +42,8 @@ Updating the status programmatically
 ------------------------------------
 
 A Nextcloud application can change the user status programmatically. This feature
-`setUserStatus` from the `OCP\\UserStatus\\IManager` interface when for example an
-user execute an action in the UI.
+`setUserStatus` from the `OCP\\UserStatus\\IManager` interface when for example a
+user executes an action in the UI.
 
 If the status is supposed to be reverted with an upcoming action from the
 user, `setUserStatus` will require to be called with `$createBackup = true`.

--- a/developer_manual/exapp_development/faq/BehindCompanyProxy.rst
+++ b/developer_manual/exapp_development/faq/BehindCompanyProxy.rst
@@ -136,7 +136,7 @@ Method 2: Set System-Wide Environment Variables
 
    .. code-block:: bash
 
-	  sudo -E -u www-data test-deploy docker_socket_proxy --info-xml https://raw.githubusercontent.com/nextcloud/test-deploy/main/appinfo/info.xml --test-deploy-mode --no-ansi --no-warnings
+	  sudo -E -u www-data php occ app_api:app:register test-deploy docker_socket_proxy --info-xml https://raw.githubusercontent.com/nextcloud/test-deploy/main/appinfo/info.xml --test-deploy-mode --no-ansi --no-warnings
 
    It should now work without connectivity issues.
 

--- a/developer_manual/getting_started/devenv.rst
+++ b/developer_manual/getting_started/devenv.rst
@@ -134,7 +134,7 @@ or to prune all merged branches, you would execute this::
 
   find . -maxdepth 3 -type d -name .git -exec sh -c 'cd "{}"/../ && pwd && git remote prune origin' \;
 
-It is even easier if you create alias from these commands in case you want to avoid retyping those each time you need them.
+It is even easier if you create aliases for these commands in case you want to avoid retyping those each time you need them.
 
 
 .. _GitHub: https://github.com/nextcloud


### PR DESCRIPTION
Eight targeted prose fixes across the developer manual: corrected grammar, fixed a                                                                                                          
  malformed RST directive, clarified phrasing, and added a missing command prefix.                                                                                                            
                                                                                                                                                                                              
  **Changes by area:**                                                                                                                                                                        
                                                                                                                                                                                              
  - **getting_started/**: `devenv` ("create alias from" → "create aliases for")                                                                                                               
  - **app_development/**: `init` ("subscribe listeners to" → "register listeners for")
  - **basics/**: `backgroundjobs` (redundant "time minimum time" → "minimum time"), `setting` (rewrite broken sentence about multiple `IDelegatedSettings` annotations)                       
  - **digging_deeper/**: `status` ("an user execute" → "a user executes"), `performance` (malformed `.. note::**Tips welcome**:` → `.. note::`)                                               
  - **client_apis/**: `general` ("Additional to specific errors" → "In addition to specific errors")
  - **exapp_development/**: `BehindCompanyProxy` (add missing `php occ app_api:app:register` prefix to command example)  

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
