### PR TITLE
Add guidance about optional services in migration guide

### DIFF
--- a/admin_manual/maintenance/migrating.rst
+++ b/admin_manual/maintenance/migrating.rst
@@ -37,6 +37,20 @@ the new location. It is also assumed that the authentication method
     your original machine was installed recently just copying that base
     configuration is a safe best practice.
 
+    .. important:: Before beginning the migration, **check the ``config/config.php`` file
+       on your ORIGINAL system** to identify any optional services that are configured,
+       such as:
+
+       * Redis or Memcached (for caching/sessions)
+       * External object storage (S3, etc.)
+       * LDAP
+       * Mail server settings
+       * Full-text search backends (Elasticsearch, etc.)
+
+       **You must also install and configure these same services on the NEW machine
+       before copying the Nextcloud files.** Failure to do so may cause errors such
+       as "Redis server went away" or connection failures during Nextcloud startup.
+
 
 #.  On the original machine then stop Nextcloud. First activate the
     maintenance mode. After waiting for 6-7 minutes for all sync clients to


### PR DESCRIPTION
## Summary
Adds explicit guidance about optional services in the migration guide to prevent migration failures.

## Problem
When migrating Nextcloud to a new server, users often encounter errors like "Redis server went away" because they fail to configure optional services (Redis, Memcached, etc.) on the new machine before completing the migration. The current migration guide makes no mention of these dependencies.

## Solution
Added an "important" notice in Step 1 of the migration guide that instructs users to:
1. Check the original system's `config/config.php` for optional services
2. Identify commonly configured services (Redis, Memcached, external storage, etc.)
3. Install and configure these same services on the new machine BEFORE copying Nextcloud files

## Changes
- Updated [admin_manual/maintenance/migrating.rst](admin_manual/maintenance/migrating.rst)
- Added explicit list of services to check for (Redis, Memcached, external storage, LDAP, mail, search backends)
- Emphasized the critical timing: services must be configured before startup

## Relates to
#14036