### PR TITLE
fix(a11y): underline content links to avoid color-only differentiation

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -17,6 +17,14 @@ h6 {
 	background-color: #0082c9;
 }
 
+/* Links in the content area must be distinguishable from body text
+   without relying on color alone (WCAG 1.4.1 / BITV 9.1.4.1).
+   RTD theme sets text-decoration: none, so underline is the simplest
+   non-color indicator that satisfies the requirement. */
+.rst-content a {
+	text-decoration: underline;
+}
+
 /* Reduce size of logo in top left */
 .wy-side-nav-search > a img.logo {
 	max-width: 180px;


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9673

### 🖼️ Screenshots

| Before | After |
|:---------:|:------:|
|<img width="781" height="333" alt="image" src="https://github.com/user-attachments/assets/a9991b76-7406-4a71-99a6-ccc0a3e5f0e1" />|<img width="781" height="333" alt="image" src="https://github.com/user-attachments/assets/8f550376-3e51-42c2-bda3-a818e09ed0c4" />|

## Explanations

RTD theme disables underlines on all links (`text-decoration: none`). In the content body this means links are distinguished from surrounding text purely by color. The contrast ratio between the link blue and body text falls below 3:1, which fails WCAG 1.4.1 / BITV 9.1.4.1 when color is the only differentiator.

Adding `text-decoration: underline` to `.rst-content a` provides a non-color visual cue. When an underline is present, no minimum color contrast between link and text is required by the standard.

cc @nextcloud/a11y, while maybe not the prettiest, it serves is purpose well ? :blush: 

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues