### PR TITLE
fix(developer): typo in TaskProcessing provider documentation

### DIFF
--- a/developer_manual/digging_deeper/task_processing.rst
+++ b/developer_manual/digging_deeper/task_processing.rst
@@ -330,7 +330,7 @@ The corresponding ``MyPromptResultListener`` class can look like:
 Implementing a TaskProcessing provider
 --------------------------------------
 
-A **Task processing provider** will usually be a class that implements the interface ``OCP\TaskProcessing\ISynchrounousProvider``.
+A **Task processing provider** will usually be a class that implements the interface ``OCP\TaskProcessing\ISynchronousProvider``.
 
 .. code-block:: php
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/documentation/issues/14024

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
