### PR TITLE
fix(a11y): make keyboard focus ring fully visible in navigation

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -122,6 +122,17 @@ div#list-of-available-icons > blockquote > div > div > p {
 	text-align: center;
 }
 
+/* Focus ring — the sidebar nav container clips outline to one edge
+   (only bottom line visible). Use a negative outline-offset to draw
+   the ring inside the element so it is never clipped (BITV 9.2.4.7). */
+.wy-menu-vertical a:focus-visible,
+.wy-menu-vertical button:focus-visible,
+.wy-side-nav-search a:focus-visible,
+.rst-versions .rst-current-version:focus-visible {
+	outline: 2px solid #0082c9;
+	outline-offset: -2px;
+}
+
 .wy-nav-content {
 	max-width: clamp(800px, calc(100vw - 600px), 1200px) !important;
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9701

### 🖼️ Screenshots

| Before | After |
|:---------:|:------:|
|<img width="386" height="293" alt="image" src="https://github.com/user-attachments/assets/fa243311-4a1d-45b8-8cd0-40680e5cd6fa" />|<img width="386" height="293" alt="image" src="https://github.com/user-attachments/assets/41d7c414-cb25-492a-9ecf-d2fa49f2ae29" />|

## Explanations

The sidebar nav container uses `overflow: hidden`, so the default browser outline is clipped to one edge — only the bottom line of the focus ring appears, as visible in the issue screenshot. WCAG 2.4.7 / BITV 9.2.4.7 requires that keyboard focus be clearly visible on all sides.

Setting `outline-offset: -2px` draws the outline inward, inside the element boundary, so it is never clipped. Scoped to sidebar nav links, expand buttons, and the version selector toggle.

cc @nextcloud/a11y 	

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues