### PR TITLE
fix(a11y): add missing alt text to Talk and KDE sync images

### DIFF
--- a/user_manual/groupware/sync_kde.rst
+++ b/user_manual/groupware/sync_kde.rst
@@ -11,50 +11,64 @@ In KOrganizer:
 1. Open KOrganizer and in the calendar list (bottom left) right-click and choose ``Add Calendar``:
 
 .. image:: ../images/KOrganizer_add_calendar.png
+   :alt: KOrganizer calendar list context menu with Add option
 
 2. In the resulting list of resources, pick ``DAV groupware resource``:
 
 .. image:: ../images/korganizer_resource_choice.png
+   :alt: KOrganizer resource type list with DAV groupware resource selected
 
 In Kalendar:
 
 1. Open Kalendar and in the menu bar open the setting and then choose ``Calendar Sources`` -> ``Add Calendar``:
 
 .. image:: ../images/Kalendar_add_calendar.png
+   :alt: Kalendar settings menu showing Add Calendar option
 
 2. In the resulting list of resources, pick ``DAV groupware resource``:
 
 .. image:: ../images/kalendar_resource_choice.png
+   :alt: Kalendar resource selection dialog with DAV groupware resource option
 
 In KOrganizer and Kalendar:
 
 3. Enter your username. As password, you need to generate an app-password/token (:ref:`Learn more <managing_devices>`):
 
 .. image:: ../images/korganizer_credentials.png
+   :alt: KOrganizer credentials dialog for entering username and app password
 
 4. Choose ``Nextcloud`` as Groupware server option:
 
 .. image:: ../images/KOrganizer_groupware_server.png
+   :alt: KOrganizer groupware server selection showing Nextcloud option
 
 5. Enter your Nextcloud server URL and, if needed, installation path (anything that comes after the first /, for example ``mynextcloud`` in ``https://example.com/mynextcloud``). Then click next:
 
 .. image:: ../images/KOrganizer_server_address.png
+   :alt: KOrganizer server URL configuration dialog
 
 6. You can now test the connection, which can take some time for the initial connection. If it does not work, you can go back and try to fix it with other settings:
 
 .. image:: ../images/KOrganizer_test1.png
+   :alt: KOrganizer connection test in progress
 
 .. image:: ../images/KOrganizer_test2.png
+   :alt: KOrganizer successful connection test result
 
 7. Pick a name for this resource, for example ``Work`` or ``Home``. By default, both CalDAV (Calendar) and CardDAV (Contacts) are synced:
 
 .. image:: ../images/KOrganizer_pick_resources.png
+   :alt: KOrganizer resource naming and calendar selection dialog
 
 .. note:: You can set a manual refresh rate for your calendar and contacts resources. By default this setting is set to 5 minutes and should be fine for the most use cases. When you create a new appointment it is synced to Nextcloud right away. You may want to change this for saving your power or cellular data plan, so that you can update with a right-click on the item in the calendar list.
 
 8. After a few seconds to minutes depending on your internet connection, you will find your calendars and contacts inside the KDE Kontact applications KOrganizer, Kalendar and KAddressBook as well as Plasma calendar applet:
 
 .. image:: ../images/KOrganizer.png
+   :alt: KOrganizer calendar application showing synchronized Nextcloud events
 .. image:: ../images/KDEPlasma.png
+   :alt: KDE Plasma desktop with Nextcloud calendar events in the system calendar widget
 .. image:: ../images/kalendar_month_view.png
+   :alt: Kalendar month view showing synchronized Nextcloud calendar events
 .. image:: ../images/KAddressBook.png
+   :alt: KAddressBook contacts application showing synchronized Nextcloud contacts

--- a/user_manual/talk/appearance.rst
+++ b/user_manual/talk/appearance.rst
@@ -8,6 +8,7 @@ Compact view of conversations list
 Compact view hides last message preview in the conversation list, providing a more focused interface.
 
 .. image:: images/talk-compact-view.png
+   :alt: Talk conversation list in compact view without message previews
    :width: 200px
 
 Chat messages
@@ -19,4 +20,5 @@ You can choose between classic list or message bubbles, with your own messages o
 You can change both settings from the ``Talk settings`` dialog in the ``Appearance`` section.
 
 .. image:: images/talk-appearance-settings.png
+   :alt: Talk settings dialog showing compact view and other appearance options
    :width: 600px

--- a/user_manual/talk/attachments.rst
+++ b/user_manual/talk/attachments.rst
@@ -10,24 +10,29 @@ You can share files in a chat in three ways.
 First, you can simply drag'n'drop them on the chat.
 
 .. image:: images/drag-and-drop.png
+   :alt: Talk chat with a file being dragged and dropped to share
    :width: 600px
 
 Second, you can select a file from your Nextcloud Files or a file manager by choosing the little paperclip and selecting where you'd like to pick the file from.
 
 .. image:: images/share-files-in-chat.png
+   :alt: Talk file selection dialog for sharing from Nextcloud Files
    :width: 500px
 
 .. image:: images/share-files-in-chat-selection.png
+    :alt: Talk file selection panel showing available files to share in chat
     :width: 600px
 
 You can add more files until you are done and decide to share the files. You can also add a text caption to your shared files, providing a brief description or context.
 
 .. image:: images/talk-upload-files.png
+   :alt: Talk file upload queue before sending files in chat
    :width: 500px
 
 All users will be able to click the files to view, edit or download them, regardless of whether they have a Nextcloud account. Users with an account will have the file automatically shared with them while external guest users will get them shared as a public link.
 
 .. image:: images/editing-document-in-chat-room.png
+   :alt: Talk chat with a shared document that participants can open and edit
    :width: 600px
 
 Polls in chat
@@ -36,6 +41,7 @@ Polls in chat
 You can create a poll in groups chats from the new message additional actions.
 
 .. image:: images/create-new-poll.png
+   :alt: Talk poll creation form in a group chat
    :width: 400px
 
 A poll has two settings:
@@ -46,21 +52,25 @@ A poll has two settings:
 You can also import polls for auto-fill and export polls as JSON files to save them locally.
 
 .. image:: images/import-poll.png
+   :alt: Talk poll import option for loading poll questions from a file
    :width: 400px
 
 You can close a poll from the poll dialog.
 
 .. image:: images/close-poll.png
+   :alt: Talk poll dialog with option to close voting
    :width: 400px
 
 As a moderator, you can create the poll directly or you can save it as a draft to edit it later.
 
 .. image:: images/save-poll-draft.png
+   :alt: Talk poll creation form with save as draft option
    :width: 400px
 
 You can find poll drafts in ``Shared items`` tab or next to the poll title input field.
 
 .. image:: images/poll-drafts-list.png
+   :alt: Talk shared items tab showing saved poll drafts
    :width: 400px
 
 

--- a/user_manual/talk/bots.rst
+++ b/user_manual/talk/bots.rst
@@ -29,4 +29,5 @@ Administrators can configure, enable and disable commands. Users can use the ``h
     ``/help``
 
 .. image:: images/command-help.png
+    :alt: Talk chat showing the /help command output listing available bot commands
     :width: 600px

--- a/user_manual/talk/breakout_rooms.rst
+++ b/user_manual/talk/breakout_rooms.rst
@@ -13,6 +13,7 @@ Configure breakout rooms
 To create breakout rooms, you need to be a moderator in a group conversation. Click on the top-bar menu and click on ``Setup breakout rooms``.
 
 .. image:: images/talk-breakout-rooms-setup.png
+    :alt: Talk Breakout rooms setup button in conversation controls
     :width: 400px
 
 A dialog will open where you can specify the number of rooms you want to create and the participants assignment method.
@@ -23,6 +24,7 @@ You have three options:
 - **Allow participants to choose**: Participants will be able to join breakout rooms themselves.
 
 .. image:: images/talk-breakout-rooms-setup-dialog.png
+    :alt: Talk breakout rooms configuration dialog showing participant assignment options
     :width: 500px
 
 Manage breakout rooms
@@ -31,6 +33,7 @@ Manage breakout rooms
 Once the breakout rooms are created, you will be able to see them in the sidebar.
 
 .. image:: images/talk-breakout-rooms-sidebar.png
+    :alt: Talk sidebar showing created breakout rooms
     :width: 500px
 
 From the sidebar header, you can:
@@ -40,12 +43,14 @@ From the sidebar header, you can:
 - **Make changes to the assigned participants**: this will open the participants editor where you can change which participants are assigned to which breakout room. From this dialog it's also possible to delete the breakout rooms.
 
 .. image:: images/talk-breakout-rooms-sidebar-header.png
+    :alt: Talk breakout rooms sidebar header with start and manage options
     :width: 400px
 
 From the breakout room element in the sidebar, you can also join a particular breakout room or send a message to a
 specific room.
 
 .. image:: images/talk-breakout-rooms-sidebar-item.png
+    :alt: Talk individual breakout room entry in the sidebar with join option
     :width: 400px
 
 .. FIXME Ask for assistance, demo "free selection for a user"

--- a/user_manual/talk/calendar_integration.rst
+++ b/user_manual/talk/calendar_integration.rst
@@ -9,12 +9,14 @@ That way you can stay informed about scheduled meetings or activities directly w
 If Calendar app is enabled, you can click on an event to view details.
 
 .. image:: images/events-upcoming.png
+    :alt: Talk conversation showing upcoming calendar events
     :width: 500px
 
 It is possible to schedule a meeting directly from a conversation. In the dialog, you can set meeting details such as title, date, time and description.
 You can also choose to invite all participants including email guests, or select specific ones.
 
 .. image:: images/talk-schedule-meeting.png
+   :alt: Talk conversation with schedule meeting option to invite participants
    :width: 500px
 
 Schedule from Calendar
@@ -23,11 +25,13 @@ Schedule from Calendar
 When creating a new event in Calendar, you can set a Talk conversation as event location. This will create a new conversation if one does not exist yet.
 
 .. image:: images/calendar-create-event.png
+   :alt: Nextcloud Calendar new event dialog with Talk conversation link option
    :width: 600px
 
 When the event is created, you will see a link to the conversation in the event details. The conversation will also appear in the list of conversations (discoverable by ``Events`` filter).
 
 .. image:: images/event-conversation-list.png
+   :alt: Nextcloud Calendar event view showing a linked Talk conversation
    :width: 300px
 
 Like instant meetings, event conversations will be automatically deleted after configured period of inactivity (by default 28 days).

--- a/user_manual/talk/call.rst
+++ b/user_manual/talk/call.rst
@@ -12,6 +12,7 @@ When you are part of a conversation and have permission to do so, you can start 
 When a call is already in progress, join it by clicking the green ``Join call`` button in the chat area or the top bar.
 
 .. image:: images/join-call.png
+    :alt: Talk conversation with a green Join call button
     :width: 600px
 
 .. note:: If you have not yet given permission to the browser or the Talk Desktop client to use your microphone and camera,
@@ -21,6 +22,7 @@ When a call is already in progress, join it by clicking the green ``Join call`` 
 You will see ``Media settings``, where you can customise your call experience:
 
 .. image:: images/calls/media-settings-initial.png
+    :alt: Talk media settings dialog before joining a call
     :width: 600px
 
 Controlling audio and video
@@ -35,6 +37,7 @@ Use the microphone and camera icons at the bottom of the video preview to mute o
 Device settings allow you to choose which microphone and camera you want to use. This is useful if you have more than one microphone or camera available:
 
 .. image:: images/calls/media-settings-devices.png
+    :alt: Talk media settings showing microphone and camera device selection
     :width: 400px
 
 Backgrounds
@@ -45,6 +48,7 @@ You can also upload your own image or choose one already in Nextcloud Files.
 Alternatively, choose the ``blur`` option to blur your live video background.
 
 .. image:: images/calls/media-settings-backgrounds.png
+    :alt: Talk media settings showing virtual background and blur options for video
     :width: 400px
 
 Immediately join a call
@@ -70,9 +74,11 @@ If you do not want to notify the other participants, start a silent call by open
 and choosing ``Call without notification``.
 
 .. image:: images/calls/media-settings-silent-call.png
+    :alt: Talk Call without notification option in media settings
     :width: 400px
 
 .. image:: images/calls/media-settings-silent-call-2.png
+    :alt: Talk confirmation step for calling without sending a notification
     :width: 400px
 
 .. note:: Other participants can modify notifications on a per-conversation level, including whether they want to receive call notifications.
@@ -103,6 +109,7 @@ During a call
 After you join a call, you will see the call view. It shows the video feeds of all participants currently in the call, with additional information and controls.
 
 .. image:: images/calls/during-a-call-details.png
+    :alt: Talk active call view showing participant video feeds
     :width: 400px
 
 The leftmost element shows the elapsed call time.
@@ -114,11 +121,13 @@ Participants that have joined the call will be listed first.
 You will also see each participant's talking time if they have spoken during the call:
 
 .. image:: images/calls/participant-talk-time.png
+    :alt: Talk active call showing talking time indicator for each participant
     :width: 400px
 
 You can access additional call options and settings from the three-dot menu in the top bar.
 
 .. image:: images/media-settings.png
+    :alt: Talk in-call three-dot menu for additional settings and options
     :width: 300px
 
 Set up breakout rooms
@@ -134,6 +143,7 @@ Download call participants list
 You can download the list of participants in a call from the three-dot menu in the top bar. This downloads a CSV file with the names and email addresses of all participants.
 
 .. image:: images/download-participants-list.png
+   :alt: Talk in-call menu showing download participants list option
    :width: 400px
 
 The CSV file contains the following columns:
@@ -149,6 +159,7 @@ Controlling audio and video
 Bottom bar of the call view offers media controls, layout settings and other features you can use during a call.
 
 .. image:: images/calls/during-a-call-controls.png
+    :alt: Talk active call bottom bar showing media controls and layout settings
     :width: 400px
 
 Use the microphone and camera icons to mute/unmute your microphone and enable/disable your camera.
@@ -161,6 +172,7 @@ Reactions
 The reactions button lets you send an emoji reaction to all participants in the call.
 
 .. image:: images/calls/call-reactions.png
+    :alt: Talk active call reactions panel with emoji options
     :width: 400px
 
 Every participant will see the emoji rising from the bottom of their call screen. The emoji disappears after two seconds.

--- a/user_manual/talk/call_recording.rst
+++ b/user_manual/talk/call_recording.rst
@@ -20,26 +20,31 @@ The moderator of the conversation can start a recording together with a call sta
 - **During the call**: click on the top-bar menu, then click "Start recording".
 
 .. image:: images/start-recording-before-call.png
+    :alt: Talk media settings showing start recording option before joining a call
     :width: 400px
 
 |
 
 .. image:: images/start-recording-in-call.png
+    :alt: Talk in-call top bar menu showing Start recording option
     :width: 300px
 
 The recording will start shortly, and you will see a red indicator next to the call time. You can stop the recording at any time while the call is still ongoing by clicking on that indicator and selecting "Stop recording", or by using the same action in the top-bar menu. If you do not manually stop the recording, it will end automatically when the call ends.
 
 .. image:: images/stop-recording.png
+    :alt: Talk active call with red recording indicator and stop recording option
     :width: 500px
 
 After stopping a recording, the server will take a few seconds to prepare and save the recorded file. The moderator, who started the recording, receives a notification when the file is uploaded. From there, it can be shared in the chat.
 
 .. image:: images/share-recording-notification.png
+    :alt: Talk notification that a call recording is ready to share
     :width: 300px
 
 |
 
 .. image:: images/shared-recordings.png
+    :alt: Talk chat showing a shared call recording file
     :width: 400px
 
 Recording consent
@@ -52,6 +57,7 @@ For compliance with privacy regulations, it is possible to ask participants for 
 - Allow moderators to configure this option on a conversation level. In such cases, moderators can access the conversation settings to configure this option accordingly:
 
 .. image:: images/enable-recording-consent.png
+    :alt: Talk admin settings for enabling recording consent requirement
     :width: 500px
 
 .. FIXME make screenshots below from user perspective not moderator
@@ -60,6 +66,7 @@ If recording consent is enabled, every participant, including moderators, will s
 This section informs participants that the call may be recorded. To give explicit consent for recording, participants must check the box. If they do not give consent, they will not be allowed to join the call.
 
 .. image:: images/give-recording-consent-checked.png
+    :alt: Talk recording consent dialog with checkbox to accept recording
     :width: 500px
 
 After a call ends, the recording is processed and saved to the chat as a shared file. Participants can play it back directly from the chat or download it from the conversation's shared items.

--- a/user_manual/talk/call_screenshare.rst
+++ b/user_manual/talk/call_screenshare.rst
@@ -12,6 +12,7 @@ Depending on your browser or the Talk Desktop client, you will get the option to
 If video from your camera is also available, other participants will see it in a small presenter view next to the screen share.
 
 .. image:: images/share-screen-with-camera.png
+    :alt: Talk call with both screen share and camera video visible
     :width: 700px
 
 To stop sharing your screen, click the ``Share screen`` button again and choose ``Stop screensharing``.

--- a/user_manual/talk/call_transcription.rst
+++ b/user_manual/talk/call_transcription.rst
@@ -10,6 +10,7 @@ Moderators need to set the transcription language in the conversation settings. 
 When enabled, the transcription appears at the bottom of the screen and is updated in real-time.
 
 .. image:: images/call-transcription.png
+   :alt: Talk call with live transcription text displayed at the bottom of the screen
    :width: 500px
 
 Live translation
@@ -18,4 +19,5 @@ Live translation
 With the `live_transcription` provider app enabled, you can also use live translation. Instead of receiving the transcription in the original language, it will be translated to the language of your choice.
 
 .. image:: images/call-translation-actions.png
+   :alt: Talk call transcription toolbar with translation and other actions
    :width: 400px

--- a/user_manual/talk/call_views.rst
+++ b/user_manual/talk/call_views.rst
@@ -5,6 +5,7 @@ Call layout
 You can switch between grid view and speaker view using the toggle icon in the three-dot menu or the bottom bar.
 
 .. image:: images/call-view-toggle-button.png
+    :alt: Talk call view toggle button to switch between grid and speaker view
     :width: 300px
 
 Grid view
@@ -13,6 +14,7 @@ Grid view
 Grid view shows all participants as tiles. Use the navigation buttons on the left and right to scroll through participants when they do not all fit on the screen.
 
 .. image:: images/talk-grid-view.png
+    :alt: Talk call in grid view showing multiple participants
     :width: 700px
 
 Speaker view
@@ -22,4 +24,5 @@ Speaker view (also called promoted view) centres the active speaker in a large t
 Use the navigation buttons on the left and right to scroll through participants when the row overflows.
 
 .. image:: images/talk-promoted-view.png
+    :alt: Talk call in promoted (speaker) view with the active speaker highlighted
     :width: 700px

--- a/user_manual/talk/chat.rst
+++ b/user_manual/talk/chat.rst
@@ -76,6 +76,7 @@ Inserting emoji
 You can add emoji using the picker on the left of the text input field.
 
 .. image:: images/emoji-picker.png
+   :alt: Talk chat emoji picker panel
    :width: 400px
 
 Smart Picker
@@ -86,6 +87,7 @@ Just choose the type of content you want to insert (files, Talk conversations, D
 You can also type `/` in the chat input to open the selector.
 
 .. image:: images/smart-picker.png
+   :alt: Talk smart picker opened with slash command for inserting objects
    :width: 400px
 
 Several integration apps can extend the Smart Picker with additional content types, such as GitHub and GitLab issues, Giphy GIFs, and more. Ask your administrator which integrations are available on your instance.
@@ -96,11 +98,13 @@ Replying to messages and more
 You can reply to a message using the arrow that appears when you hover a message.
 
 .. image:: images/reply.png
+   :alt: Talk chat message with the reply arrow highlighted on hover
    :width: 600px
 
 In the ``...`` menu you can also choose to reply privately. This will open a one-to-one conversation.
 
 .. image:: images/chat-message-menu.png
+   :alt: Talk chat message context menu with reply and other options
    :width: 600px
 
 Here you can also create a direct link to the message or mark it unread so you will scroll back there next time you enter the chat. When it is a file, you can view the file in Files.
@@ -112,6 +116,7 @@ If you don't want to disturb anyone in the middle of the night, there is a silen
 While it is enabled, other participants will not receive notifications from your messages.
 
 .. image:: images/message-silent.png
+   :alt: Talk chat input with silent message option enabled
    :width: 600px
 
 Scheduling messages
@@ -120,11 +125,13 @@ Scheduling messages
 If you want to send a message not right now, but at a specific time, you can schedule it. Just select the desired date and time in the quick actions next to the input field.
 
 .. image:: images/message-schedule-action.png
+   :alt: Talk message compose area with schedule send option
    :width: 600px
 
 You can find all your scheduled messages by clicking on the clock icon next to the input field. There you can edit, reschedule or delete currently prepared messages.
 
 .. image:: images/message-schedule-toggle.png
+   :alt: Talk navigation bar with clock icon to view scheduled messages
    :width: 400px
 
 Chat summary
@@ -134,7 +141,9 @@ When AI assistant is enabled, a summary can be generated for a conversation if t
 You can generate it by pressing the button that is visible in chat above the first unread messages.
 
 .. image:: images/chat-summary-button.png
+   :alt: Talk chat view with the AI summary generation button visible
    :width: 500px
 
 .. image:: images/chat-summary-text.png
+   :alt: Talk AI-generated chat summary displayed in the conversation
    :width: 500px

--- a/user_manual/talk/conversations.rst
+++ b/user_manual/talk/conversations.rst
@@ -11,17 +11,20 @@ This is where you have a private chat or call with another Talk user.
 In the content sidebar, you can find additional information about the person you are chatting with, such as their email address, phone number, or other details they have shared in their profile.
 
 .. image:: images/one-to-one-right-sidebar.png
+    :alt: Talk right sidebar showing contact information for a one-to-one conversation
     :width: 300px
 
 Nobody except you and the other person can see this conversation or join a call in it.
 You can extend an ongoing call to a new group conversation by adding more people. Call will be continued there without interruption.
 
 .. image:: images/one-to-one-extend.png
+    :alt: Talk dialog to extend a one-to-one call by adding more participants to a group conversation
     :width: 300px
 
 If a user becomes unavailable and has set an **out-of-office** status in ``Personal settings > Availability``, you will find additional information in this conversation, such as provided description, absence date, or their replacement person.
 
 .. image:: images/one-to-one-out-of-office.png
+    :alt: Talk showing an out-of-office status message for a user in a one-to-one conversation
     :width: 500px
 
 2. Group conversations
@@ -33,6 +36,7 @@ A group conversation can be shared with a public link, so guests can join a chat
 It can also be opened to registered users (or users from 'Guests' app), so they can discover and join this conversation.
 
 .. image:: images/group-public-settings.png
+    :alt: Talk conversation settings dialog for group and public access options
     :width: 400px
 
 
@@ -45,6 +49,7 @@ This is a special conversation with yourself. Messages here do not have a limit 
 - **Forward messages from other chat**: use the message menu to forward important messages from other conversations to your Note to self.
 
 .. image:: images/note-to-self.png
+    :alt: Talk note-to-self personal conversation for saving messages
     :width: 500px
 
 4. Disposable conversations
@@ -57,6 +62,7 @@ These conversations cover some special cases and exist for a limited period of t
 - **Video verification**: these are created, when someone tries to access a public link, protected by password with video verification (deleted instantly after call ends).
 
 .. image:: images/instant-meeting-dispose.png
+    :alt: Talk instant meeting with option to dispose after use
     :width: 500px
 
 Talk Dashboard
@@ -70,6 +76,7 @@ The Talk Dashboard is your central hub for managing and accessing your conversat
 - Shortcut actions to create new conversations, join open ones, or quickly check your media devices.
 
 .. image:: images/talk-dashboard.png
+    :alt: Talk dashboard showing recent conversations and shortcut actions
     :width: 600px
 
 Creating a conversation
@@ -78,26 +85,31 @@ Creating a conversation
 You can create a private (one-to-one) chat by searching for the name of a user, a group or a team and clicking it. For a single user, a conversation is immediately created and you can start your chat. For a group or circle you get to pick a name and settings before you create the conversation and add the participants.
 
 .. image:: images/chat-with-one-user.png
+    :alt: Talk search dialog to start a private chat with a user
     :width: 400px
 
 If you want to create a custom group conversation, click the button next to the search field and filters button and then on ``Create a new conversation``.
 
 .. image:: images/create-new-conversation.png
+    :alt: Talk button to create a new group conversation
     :width: 400px
 
 You can then pick a name for the conversation, put a description, and set up an avatar for it (with uploaded photo or emoji), and select if the conversation should be open to external users and if other users on the server can see and join the conversation.
 
 .. image:: images/creating-open-conversation.png
+    :alt: Talk new conversation setup dialog for name, description, and access type
     :width: 500px
 
 In the second step, you get to add participants and finalize the creation of the conversation.
 
 .. image:: images/add-participants.png
+    :alt: Talk participant selection step when creating a new conversation
     :width: 500px
 
 After confirmation you will be redirected to the new conversation and can start communicating right away.
 
 .. image:: images/new-room.png
+    :alt: Talk empty new conversation ready for chatting
     :width: 700px
 
 Filter your conversations
@@ -109,11 +121,13 @@ You can filter your conversations using the filter button next to the search fie
 3. **Event conversations**: view all conversations, created for upcoming or past events.
 
 .. image:: images/filters-menu.png
+    :alt: Talk conversation list filter menu
     :width: 400px
 
 You can then clear the filter from the filters menu.
 
 .. image:: images/clear-filter.png
+    :alt: Talk conversation list with active filter and clear filter option
     :width: 400px
 
 Archive conversations
@@ -122,11 +136,13 @@ You can archive conversations that you no longer need to see in your main conver
 An archived conversation will not appear in your main conversation list, but it will still align with notification level set in its settings.
 
 .. image:: images/archived-conversations-list.png
+    :alt: Talk list of archived conversations
     :width: 400px
 
 The list is accessible from the button at the bottom of the navigation bar.
 
 .. image:: images/archived-conversations-button.png
+    :alt: Talk navigation bar showing the archived conversations button
     :width: 400px
 
 Managing a conversation
@@ -137,16 +153,19 @@ You are always moderator in your new conversation. In the participant list you c
 Changing permissions of a user that joined a public conversation will also permanently add them to the conversation.
 
 .. image:: images/participant-menu.png
+    :alt: Talk participant menu showing permission and moderation options
     :width: 400px
 
 Moderators can configure the conversation. Select ``Conversation settings`` from the ``...`` menu of the conversation on the top to access the settings.
 
 .. image:: images/open-settings.png
+    :alt: Talk conversation menu with Conversation settings option
     :width: 500px
 
 Here you can configure the description, guest access, if the conversation is visible to others on the server and more.
 
 .. image:: images/conversation-settings-dialog.png
+   :alt: Talk conversation settings dialog showing description and access configuration
    :width: 600px
 
 Ban participants
@@ -158,17 +177,20 @@ This applies to internal users and guests alike; for guests, their IP address wi
 In the participants list, select the user or guest, and click ``Remove participant``.
 
 .. image:: images/ban-participant.png
+    :alt: Talk participant menu with Remove participant option
     :width: 300px
 
 There, toggle checkbox ``Also ban from this conversation`` and provide a reason for the ban. The banned user will be removed and prevented from rejoining.
 
 .. image:: images/ban-participant-dialog.png
+    :alt: Talk dialog to ban a participant with a reason field
     :width: 400px
 
 You can later find the list of banned users in the ``Moderation`` section of conversation settings.
 Here, you can see the reason for the ban and revert it if needed.
 
 .. image:: images/ban-participant-list.png
+    :alt: Talk list of banned participants with reasons and revert options
     :width: 400px
 
 Messages expiration
@@ -178,6 +200,7 @@ A moderator can configure message expiration under the ``Conversation settings``
 The available expiration durations are 1 hour, 8 hours, 1 day, 1 week, 4 weeks, or never (which is the default setting).
 
 .. image:: images/messages-expiration.png
+   :alt: Talk conversation settings showing message expiration duration options
    :width: 500px
 
 
@@ -197,9 +220,11 @@ You can change this behavior in the conversation settings. Additionally, you can
 - **Sensitive conversations**: content of messages will not be shown in the conversation list and obscured from notifications.
 
 .. image:: images/conversation-notifications.png
+    :alt: Talk conversation notification settings panel
     :width: 300px
 
 To have more control over your privacy, you can also configure the visibility of your typing and read indicators in ``Talk settings``:
 
 .. image:: images/privacy-settings.png
+    :alt: Talk privacy settings for controlling conversation visibility
     :width: 600px

--- a/user_manual/talk/federation_index.rst
+++ b/user_manual/talk/federation_index.rst
@@ -13,6 +13,7 @@ To receive an invitation, the other party needs your CloudID — your federated 
 The moderator of the conversation can send an invite to a participant on a different server:
 
 .. image:: images/federation-invite-send.png
+   :alt: Talk participant panel with option to invite a user from another server
    :width: 400px
 
 Accepting an invitation
@@ -21,16 +22,19 @@ Accepting an invitation
 When receiving a notification, the user will see a counter of pending invites above the conversations list.
 
 .. image:: images/federation-invite-pending.png
+   :alt: Talk notification counter showing pending federation invites
    :width: 400px
 
 Upon clicking it, more information will be provided about the inviting party, and the user can either accept or decline the invitation.
 
 .. image:: images/federation-invite-dialog.png
+   :alt: Talk federation invite dialog showing the inviting server details
    :width: 500px
 
 By accepting the invite, the conversation will appear in the list as any other one.
 
 .. image:: images/federation-conversations-list.png
+   :alt: Talk conversation list showing a federated conversation from another server
    :width: 400px
 
 You can use it to chat with participants from other federated servers, join calls, and use other available Talk features.

--- a/user_manual/talk/files_integration.rst
+++ b/user_manual/talk/files_integration.rst
@@ -7,21 +7,25 @@ Talk from Files
 In the Files app, you can chat about files in the sidebar, and even have a call while editing the file. You first have to join the chat.
 
 .. image:: images/join-chat.png
+    :alt: Nextcloud Files sidebar with Talk chat panel open for a file
     :width: 500px
 
 |
 
 .. image:: images/sidebar-chat.png
+    :alt: Nextcloud Files sidebar showing an active Talk chat and call for a file
     :width: 500px
 
 You can then chat or have a call with other participants, even when you start editing the file.
 
 .. image:: images/text-and-talk.png
+    :alt: Nextcloud Text editor with Talk conversation sidebar open for collaboration
     :width: 700px
 
 In Talk, a conversation will be created for the file. You can chat from there, or go back to the file using the ``...`` menu in the top-right.
 
 .. image:: images/file-room.png
+    :alt: Talk conversation created for a specific file showing the file at the top
     :width: 400px
 
 .. FIXME Add video verification for public shares

--- a/user_manual/talk/guest.rst
+++ b/user_manual/talk/guest.rst
@@ -12,16 +12,19 @@ Joining a chat
 If you received a link to a chat conversation, you can open it in your browser to join the chat. Here, you will be prompted to enter your name before joining.
 
 .. image:: images/guest-view.png
+    :alt: Talk guest view showing a public conversation without signing in
     :width: 400px
 
 You can also change your name later by clicking the ``Edit`` button, located top-right.
 
 .. image:: images/change-name.png
+    :alt: Talk guest name edit dialog to change display name
     :width: 400px
 
 Your camera and microphone settings can be found in the ``Settings`` menu. There you can also find a list of shortcuts you can use.
 
 .. image:: images/guest-settings.png
+    :alt: Talk guest settings panel with camera and microphone options
     :width: 600px
 
 Joining a call
@@ -30,16 +33,19 @@ Joining a call
 You can start a call any time with the ``Start call`` button. Other participants will get notified and can join the call. If somebody else has started a call already, the button will change in a green ``Join call`` button.
 
 .. image:: images/join-call.png
+    :alt: Talk conversation with a green Join call button
     :width: 600px
 
 Before joining, you will see a device check where you can select your camera and microphone, enable background blur, or join without any devices.
 
 .. image:: images/device-settings-before-call.png
+    :alt: Talk device check dialog for guests before joining a call
     :width: 600px
 
 During a call, you can find the Camera and Microphone settings in the ``...`` menu in the top bar.
 
 .. image:: images/guest-call-menu.png
+    :alt: Talk guest in-call menu showing camera and microphone settings
     :width: 300px
 
 During a call, you can mute your microphone and disable your video with the buttons in the top-right, or using the shortcuts ``M`` to mute audio and ``V`` to disable video. You can also use the ``space bar`` to toggle mute. When you are muted, pressing space will unmute you so you can speak until you let go of the space bar. If you are unmuted, pressing space will mute you until you let go.
@@ -57,6 +63,7 @@ Full-screen and other settings
 In the conversation menu you can choose to go full-screen. You can also do this by using the ``F`` key on your keyboard. In the conversation settings, you can find notification options and the full conversation description.
 
 .. image:: images/guest-room-menu.png
+    :alt: Talk guest conversation menu with full-screen and other options
     :width: 500px
 
 Joining as an email guest
@@ -66,15 +73,18 @@ A guest can be invited to a conversation via email. The email contains a link to
 If the guest clicks the link, they will be redirected to the conversation with an individual access token.
 
 .. image:: images/guest-invitation-email.png
+    :alt: Email invitation received by a guest with a link to join a Talk conversation
     :width: 500px
 
 An invitation can be done via inserting the email address in ``Participants`` tab search field.
 
 .. image:: images/guest-email-invitation.png
+    :alt: Talk participant panel showing email address field for inviting guests
     :width: 500px
 
 You can bulk invite email participants by uploading a CSV file. The option is available in the conversation settings under ``Meeting`` section.
 
 .. image:: images/guest-invitation-bulk.png
+    :alt: Talk bulk email invite option using a CSV file upload
     :width: 500px
 

--- a/user_manual/talk/index.rst
+++ b/user_manual/talk/index.rst
@@ -9,6 +9,7 @@ You can find out more about Nextcloud Talk `on our website <https://nextcloud.co
 Download the desktop and mobile clients from `nextcloud.com/install <https://nextcloud.com/install/>`_.
 
 .. image:: images/talk-grid-view.png
+   :alt: Talk call in grid view showing multiple participants
 
 .. toctree::
    :maxdepth: 2

--- a/user_manual/talk/matterbridge.rst
+++ b/user_manual/talk/matterbridge.rst
@@ -9,6 +9,7 @@ Matterbridge integration in Nextcloud Talk makes it possible to create 'bridges'
 A moderator can add a Matterbridge connection in the chat conversation settings.
 
 .. image:: images/matterbridge-settings.png
+    :alt: Talk conversation settings showing Matterbridge chat bridge configuration
     :width: 700px
 
 Each bridge has its own configuration requirements. Information for most is available on the Matterbridge wiki and can be accessed behind ``more information`` menu in the ``...`` menu. You can also `access the wiki directly. <https://github.com/42wim/matterbridge/wiki>`_

--- a/user_manual/talk/message_integrations.rst
+++ b/user_manual/talk/message_integrations.rst
@@ -15,11 +15,13 @@ Create tasks from chat message
 If Deck is installed, you can use the ``...`` menu of a chat message and turn the message into a Deck card.
 
 .. image:: images/deck-talk-create-card-menu.png
+    :alt: Talk message context menu with Create Deck card option
     :width: 500px
 
 |
 
 .. image:: images/deck-talk-create-card-dialog.png
+    :alt: Deck card creation dialog opened from a Talk message
     :width: 400px
 
 
@@ -29,9 +31,11 @@ Share card into a chat
 From within Deck, you can share cards into a chat.
 
 .. image:: images/deck-talk-share-card-to-chat-menu.png
+    :alt: Deck card menu with Share to Talk chat option
     :width: 400px
 
 |
 
 .. image:: images/deck-talk-share-card-to-chat-in-talk.png
+    :alt: Talk chat showing a shared Deck card
     :width: 600px

--- a/user_manual/talk/messages.rst
+++ b/user_manual/talk/messages.rst
@@ -8,6 +8,7 @@ Editing messages
 You can edit messages and captions to file shares up to 6 hours after sending.
 
 .. image:: images/message-editing.png
+   :alt: Talk chat view showing the edit option on a message
    :width: 600px
 
 Pinning messages
@@ -16,11 +17,13 @@ Pinning messages
 A moderator can pin important messages in a conversation, for a certain period of time or until it's no longer relevant.
 
 .. image:: images/message-pin-action.png
+   :alt: Talk message context menu with pin message option
    :width: 400px
 
 Pinned messages are highlighted and accessible above the chat or in the ``Shared items`` tab of the content sidebar. If you no longer need a pinned message, you can unpin it for everyone or only yourself from quick actions.
 
 .. image:: images/message-pin-in-chat.png
+   :alt: Talk chat view with a pinned message highlighted above the conversation
    :width: 700px
 
 Setting reminder on messages
@@ -29,11 +32,13 @@ Setting reminder on messages
 You can set reminders on specific messages. If there's an important message you want to be notified about later, simply hover over it and click on the reminder icon.
 
 .. image:: images/set-message-reminder.png
+   :alt: Talk message context menu showing the set reminder option
    :width: 400px
 
 In the submenu, you can select an appropriate time to receive a notification later.
 
 .. image:: images/configure-message-reminder.png
+   :alt: Talk reminder time selection submenu for a message
    :width: 400px
 
 You can also forward a message to another conversation using the ``...`` menu, or send it to your **Note to self** conversation for personal reference.
@@ -44,11 +49,13 @@ Messages search in a conversation
 In addition to global unified search, you can search for messages within a specific conversation. In the content sidebar of a conversation, click the search icon to open the search tab.
 
 .. image:: images/chat-search-messages.png
+   :alt: Talk in-conversation message search field
    :width: 500px
 
 You can narrow down your search by using filters such as date range, and sender.
 
 .. image:: images/chat-search-messages-tab.png
+   :alt: Talk message search with date range and sender filter options
    :width: 500px
 
 Threaded messages
@@ -57,29 +64,35 @@ Threaded messages
 You can create threads in conversations to keep discussions organized. The thread creation option is available in the new message additional actions.
 
 .. image:: images/thread-create-action.png
+   :alt: Talk message context menu showing the create thread option
    :width: 400px
 
 Then, you can add a title and description for the thread and start the discussion.
 
 .. image:: images/thread-example.png
+   :alt: Talk thread creation dialog with title and description fields
    :width: 600px
 
 You can view all replies in a thread either from the replies button on the message or from ``Shared items`` tab in the content sidebar.
 
 .. image:: images/threads-list-shared-items.png
+   :alt: Talk shared items sidebar panel listing conversation threads
    :width: 500px
 
 You can subscribe to a thread to receive notifications about new replies. It is possible to subscribe from the thread itself or from the sidebar.
 
 .. image:: images/thread-notifications.png
+   :alt: Talk thread with notification subscription toggle
    :width: 500px
 
 Subscribed threads are easily accessible from the navigation bar in ``Threads`` navigation.
 
 .. image:: images/threads-followed.png
+   :alt: Talk navigation bar Threads section showing followed threads
    :width: 500px
 
 You can edit the thread title from the thread itself or from the sidebar.
 
 .. image:: images/thread-edit-title.png
+   :alt: Talk thread title edit option in the thread header
    :width: 500px

--- a/user_manual/talk/open_conversations.rst
+++ b/user_manual/talk/open_conversations.rst
@@ -8,6 +8,7 @@ Creating an open conversation
 You can create an open conversation that any registered user on this server can discover and join.
 
 .. image:: images/creating-open-conversation.png
+    :alt: Talk new conversation setup dialog for name, description, and access type
     :width: 500px
 
 View all open conversations
@@ -16,4 +17,5 @@ View all open conversations
 You can view all the conversations that you can join by clicking the button next to the search field, then clicking ``Join open conversations``.
 
 .. image:: images/join-open-conversations.png
+    :alt: Talk open conversations browser showing public conversations to join
     :width: 400px

--- a/user_manual/talk/webinar.rst
+++ b/user_manual/talk/webinar.rst
@@ -5,6 +5,7 @@ Webinar and lobby
 The lobby feature allows you to show guests a waiting screen until the call starts. This is ideal for webinars with external participants, for example.
 
 .. image:: images/lobby-in-talk.png
+    :alt: Talk lobby screen shown to guests while waiting for the host to start the meeting
     :width: 600px
 
 You can choose to let the participants join the call at a specific time, or when you dismiss the lobby manually.


### PR DESCRIPTION
### ☑️ Resolves

* Partial fix for #9663

### 🖼️ Screenshots

Images without `:alt:` attributes cause Sphinx to fall back to the file path (e.g. `../_images/foo.png`) as the rendered `alt` value, which is meaningless to screen readers and fails WCAG 1.1.1 / BITV 9.1.1.1.

This PR adds descriptive `:alt:` text to **135 image directives** across the user manual Talk section and the KDE sync guide:

- `user_manual/talk/` — conversations, messages, calls, chat, guests, attachments, call recording, breakout rooms, call views, federation, files integration, calendar integration, appearance, bots, matterbridge, message integrations, webinar
- `user_manual/groupware/sync_kde.rst`

Remaining images in other manuals and sections (admin manual, other groupware pages) will be addressed in follow-up contributions.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues