### PR TITLE
Document required Apache modules for PHP-FPM setup

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -106,12 +106,20 @@ command to enable the configuration::
 Additional Apache configurations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+**Required modules:**
+
 * For Nextcloud to work correctly, we need the module ``mod_rewrite``. Enable
   it by running::
 
     a2enmod rewrite
 
-  Additional recommended modules are ``mod_headers``, ``mod_env``, ``mod_dir`` and ``mod_mime``::
+* If you're using ``mod_fcgi`` or ``php-fpm`` (PHP FastCGI Process Manager),
+  you must enable the proxy modules::
+
+    a2enmod proxy
+    a2enmod proxy_fcgi
+
+**Recommended modules** are ``mod_headers``, ``mod_env``, ``mod_dir`` and ``mod_mime``::
 
     a2enmod headers
     a2enmod env
@@ -129,6 +137,17 @@ Additional Apache configurations
     <FilesMatch remote.php>
       SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
     </FilesMatch>
+
+**Verifying modules are enabled:**
+
+  To verify that required modules are enabled, use the ``apache2ctl`` command::
+
+    apache2ctl -M | grep -E "rewrite|proxy|proxy_fcgi"
+
+  If you see matching output for the modules you've enabled, they are active.
+  If any required module is missing, troubleshoot your OS package manager to
+  ensure the Apache modules are installed (package names may vary by distribution;
+  for example, on Debian/Ubuntu look for ``libapache2-mod-fcgid`` or similar).
 
 * You must disable any server-configured authentication for Nextcloud, as it
   uses Basic authentication internally for DAV services. If you have turned on


### PR DESCRIPTION
## Summary
Adds explicit documentation about required Apache modules when using PHP-FPM with Nextcloud.

## Problem
The Apache configuration guide doesn't clearly document that `proxy_module` and `proxy_fcgi_module` are required when using php-fpm instead of mod_php. This causes confusion for users on distributions like Raspberry Pi OS, where these modules may not be enabled by default. Users encounter connection or configuration errors without understanding what modules are missing.

## Solution
1. Reorganized the "Additional Apache configurations" section to clearly separate **required** modules from **recommended** modules
2. Explicitly listed `proxy_module` and `proxy_fcgi_module` as required for php-fpm setups with `a2enmod` commands
3. Added `apache2ctl -M` verification command and troubleshooting guidance
4. Included note about distribution-specific package names

## Changes
- Updated [admin_manual/installation/source_installation.rst](admin_manual/installation/source_installation.rst)
- Reorganized module section for clarity
- Added verification command and troubleshooting steps
- Added guidance for cross-platform module availability

## Relates to
#14036