### PR TITLE
fix(a11y): fix contrast ratio of content links

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -17,6 +17,14 @@ h6 {
 	background-color: #0082c9;
 }
 
+/* Content links — RTD default #2980b9 gives ~4.3:1 against white,
+   below the 4.5:1 required by WCAG AA / BITV 9.1.4.1 and 9.1.4.3.
+   #2474a4 yields ~5.1:1 while keeping the same blue visual style. */
+.rst-content a,
+.rst-content a:visited {
+	color: #2474a4;
+}
+
 /* Reduce size of logo in top left */
 .wy-side-nav-search > a img.logo {
 	max-width: 180px;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9674

### 🖼️ Screenshots

:warning: the diff is very subtle

| Before | After |
|:---------:|:------:|
|<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/33032b35-80c5-4598-9ed3-065d53e56747" />|<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/19c8636f-0246-412c-8788-dc5f177b85a7" />|

RTD theme defaults to `#2980b9` for links, yielding ~4.3:1 against a white content background. WCAG AA / BITV 9.1.4.3 requires 4.5:1.

Overriding to `#2474a4` in the content area brings the ratio to ~5.1:1. The override is scoped to `.rst-content` so sidebar and header links (which sit on colored backgrounds) are not affected.

cc @nextcloud/a11y 

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues