### PR TITLE
fix(a11y): make content accessible at 200% browser zoom

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -130,6 +130,22 @@ div#list-of-available-icons > blockquote > div > div > p {
 	max-width: 900px;
 }
 
+/* At 200% browser zoom a 1 280 px display has an effective viewport of
+   ~640 px, which is below the RTD mobile breakpoint (768 px). The
+   clamp() above keeps a hard 800 px minimum that then overflows the
+   viewport horizontally, making the documentation content unreachable
+   without horizontal scrolling (WCAG 1.4.4 / BITV 9.1.4.4).
+   Override to 100% so the content fills the available space. */
+@media screen and (max-width: 768px) {
+	.wy-nav-content {
+		max-width: 100% !important;
+	}
+
+	.wy-nav-content section {
+		max-width: 100%;
+	}
+}
+
 table.docutils {
 	min-width: 50%;
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9678

### 🖼️ Screenshots

At 200% browser zoom a 1280 px display has a CSS viewport of ~640 px, which is below the RTD mobile breakpoint (768 px). RTD collapses the sidebar and switches to a hamburger layout, but the custom `clamp(800px, ...)` rule forces a minimum 800 px width on the content area. On a 640 px viewport that overflows horizontally, making the page content unreachable without horizontal scrolling — violating WCAG 1.4.4 / BITV 9.1.4.4.

Adding a `@media (max-width: 768px)` override resets the width to `100%` so content fills the available viewport in the mobile/zoomed layout.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues