### PR TITLE
Improve default_language configuration parameter description

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -494,8 +494,8 @@ default_language
 This sets the default language on your Nextcloud server, using ISO_639-1
 language codes such as ``en`` for English, ``de`` for German, and ``fr`` for
 French. The default_language parameter is only used when the browser does
-not send any language, and the user hasn’t configured their own language
-preferences.
+not send any language preferences, and the user hasn’t configured their own
+either.
 
 Nextcloud has two distinguished language codes for German, ``de`` and ``de_DE``.
 ``de`` is used for informal German and ``de_DE`` for formal German. By setting

--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -362,8 +362,9 @@ dbhost
 
 	'dbhost' => '',
 
-Your host server name, for example ``localhost``, ``hostname``,
-``hostname.example.com``, or the IP address.
+The host server name/address for Nextcloud to connect to the database service,
+for example, ``localhost``, ``hostname``, ``hostname.example.com``, or the
+IP address.
 
 To specify a port, use ``hostname:####``; for IPv6 addresses, use the URI notation ``[ip]:port``.
 To specify a Unix socket, use ``localhost:/path/to/directory/containing/socket`` or


### PR DESCRIPTION
## Summary
Improves the description text of the `default_language` configuration parameter in the admin guide.

## Changes
Changed the description from:
> The default_language parameter is only used when the browser does not send any language, and the user hasn't configured their own language preferences.

to:
> The default_language parameter is only used when the browser does not send any language preferences, and the user hasn't configured their own either.

This improves clarity and wording consistency by:
- Clarifying "any language" → "any language preferences"
- Simplifying "and the user hasn't configured their own language preferences" → "and the user hasn't configured their own either"

## Fixes
Resolves #13652