### PR TITLE
feat: Document oauth2 setting 'skipAuthPickerApplications'

### DIFF
--- a/admin_manual/configuration_server/oauth2.rst
+++ b/admin_manual/configuration_server/oauth2.rst
@@ -41,3 +41,11 @@ Security considerations
 Nextcloud ``OAuth2`` implementation currently does not support scoped access. This means that every token has full access to the complete account including read and write permission to the stored files. It is essential to store the ``OAuth2`` tokens in a safe way! 
 
 Without scopes and restrictable access it is not recommended to use a Nextcloud instance as a user authentication service.
+
+Skipping pre-login warning
+--------------------------
+
+In Nextcloud default ``OAuth2`` flow, a confirmation step is shown before login if the user is not yet logged-in, and a second one is shown after login.
+To skip the pre-login one for a trusted application, the configuration option ``skipAuthPickerApplications`` can be set through occ::
+
+ sudo -E -u www-data php occ config:app:set oauth2 skipAuthPickerApplications --type array --value '["myapplication"]'


### PR DESCRIPTION
### ☑️ Resolves

* Document https://github.com/nextcloud/server/pull/49670

### 🖼️ Screenshots

<img width="893" height="346" alt="Copie d&#39;écran_20260505_094751" src="https://github.com/user-attachments/assets/9de0276b-78c9-4af1-9470-1a1c6e676813" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
