### PR TITLE
fix(a11y): improve contrast of version label in sidebar

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -53,7 +53,9 @@ h6 {
 .rst-versions .rst-current-version {
 	display: flex;
 	align-items: center;
-	color: #0082c9;
+	/* Use white instead of #0082c9 — the NC blue at 3.7:1 on the dark
+	   #272525 sidebar background fails WCAG AA (4.5:1 required). */
+	color: #fff;
 }
 .rst-versions .rst-current-version .fa-caret-down {
 	margin-left: 5px;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9676

### 🖼️ Screenshots


| Before | After |
|:---------:|:------:|
|<img width="378" height="293" alt="image" src="https://github.com/user-attachments/assets/7281693d-f0b5-40c4-b162-35998c4b2034" />|<img width="378" height="293" alt="image" src="https://github.com/user-attachments/assets/306ca833-f9c8-49b9-815b-2b4ceb55ce2d" />|

## Explanations


The "Nextcloud" prefix and version string in the bottom-left sidebar version panel use `#0082c9` (Nextcloud blue) on the dark `#272525` RTD background, giving a contrast ratio of ~3.7:1. WCAG AA / BITV 9.1.4.3 requires 4.5:1 for normal-weight text.

Changing the color to `#fff` brings the ratio to ~15:1.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues