### PR TITLE
feat(antivirus): extend documentation on ClamAV limitations with encrypted files

### DIFF
--- a/admin_manual/configuration_server/antivirus_configuration.rst
+++ b/admin_manual/configuration_server/antivirus_configuration.rst
@@ -178,6 +178,19 @@ https://www.eicar.org/download-anti-malware-testfile/
 Uploading the file will trigger an error:
    "Virus Win.Test.EICAR_HDB-1 is detected in the file. Upload cannot be completed."
 
+Encrypted File Detection Limitations with ClamAV
+------------------------------------------------
+
+By default, ClamAV may still return "OK" for password-protected archives and encrypted files.
+This known ClamAV behavior bypasses "Block unscannable files" option of Antivirus app.
+You may configure additional alert options in ``clamd.conf``, that should catch it:
+
+* ``AlertEncryptedArchive`` - Alert on encrypted archives with heuristic signature (encrypted .zip, .7zip, .rar).
+* ``AlertEncryptedDoc`` - Alert on encrypted archives with heuristic signature (encrypted .pdf).
+* ``AlertEncrypted`` - Alert on both encrypted archives and documents with heuristic signature.
+
+For reliable detection and blocking of encrypted files, consult available antivirus backends documentation.
+
 Manage the background scanner
 -----------------------------
 


### PR DESCRIPTION
### ☑️ Resolves

* Document identified issue with ClamAV antivirus: it doesn't alert on encrypted and password-protected files by default

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
