### PR TITLE
fix: prose quality fixes across all three manuals (LOW severity)

### DIFF
--- a/admin_manual/ai/app_assistant.rst
+++ b/admin_manual/ai/app_assistant.rst
@@ -65,7 +65,7 @@ Text processing
 In order to make use of text processing features in the assistant, you will need an app that provides a Text processing backend:
 
 * :ref:`llm2<ai-app-llm2>` - Runs open source AI language models locally on your own server hardware (Customer support available upon request)
-* * `OpenAI and LocalAI integration (via OpenAI API) <https://apps.nextcloud.com/apps/integration_openai>`_ - Integrates with the OpenAI API to provide AI functionality from OpenAI servers  (Customer support available upon request; see :ref:`AI as a Service<ai-ai_as_a_service>`)
+* `OpenAI and LocalAI integration (via OpenAI API) <https://apps.nextcloud.com/apps/integration_openai>`_ - Integrates with the OpenAI API to provide AI functionality from OpenAI servers  (Customer support available upon request; see :ref:`AI as a Service<ai-ai_as_a_service>`)
 * *integration_watsonx* - Integrates with the IBM watsonx.ai API to provide AI functionality from IBM Cloud servers  (Customer support available upon request; see :ref:`AI as a Service<ai-ai_as_a_service>`)
 
 These apps currently implement the following Assistant Tasks:
@@ -85,7 +85,7 @@ Text-To-Image
 In order to make use of Text-To-Image features, you will need an app that provides an image generation backend:
 
 * :ref:`tex2image_stablediffusion2<ai-app-text2image_stablediffusion2>` (Customer support available upon request)
-* * `OpenAI and LocalAI integration (via OpenAI API) <https://apps.nextcloud.com/apps/integration_openai>`_ - Integrates with the OpenAI API to provide AI functionality from OpenAI servers  (Customer support available upon request; see :ref:`AI as a Service<ai-ai_as_a_service>`)
+* `OpenAI and LocalAI integration (via OpenAI API) <https://apps.nextcloud.com/apps/integration_openai>`_ - Integrates with the OpenAI API to provide AI functionality from OpenAI servers  (Customer support available upon request; see :ref:`AI as a Service<ai-ai_as_a_service>`)
 * *integration_replicate* - Integrates with the replicate API to provide AI functionality from replicate servers (see :ref:`AI as a Service<ai-ai_as_a_service>`)
 
 Context Chat
@@ -103,7 +103,7 @@ Chat
 In order to make use of our "Chat with AI" feature you will need any one of the following apps:
 
 * :ref:`llm2<ai-app-llm2>` - Runs open source AI language models locally on your own server hardware (Customer support available upon request)
-* * `OpenAI and LocalAI integration (via OpenAI API) <https://apps.nextcloud.com/apps/integration_openai>`_ - Integrates with the OpenAI API to provide AI functionality from OpenAI servers  (Customer support available upon request; see :ref:`AI as a Service<ai-ai_as_a_service>`)
+* `OpenAI and LocalAI integration (via OpenAI API) <https://apps.nextcloud.com/apps/integration_openai>`_ - Integrates with the OpenAI API to provide AI functionality from OpenAI servers  (Customer support available upon request; see :ref:`AI as a Service<ai-ai_as_a_service>`)
 
 
 Voice Chat

--- a/admin_manual/configuration_files/external_storage/openstack.rst
+++ b/admin_manual/configuration_files/external_storage/openstack.rst
@@ -18,7 +18,7 @@ protocol. Your Nextcloud configuration needs:
 * **Identity Endpoint URL**, the URL to log in to your OpenStack account.
 
 .. figure:: images/openstack.png
-   :alt: Openstack configuration.
+   :alt: OpenStack configuration.
 
 The Rackspace authentication mechanism requires: 
 
@@ -29,7 +29,7 @@ The Rackspace authentication mechanism requires:
 You must also enter the term **cloudFiles** in the **Service name** field.
 
 .. figure:: images/rackspace.png
-   :alt: Openstack configuration.
+   :alt: OpenStack configuration.
 
 It may be necessary to specify a **Region**. Your region should be named in 
 your account information, and you can read about Rackspace regions at 

--- a/admin_manual/configuration_server/language_configuration.rst
+++ b/admin_manual/configuration_server/language_configuration.rst
@@ -10,7 +10,8 @@ If this does not work properly or you want to make sure that Nextcloud always
 starts with a given language, you can set a **default_language** parameter in the
 :file:`config/config.php`.
 
-.. note:: The default_language parameter is only used when the browser does not send any language, and the user hasn’t configured their own language preferences. This sets the default language on your Nextcloud server, using ISO_639-1 language codes such as en for English, de for German, and fr for French. Nextcloud has two distinguished language codes for German, de and de_DE. de is used for informal German and de_DE for formal German. By setting this value to de_DE, you can enforce the formal version of German unless the user has chosen something different explicitly.
+.. note:: The ``default_language`` parameter only applies when the browser sends no language preference and the user has not set their own.
+   Accepts ISO 639-1 codes such as ``en`` (English), ``fr`` (French), ``de`` (informal German), or ``de_DE`` (formal German).
 
 ::
 

--- a/admin_manual/maintenance/manual_upgrade.rst
+++ b/admin_manual/maintenance/manual_upgrade.rst
@@ -130,7 +130,7 @@ You'll find previous Nextcloud releases in the `Nextcloud Server Changelog
 Troubleshooting
 ---------------
 
-Occasionally, *files do not show up after a upgrade*. A rescan of the files can 
+Occasionally, *files do not show up after an upgrade*. A rescan of the files can 
 help::
 
  sudo -E -u www-data php console.php files:scan --all

--- a/admin_manual/maintenance/migrating_owncloud.rst
+++ b/admin_manual/maintenance/migrating_owncloud.rst
@@ -9,7 +9,7 @@ Migrating from ownCloud
 
 Currently migrating from ownCloud is like performing a manual update.
 So it is quite easy, to migrate from one ownCloud version to at least one Nextcloud version.
-However this does only work with versions that are close enough database and code-wise.
+However this does only work with versions that are sufficiently compatible in database schema and codebase.
 See the table below for a version map, where migrating is easily possible:
 
 +-------------------+-------------------------------+

--- a/developer_manual/app_development/info.rst
+++ b/developer_manual/app_development/info.rst
@@ -32,7 +32,7 @@ A minimum valid **info.xml** would look like this:
         </dependencies>
     </info>
 
-A full blown example would look like this (needs to be utf-8 encoded):
+A comprehensive example would look like this (needs to be utf-8 encoded):
 
 .. code-block:: xml
     :caption: appinfo/info.xml

--- a/developer_manual/app_publishing_maintenance/publishing.rst
+++ b/developer_manual/app_publishing_maintenance/publishing.rst
@@ -82,7 +82,7 @@ To deliver on the promises above, we have two simple rules.
 
 We want to make sure that when you find other things in life which are more urgent or otherwise are unable to help your project anymore, it does not become 'dead code' as long as there are people who want to keep it alive. This is not fair to users, who would be forced to remove the app and install another.
 
-Please note that the role of a maintainer is not to be the most active or prolific contributor to a project! Being friendly, welcoming and responsive are what it takes to be a successful maintainer. Not being the most brilliant developer ever, or spending nights and weekends coding!
+Please note that the role of a maintainer is not to be the most active or prolific contributor to a project! Being friendly, welcoming and responsive are what it takes to be a successful maintainer. Not being the most brilliant developer ever, or spending nights and weekends coding.
 
 The goal of these rules is simple: help your project be more successful. We also suggest you watch this talk by `Jan about building a great community. <https://www.youtube.com/watch?v=UtAoRIKVpW4>`_
 

--- a/developer_manual/digging_deeper/snowflake_ids.rst
+++ b/developer_manual/digging_deeper/snowflake_ids.rst
@@ -98,7 +98,7 @@ It’s also possible to decode IDs in your code, for example to get the creation
 
     namespace OCA\MyApp;
 
-    use DateTimeImmutable
+    use DateTimeImmutable;
     use OCP\Snowflake\IDecoder;
 
     class MyObject {

--- a/developer_manual/prologue/bugtracker/triaging.rst
+++ b/developer_manual/prologue/bugtracker/triaging.rst
@@ -24,7 +24,7 @@ The process of checking, reproducing and closing invalid issues is called ‘bug
 2. Incomplete or duplicate bug reports or feature requests
 3. Irrelevant or wrong bug reports or feature requests
 
-The job of a bug triager is to identify the One’s for developers to look at, help remove, merge or improve any Two to a One and dismiss Three’s in a friendly and emphatic way.
+The job of a bug triager is to identify Category 1 issues for developers to look at, help remove, merge or improve any Category 2 issue to a Category 1, and dismiss Category 3 issues in a friendly and emphatic way.
 
 Triaging follows these steps:
 

--- a/user_manual/desktop/faq.rst
+++ b/user_manual/desktop/faq.rst
@@ -4,7 +4,7 @@ FAQ
 
 How the "Edit locally" functionality works
 ------------------------------------------
-This functionality depends on the desktop client ability to register the mime to handle the nc:// scheme. That is the handler used by the server to open a file locally. This will allow the desktop client to open a document with the local editor when you click on the option "Edit locally" in your Nextcloud instance. 
+This functionality depends on the desktop client ability to register the nc:// protocol handler. That is the handler used by the server to open a file locally. This will allow the desktop client to open a document with the local editor when you click on the option "Edit locally" in your Nextcloud instance. 
 
 .. note:: 
    Without properly registering the mime, independent of the browser and distro being used, the desktop client will fail to open a document with the local editor when you click on the option "Edit locally" in your Nextcloud instance.
@@ -24,9 +24,9 @@ We use AppImage due to its universal compatibility but to take full advantage of
 On Windows
 ^^^^^^^^^^
 
-The MSI installer will alter your system registry to register the mime to handle the nc:// scheme. 
+The MSI installer will alter your system registry to register the nc:// protocol handler. 
 
-Alternatively, you can manually register the mime to handle the nc:// scheme:
+Alternatively, you can manually register the nc:// protocol handler:
 
 1. Save the following content to a .reg file:
 

--- a/user_manual/files/access_webgui.rst
+++ b/user_manual/files/access_webgui.rst
@@ -98,7 +98,7 @@ Navigating inside your Nextcloud
 
 Navigating through folders in Nextcloud is as simple as clicking on a folder to
 open it and using the back button on your browser to move to a previous level.
-Nextcloud also provides a navigation bar at the top of the Files field for quick
+Nextcloud also provides a navigation bar at the top of the Files page for quick
 navigation.
 
 Sharing status icons

--- a/user_manual/groupware/contacts.rst
+++ b/user_manual/groupware/contacts.rst
@@ -7,7 +7,7 @@ be installed separately from our App Store.
 
 The Nextcloud Contacts app is similar to other mobile contact applications, but
 with more functionality.
-Let's run through basic features that will help you maintain your address book
+This section covers the basic features that will help you maintain your address book
 in the application.
 
 Below, you will learn how to add contacts, edit or remove contacts, upload a

--- a/user_manual/talk/open_conversations.rst
+++ b/user_manual/talk/open_conversations.rst
@@ -13,7 +13,7 @@ You can create an open conversation that any registered user on this server can 
 View all open conversations
 ---------------------------
 
-You can view all the conversations that you can join by clicking the button next to the search field and filters button and then on ``Join open conversations.``
+You can view all the conversations that you can join by clicking the button next to the search field, then clicking ``Join open conversations``.
 
 .. image:: images/join-open-conversations.png
     :width: 400px


### PR DESCRIPTION
Thirteen targeted LOW-severity fixes across user, admin, and developer manuals.                                                                                                             
                                                                                                                                                                                              
  **User manual:**                                                                                                                                                                            
  - `files/access_webgui` — "Files field" → "Files page"                                                                                                                                      
  - `talk/open_conversations` — remove double "button" in join flow description
  - `groupware/contacts` — replace informal "Let's run through" opener                                                                                                                        
  - `desktop/faq` — fix incorrect MIME terminology: "register the mime to handle the nc:// scheme" → "register the nc:// protocol handler" (3 occurrences)                                    
                                                                                                                                                                                              
  **Admin manual:**                                                                                                                                                                           
  - `maintenance/manual_upgrade` — "after a upgrade" → "after an upgrade"                                                                                                                     
  - `maintenance/migrating_owncloud` — "close enough database and code-wise" → "sufficiently compatible in database schema and codebase"                                                      
  - `configuration_server/language_configuration` — split dense single-sentence note into two cleaner lines                             
  - `configuration_files/external_storage/openstack` — "Openstack" → "OpenStack" in image alt text (2 occurrences)                                                                            
  - `ai/app_assistant` — remove spurious double asterisk (`* *`) from list items (3 occurrences)                                                                                              
                                                                                                                                                                                              
  **Developer manual:**                                                                                                                                                                       
  - `app_development/info` — "A full blown example" → "A comprehensive example"                                                                                                               
  - `prologue/bugtracker/triaging` — replace awkward "the One's for developers" with explicit Category 1/2/3 references                                                                       
  - `digging_deeper/snowflake_ids` — add missing semicolon to `use DateTimeImmutable`                                                                                                         
  - `app_publishing_maintenance/publishing` — replace mid-paragraph exclamation mark with period   

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
