### PR TITLE
fix(a11y): fix contrast of inline code text

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -65,6 +65,14 @@ h6 {
 	background: rgba(0, 130, 201, 0.1)
 }
 
+/* Inline code — RTD uses #e74c3c on white which gives ~3.82:1, below
+   the 4.5:1 required by WCAG AA / BITV 9.1.4.3. Use a darker shade. */
+.rst-content code,
+.rst-content tt,
+code {
+	color: #c0392b;
+}
+
 /* Fix code within tables - remove too big margins */
 .rst-content td {
 	div[class^="highlight"]:last-of-type,

--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -70,7 +70,7 @@ h6 {
 .rst-content code,
 .rst-content tt,
 code {
-	color: #c0392b;
+	color: #c0392b !important;
 }
 
 /* Fix code within tables - remove too big margins */


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9677

### 🖼️ Screenshots

| Before | After |
|:---------:|:------:|
|<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/11e9eb63-dc65-4df3-af4e-57fcce24705b" />|<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/112bbc87-1c2a-436a-89df-e230688a4adf" />|

RTD theme styles inline `<code>` elements with `color: #e74c3c` on a white background, giving a contrast ratio of ~3.82:1. WCAG AA / BITV 9.1.4.3 requires 4.5:1.

Overriding to `#c0392b` (a darker red) brings the ratio to ~5.4:1 while keeping the same visual style.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues