### PR TITLE
fix(a11y): use <button> with aria-expanded for the version toggle

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -69,6 +69,12 @@ button.rst-current-version {
 }
 .rst-versions .rst-current-version .fa-caret-down {
 	margin-left: 5px;
+.rst-versions .rst-current-version .fa-caret-down {
+	margin-left: 5px;
+}
+
+.rst-versions .rst-current-version .fa-caret-down:not(:last-of-type) {
+	margin-right: 10px;
 }
 
 /* Code blocks */

--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -46,6 +46,18 @@ h6 {
 .rst-versions .rst-current-version .fa-book {
 	display: none;
 }
+
+/* The version toggle is now a <button> element. Reset default button
+   styling so it looks identical to the old <span>. */
+button.rst-current-version {
+	background: none;
+	border: none;
+	padding: 12px;
+	font-family: inherit;
+	font-size: 90%;
+	width: 100%;
+	cursor: pointer;
+}
 .rst-versions .rst-current-version:before {
 	content: 'Nextcloud';
 	margin-right: auto;

--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -69,8 +69,6 @@ button.rst-current-version {
 }
 .rst-versions .rst-current-version .fa-caret-down {
 	margin-left: 5px;
-.rst-versions .rst-current-version .fa-caret-down {
-	margin-left: 5px;
 }
 
 .rst-versions .rst-current-version .fa-caret-down:not(:last-of-type) {

--- a/admin_manual/_templates/versions.html
+++ b/admin_manual/_templates/versions.html
@@ -1,11 +1,18 @@
 {% if READTHEDOCS %}
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
-    <span class="rst-current-version" data-toggle="rst-current-version">
+    {# Use <button> so the toggle has native keyboard semantics and can
+       carry aria-expanded. The RTD theme JS uses [data-toggle] selectors
+       so the element type does not matter for the toggle behaviour. #}
+    <button type="button"
+            class="rst-current-version"
+            data-toggle="rst-current-version"
+            aria-expanded="false"
+            aria-controls="rst-other-versions-admin">
       ☁️ {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
+      <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </button>
+    <div id="rst-other-versions-admin" class="rst-other-versions">
       <dl>
         <dt>☁️ {{ _('Versions') }}</dt>
         {% for slug, url in versions|reverse %}
@@ -22,4 +29,15 @@
       </dl>
     </div>
   </div>
+  <script>
+    /* Keep aria-expanded in sync with the RTD theme toggle class. */
+    (function () {
+      var btn = document.querySelector('.rst-current-version[aria-expanded]');
+      if (!btn) return;
+      btn.addEventListener('click', function () {
+        var expanded = this.getAttribute('aria-expanded') === 'true';
+        this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      });
+    }());
+  </script>
 {% endif %}

--- a/developer_manual/_templates/versions.html
+++ b/developer_manual/_templates/versions.html
@@ -1,11 +1,18 @@
 {% if READTHEDOCS %}
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
-    <span class="rst-current-version" data-toggle="rst-current-version">
+    {# Use <button> so the toggle has native keyboard semantics and can
+       carry aria-expanded. The RTD theme JS uses [data-toggle] selectors
+       so the element type does not matter for the toggle behaviour. #}
+    <button type="button"
+            class="rst-current-version"
+            data-toggle="rst-current-version"
+            aria-expanded="false"
+            aria-controls="rst-other-versions-dev">
       ☁️ {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
+      <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </button>
+    <div id="rst-other-versions-dev" class="rst-other-versions">
       <dl>
         <dt>☁️ {{ _('Versions') }}</dt>
         {% for slug, url in versions|reverse %}
@@ -22,4 +29,15 @@
       </dl>
     </div>
   </div>
+  <script>
+    /* Keep aria-expanded in sync with the RTD theme toggle class. */
+    (function () {
+      var btn = document.querySelector('.rst-current-version[aria-expanded]');
+      if (!btn) return;
+      btn.addEventListener('click', function () {
+        var expanded = this.getAttribute('aria-expanded') === 'true';
+        this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      });
+    }());
+  </script>
 {% endif %}

--- a/user_manual/_templates/versions.html
+++ b/user_manual/_templates/versions.html
@@ -58,13 +58,20 @@
   {% set sorted_languages = language_tuples | sort(attribute='name') %}
 
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
-    <span class="rst-current-version" data-toggle="rst-current-version">
+    {# Use <button> so the toggle has native keyboard semantics and can
+       carry aria-expanded. The RTD theme JS uses [data-toggle] selectors
+       so the element type does not matter for the toggle behaviour. #}
+    <button type="button"
+            class="rst-current-version"
+            data-toggle="rst-current-version"
+            aria-expanded="false"
+            aria-controls="rst-other-versions-user">
       🌐 {{ language_names.get(language, language) }}
-      <span class="fa fa-caret-down"></span>
-       ☁️ {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
+      <span class="fa fa-caret-down" aria-hidden="true"></span>
+       ☁️ {{ current_version }}
+      <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </button>
+    <div id="rst-other-versions-user" class="rst-other-versions">
       <dl>
         <dt>🌐 {{ _('Languages') }}</dt>
         {% for lang in sorted_languages %}
@@ -97,4 +104,15 @@
       </dl>
     </div>
   </div>
+  <script>
+    /* Keep aria-expanded in sync with the RTD theme toggle class. */
+    (function () {
+      var btn = document.querySelector('.rst-current-version[aria-expanded]');
+      if (!btn) return;
+      btn.addEventListener('click', function () {
+        var expanded = this.getAttribute('aria-expanded') === 'true';
+        this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      });
+    }());
+  </script>
 {% endif %}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9747

### 🖼️ Screenshots

| Before | After |
|:---------:|:------:|
|<img width="627" height="555" alt="image" src="https://github.com/user-attachments/assets/8c44f321-2cc8-440d-a091-d65d76f46c5d" />|<img width="627" height="555" alt="image" src="https://github.com/user-attachments/assets/d9568f4d-12cd-4515-85aa-126345e44663" />|

### Explanations 

The version selector used a `<span>` as an interactive control. Spans have no implicit ARIA role, no native keyboard focus semantics, and cannot carry an `aria-expanded` state — failing WCAG 4.1.2 / BITV 9.4.1.2.

Changes in all three manual version templates (`user_manual`, `developer_manual`, `admin_manual`):
- `<span class="rst-current-version">` replaced with `<button type="button">`. The RTD theme JS uses `[data-toggle]` attribute selectors, so the element type change does not break the toggle.
- `aria-expanded="false"` added to the button; a small inline script mirrors the RTD toggle-class event to keep the attribute in sync.
- `aria-controls` links the button to its dropdown panel.
- Decorative caret `<span>` icons get `aria-hidden="true"`.
- CSS reset added to `custom.css` so the button looks identical to the previous span.

cc @nextcloud/a11y 

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues