### PR TITLE
fix(user_manual): add summary sentence to collectives index page

### DIFF
--- a/user_manual/collectives/index.rst
+++ b/user_manual/collectives/index.rst
@@ -2,6 +2,9 @@
 Collectives
 ===========
 
+Your space to collaboratively write and organize. Collectives is designed for groups and communities
+to structure shared knowledge.
+
 .. toctree::
    :maxdepth: 1
 

--- a/user_manual/collectives/markdown_files.rst
+++ b/user_manual/collectives/markdown_files.rst
@@ -1,6 +1,6 @@
-==============
-Markdown files
-==============
+=====================
+Access Markdown files
+=====================
 
 The pages of your collectives are stored in Markdown files. You can access them via the Files app.
 Per default, the folder is hidden as it's called ``.Collectives`` (or a translated version of it).


### PR DESCRIPTION
### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
