### PR TITLE
Improve dbhost configuration parameter description

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -362,8 +362,9 @@ dbhost
 
 	'dbhost' => '',
 
-Your host server name, for example ``localhost``, ``hostname``,
-``hostname.example.com``, or the IP address.
+The host server name/address for Nextcloud to connect to the database service,
+for example, ``localhost``, ``hostname``, ``hostname.example.com``, or the
+IP address.
 
 To specify a port, use ``hostname:####``; for IPv6 addresses, use the URI notation ``[ip]:port``.
 To specify a Unix socket, use ``localhost:/path/to/directory/containing/socket`` or


### PR DESCRIPTION
## Summary
Improves the description text of the `dbhost` configuration parameter in the admin guide for clarity.

## Changes
Changed the description from:
> Your host server name, for example `localhost`, `hostname`, `hostname.example.com`, or the IP address.

to:
> The host server name/address for Nextcloud to connect to the database service, for example, `localhost`, `hostname`, `hostname.example.com`, or the IP address.

This improves clarity by explicitly stating:
- What `dbhost` is used for (connecting to the database service)
- The type of value (server name/address, not just "host server name")

## Fixes
Resolves #13650