### PR TITLE
fix(a11y): remove sensory-only position references

### DIFF
--- a/admin_manual/ai/app_assistant.rst
+++ b/admin_manual/ai/app_assistant.rst
@@ -154,7 +154,7 @@ Assistant configuration
 
    occ config:app:set assistant assistant_enabled --value=1 --type=string
 
-To enable/disable the assistant button from the top-right corner for all the users.
+To enable/disable the assistant button in the navigation bar for all users.
 
 2. AI text generation smart picker
 

--- a/admin_manual/configuration_files/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration_files/external_storage_configuration_gui.rst
@@ -19,8 +19,8 @@ disabled by default, so to use this feature you simply need to enable it under
 Configuring
 -----------
 
-To access the settings for configuring external storage mounts, click your Profile icon
-in the top right and select **Settings** from the dropdown. On the left side, under
+To access the settings for configuring external storage mounts, click your **Profile** icon
+and select **Settings** from the dropdown. On the left side, under
 **Administration**, select **External Storage**.
 
 .. note::

--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -14,7 +14,7 @@ able to send emails. You may have a mail server on the same machine as Nextcloud
 or it may be a remote server.
 
 To access the setup page below log in with an admin account. Click on your avatar
-in the top right, and then click Settings. On the left side under Administration and
+and then click **Settings**. On the left side under Administration and
 click Basic settings.
 
 .. figure:: ../images/smtp-config-wizard.png

--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -16,7 +16,7 @@ This is just three steps:
 
 .. figure:: images/install-wizard-initial.png
    :scale: 75%
-   :alt: screenshot of the installation wizard
+   :alt: Nextcloud installation wizard showing database and admin account configuration fields
 
 You're finished and can start using your new Nextcloud server.
 

--- a/admin_manual/windmill_workflows/index.rst
+++ b/admin_manual/windmill_workflows/index.rst
@@ -45,7 +45,7 @@ Building a workflow
 To make a workflow react to a Nextcloud Webhook Event, you need to add a trigger. To do this, click on the Plus in the Triggers box of the Flow and select "Nextcloud"
 
 .. image:: images/windmill_add_trigger.png
-   :alt: Screenshot of adding a Nextcloud trigger in a workflow
+   :alt: Windmill workflow editor showing the Add Trigger panel with Nextcloud selected
 
 Now you can choose an event out of a drop-down list  of events that your flow should react to. You can additionally fill in some parameters:
 
@@ -148,7 +148,7 @@ In order to reference the workflow input (details about the event that triggered
 For example, ``flow_input.event.form.hash`` will reference the hash of a form from a nextcloud Forms event. As it is a JavaScript expression and not a static value, you have to switch the parameter input with the button next to it.
 
 .. image:: images/windmill_js_expression.png
-   :alt: Screenshot of adding a Nextcloud trigger in a workflow
+   :alt: Windmill workflow editor showing the Add Trigger panel with Nextcloud selected
 
 The fields available for each event are listed in the :ref:`webhook_listeners documentation<webhook_listeners>`.
 
@@ -165,10 +165,10 @@ The most prominent use case for this are approval workflows where you get automa
 Once the human approves or disapproves by triggering the webhook URL the workflow will resume.
 
 In order to turn a newly added step into an approval step, the workflow edit screen,
-select the script and in the bottom right pan, go in the "Advanced" tab, "Suspend" sub tab and check "Suspend/Approval/Prompt".
+select the script and in the step panel, go in the "Advanced" tab, "Suspend" sub tab and check "Suspend/Approval/Prompt".
 
 .. image:: images/windmill_approval_step_config.png
-   :alt: Screenshot of the workspace edit screen to turn a normal step into an Approval step
+   :alt: Windmill workflow step editor with the Advanced tab open showing the Suspend/Approval option
 
 Using the scripts provided for Nextcloud, you can send approval links to the humans in charge of approving
 via Nextcloud Talk or a simple notification in Nextcloud.

--- a/developer_manual/html_css_design/list.rst
+++ b/developer_manual/html_css_design/list.rst
@@ -15,7 +15,7 @@ Basic layout
 =============
 
 .. figure:: ../images/list.png
-   :alt: Content list screenshot
+   :alt: Content list component showing rows of entries with titles, metadata, and action buttons
 
 .. code-block:: html
 

--- a/developer_manual/html_css_design/navigation.rst
+++ b/developer_manual/html_css_design/navigation.rst
@@ -79,7 +79,7 @@ Basic layout
 ------------
 
 .. figure:: ../images/navigation.png
-   :alt: Navigation screenshot
+   :alt: App navigation sidebar showing a list of navigation entries with icons
    :figclass: figure-with-code
 
 .. code-block:: html

--- a/user_manual/collectives/onboard_your_team.rst
+++ b/user_manual/collectives/onboard_your_team.rst
@@ -25,7 +25,7 @@ Step 2: Create an “Introduction”-template together 👥
 3. Give your template the title ``Introduction``. Now add your fields as simple text to your document -
    don't forget to decide on them collectively! By pressing on the Tt button in the formatting toolbar,
    you can format your new text as headings!
-4. When you're finished, just press the X in the top right corner - your template will be automatically
+4. When you're finished, just press the **Close** button - your template will be automatically
    saved and you should be back in your template manager.
 5. Let’s add a fun emoji for our new template last. Click the … button next to your new template and
    click choose emoji…. Afterwards you can close the template manager.

--- a/user_manual/desktop/faq.rst
+++ b/user_manual/desktop/faq.rst
@@ -93,7 +93,7 @@ Specifically, you have to:
 .. figure:: images/setup/remove.png
    :alt: Remove an existing connection
 
-To do so, in the client UI, which you can see above, click the "**Account**" drop-down menu and then click "Remove".
+To do so, click the "**Account**" drop-down menu and then click "Remove".
 This will display a "**Confirm Account Removal**" dialog window.
 
 .. figure:: images/setup/confirm.png
@@ -106,7 +106,7 @@ Then, click the Account drop-down menu again, and this time click "**Add new**".
 .. figure:: images/setup/wizard.png
    :alt: Replacement connection wizard
 
-This opens the Nextcloud Connection Wizard, which you can see above, *but* with an extra option.
+This opens the Nextcloud Connection Wizard *but* with an extra option.
 This option provides the ability to either: keep the existing data (synced by the previous connection) or to start a clean sync (erasing the existing data).
 
 .. important::

--- a/user_manual/desktop/installation.rst
+++ b/user_manual/desktop/installation.rst
@@ -116,8 +116,7 @@ the Nextcloud server, or select individual folders. The default local
 sync folder is ``Nextcloud``, in your home directory. You may change
 this as well.
 
-When you have completed selecting your sync folders, click the *Connect*
-button at the bottom right. The client will attempt to connect to your
+When you have completed selecting your sync folders, click the *Connect* button. The client will attempt to connect to your
 Nextcloud server. If it is successful, the wizard will close itself. You
 can then observe the sync activity and open the main dialog by clicking
 on the tray icon.

--- a/user_manual/desktop/macosvfs.rst
+++ b/user_manual/desktop/macosvfs.rst
@@ -27,7 +27,7 @@ Virtual files-related settings can be adjusted on a per-account basis
 via the Nextcloud desktop client's settings window.
 
 .. image:: images/macosvfs-settings.jpg
-   :alt: Screenshot of client settings for the file provider extension
+   :alt: Nextcloud desktop client settings showing the macOS file provider extension toggle
 
 Here the integration into Finder can be enabled or disabled.
 
@@ -77,7 +77,7 @@ Context menu actions
 --------------------
 
 .. image:: images/macosvfs-context-menu.jpg
-   :alt: Screenshot of Finder with an open context menu
+   :alt: macOS Finder context menu on a Nextcloud file showing Keep Downloaded, Lock, and Share options
 
 The file provider extension also provides special Nextcloud features through
 the context menu in Finder.
@@ -103,7 +103,7 @@ Locking
 ^^^^^^^
 
 .. image:: images/macosvfs-file-locking.jpg
-   :alt: Screenshot of Finder showing the successful locking of a file
+   :alt: macOS Finder showing a Nextcloud file with a lock indicator after locking
 
 If the server supports file locking, the client will offer manual locking and
 unlocking of files in Finder.
@@ -112,7 +112,7 @@ Sharing
 ^^^^^^^
 
 .. image:: images/macosvfs-file-sharing.jpg
-   :alt: Screenshot of Finder showing the share management
+   :alt: macOS Finder share management panel for a Nextcloud file showing existing shares
 
 When the server supports sharing and the item is allowed to be shared,
 then you can create new shares or manage existing shares for an item directly

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -67,8 +67,8 @@ If Nextcloud is installed in a subdirectory called "nextcloud"::
    built-in client), you should use an application password for login rather than your
    regular password. In addition improved security, this `increases performance significantly
    <https://github.com/nextcloud/server/issues/32729#issuecomment-1556667151>`_. To
-   configure an application password, log into the Nextcloud Web interface, click on the avatar
-   in the top right and choose *Personal settings*. Then choose *Security* in the left
+   configure an application password, log into the Nextcloud Web interface, click on your avatar
+   and choose *Personal settings*. Then choose *Security* in the left
    sidebar and scroll to the very bottom. There you can create an app password (which can
    also be revoked in the future without changing your main user password).
 
@@ -79,7 +79,7 @@ If Nextcloud is installed in a subdirectory called "nextcloud"::
    See the WebDAV URL, to be found in Files Settings -> WebDAV in the Files on your Nextcloud account.
 
    .. image:: ../images/webdav_link.png
-    :alt: Screenshot of the Files settings showing the personal WebDAV link
+    :alt: Nextcloud Files settings panel showing the personal WebDAV URL
 
 
 
@@ -105,7 +105,7 @@ share::
    of ``davs://``:
 
 .. image:: ../images/webdav_gnome3_nautilus.png
-   :alt: Screenshot of configuring Nautilus file manager to use WebDAV
+   :alt: GNOME Nautilus file manager Connect to Server dialog with a Nextcloud WebDAV address entered
 
 .. note:: The same method works for other file managers that use GVFS,
       such as MATE's Caja and Cinnamon's Nemo.
@@ -229,14 +229,14 @@ To access files through the macOS Finder:
 #. From the Finder's top menu bar, choose **Go > Connect to Server…**:
 
    .. image:: ../images/osx_webdav1.png
-     :alt: Screenshot of entering your Nextcloud server address on macOS
+     :alt: macOS Go menu with Connect to Server option highlighted
 
 #. When the **Connect to Server…** window opens, enter your Nextcloud server's WebDAV address in the **Server Address:** field, i.e.::
 
     https://cloud.YOURDOMAIN.com/remote.php/dav/files/USERNAME/
 
    .. image:: ../images/osx_webdav2.png
-     :alt: Screenshot: Enter Nextcloud server address in "Connect to Server…" dialog box
+     :alt: macOS Connect to Server dialog with a Nextcloud WebDAV URL in the Server Address field
 
 #. Click **Connect**. Your WebDAV server should appear on the Desktop as a shared disk drive.
 
@@ -317,7 +317,7 @@ To map a drive using Microsoft Windows Explorer:
 
    .. figure:: ../images/explorer_webdav.png
      :scale: 80%
-     :alt: Screenshot of mapping WebDAV on Windows Explorer
+     :alt: Windows Explorer Map Network Drive wizard with a Nextcloud WebDAV URL entered
 
 5. Click the ``Finish`` button.
 

--- a/user_manual/files/access_webgui.rst
+++ b/user_manual/files/access_webgui.rst
@@ -96,8 +96,8 @@ view:
 Grid view
 ---------
 
-The Files app defaults to a list view. Click the grid toggle button at the
-top-right of the file list to switch to a thumbnail grid, which is useful for
+The Files app defaults to a list view. Click the grid toggle button above the
+file list to switch to a thumbnail grid, which is useful for
 browsing image folders:
 
 .. figure:: ../images/files_page-8.png

--- a/user_manual/files/external_storage.rst
+++ b/user_manual/files/external_storage.rst
@@ -53,7 +53,7 @@ your own storage services under **Personal Settings → External Storage**.
 
 To add a new mount:
 
-1. Click your profile icon in the top right and select **Personal Settings**.
+1. Click your profile icon and select **Personal Settings**.
 2. Select **External Storage** from the left sidebar.
 3. Choose a backend from the **Add storage** dropdown.
 4. Fill in the required fields for the backend (server address, path, credentials, etc.).

--- a/user_manual/files/transfer_ownership.rst
+++ b/user_manual/files/transfer_ownership.rst
@@ -6,7 +6,7 @@ Users can transfer the ownership of files and folders to other users. Sharing
 settings and permissions for transferred files and folders will also be transferred
 to the new owner.
 
-#. Navigate to *Settings* (top-right menu) > *Sharing*.
+#. Navigate to *Settings* > *Sharing*.
 #. In the *Files* section, click on *Choose file or folder to transfer*. A file picker opens,
    showing all files and folders in the user's account.
 #. Pick a file or folder and click on *Choose*. The chosen file or folder name gets displayed.

--- a/user_manual/groupware/calendar.rst
+++ b/user_manual/groupware/calendar.rst
@@ -46,7 +46,7 @@ instance, importing is the best way to do so.
 .. figure:: images/calendar_importing.png
             :scale: 50%
 
-1. Click on the settings-icon labeled with ``Calendar settings`` at the bottom-left.
+1. Click on the **Calendar settings** icon.
 
 2. After clicking on ``Import Calendar``, found in the ``General`` section, you can select one or more calendar files
    from your local device to upload.
@@ -64,7 +64,7 @@ Import an Event/Add .ics Event
 
 Individual events are often distributed as ``.ics`` files (sometimes via a button labelled "iCal", "Apple Calendar" or "Outlook"). You can import them into Nextcloud Calendar using the same import flow as a full calendar.
 
-1. Click on the settings-icon labeled with ``Calendar settings`` at the bottom-left.
+1. Click on the **Calendar settings** icon.
 
 2. After clicking on ``Import calendar`` you can select one or more ``.ics`` files
    from your local device to upload. Single-event files are added to the calendar you select.
@@ -229,7 +229,7 @@ If you want to edit, duplicate or delete a specific event, you first need to cli
 After that you will be able to re-set all event details and open the
 advanced editor by clicking on ``More``.
 
-Clicking on the ``Update`` button will update the event. To cancel your changes, click on the close icon on top right of the popup or advanced editor.
+Clicking on the ``Update`` button will update the event. To cancel your changes, click the **Close** button of the popup or advanced editor.
 
 If you open the advanced view and click the three dot menu next to the event name, you have an option to export the event as an ``.ics`` file or remove the event from your calendar.
 
@@ -305,7 +305,7 @@ You can import attachments to your events either by uploading them or adding the
 .. note:: Attachments can be added while creating new events or editing existent ones.
    Newly uploaded files will be saved in files by default in the calendar folder in the root directory.
 
-You can change the attachment folder by going to ``Calendar settings`` in the bottom left corner and changing ``default attachments location``.
+You can change the attachment folder by going to **Calendar settings** and changing ``default attachments location``.
 
 .. figure:: images/calendar_attachments_location.png
    :scale: 60%

--- a/user_manual/groupware/contacts.rst
+++ b/user_manual/groupware/contacts.rst
@@ -38,7 +38,7 @@ Importing Virtual Contacts
 
 To Import Contacts Using a VCF/vCard File:
 
-1. On top left of the screen you have "Import contacts" button that is shown only when you don't have any contacts yet.
+1. An **Import contacts** button is shown when you have no contacts yet.
 2. Find "Settings" at the bottom of the left sidebar, next to the gear button:
 
     .. figure:: ../images/contact_bottombar.png

--- a/user_manual/groupware/mail.rst
+++ b/user_manual/groupware/mail.rst
@@ -83,7 +83,7 @@ This setting allows you to show messages set as favorite in a separate section o
 
 Scheduled messages
 ~~~~~~~~~~~~~~~~~~~
-1. Click new message button on top left of your screen
+1. Click the **New message** button
 2. Click the (...) action menu on the modal composer
 3. Click *send later*
 
@@ -213,7 +213,7 @@ Disable trash retention by leaving the field empty or setting it to 0.
 Compose messages
 ----------------
 
-1. Click new message on the top left of your screen
+1. Click the **New message** button
 2. Start writing your message
 
 Minimize the composer modal
@@ -221,15 +221,15 @@ Minimize the composer modal
 
 .. versionadded:: 3.2
 
-The composer modal can be minimized while writing a new message, editing an existing draft or a message from the outbox. Simply click the minimize button on the top right of the modal or click anywhere outside the modal.
+The composer modal can be minimized while writing a new message, editing an existing draft or a message from the outbox. Simply click the **Minimize** button on the modal or click anywhere outside the modal.
 
 .. figure:: images/mail-minimize-composer.png
 
-You can resume your minimized message by clicking anywhere on the indicator on the bottom right of your screen.
+You can resume your minimized message by clicking anywhere on the minimized composer indicator.
 
 .. figure:: images/mail-composer-indicator.png
 
-Press close button on the modal or the indicator in the bottom right corner to stop editing a message. A draft will be saved automatically into your draft mailbox.
+Press the **Close** button on the modal or on the minimized composer indicator to stop editing a message. A draft will be saved automatically into your draft mailbox.
 
 
 Recipient info on composer
@@ -239,8 +239,8 @@ Recipient info on composer
 
 When you add your first recipient or contact in the "To" field, a right pane will appear displaying the saved profile details of that contact.
 Adding a second contact will collapse the list, allowing you to select and expand any contact you added to view their details.
-If you prefer to focus solely on writing in the composer, you can hide the right pane by clicking the expand icon in the top-right corner.
-To show the right pane again, simply click the minimize icon in the same location.
+If you prefer to focus solely on writing in the composer, you can hide the right pane by clicking the **Expand** icon in the composer toolbar.
+To show the right pane again, simply click the **Minimize** icon in the same toolbar.
 
 Mention contacts
 ----------------
@@ -264,7 +264,7 @@ Text blocks can be shared with users and user groups.
 Outbox
 ------
 
-When a message has been composed and the "Send" button was clicked, the message is added to the outbox which can be found in the bottom left corner of the left sidebar.
+When a message has been composed and the "Send" button was clicked, the message is added to the **Outbox**, which appears at the bottom of the left sidebar.
 
 You can also set the date and time for the send operation to a point in the future (see :ref:`Scheduled messages <mail-scheduled-messages>`)- the message will be kept in the outbox until your chosen date and time arrives, then it will be sent automatically.
 

--- a/user_manual/groupware/sync_gnome.rst
+++ b/user_manual/groupware/sync_gnome.rst
@@ -20,7 +20,7 @@ This can be done by following these steps:
    .. image:: ../images/goa-add-nextcloud-account.png
 
 #. In the next window, select which resources GNOME should access and
-   press the cross in the top right to close:
+   press the **Close** button to close the dialog:
 
    .. image:: ../images/goa-nextcloud-select.png
 

--- a/user_manual/groupware/sync_kde.rst
+++ b/user_manual/groupware/sync_kde.rst
@@ -8,7 +8,7 @@ This can be done by following these steps depending on if you use KOrganizer or 
 
 In KOrganizer:
 
-1. Open KOrganizer and in the calendar list (bottom left) right-click and choose ``Add Calendar``:
+1. Open KOrganizer and in the **Calendar** list on the left right-click and choose ``Add Calendar``:
 
 .. image:: ../images/KOrganizer_add_calendar.png
 

--- a/user_manual/groupware/sync_osx.rst
+++ b/user_manual/groupware/sync_osx.rst
@@ -9,7 +9,7 @@ In the following steps you will add **CalDAV** (Calendar)
 and **CardDAV** (Contacts) to your macOS integrated Calendar and Contacts applications.
 At the time of writing this guide, macOS is at version 26.3.1.
 
-1. Click on the Apple logo in the top left corner of your screen and select
+1. Click on the **Apple** menu and select
    **System Settings...** from the dropdown menu.
 
 .. figure:: ./images/macos_1.png

--- a/user_manual/groupware/sync_thunderbird.rst
+++ b/user_manual/groupware/sync_thunderbird.rst
@@ -59,6 +59,6 @@ Alternative: Using the CardBook add-on (Contacts only)
 
    .. image:: ../images/addressbook_name.png
 
-#. When you are finished, CardBook synchronizes your address books. You can always trigger a synchronization manually by clicking "Synchronize" in the top left corner of CardBook:
+#. When you are finished, CardBook synchronizes your address books. You can always trigger a synchronization manually by clicking the **Synchronize** button in CardBook:
 
    .. image:: ../images/synchronize_cardbook.png

--- a/user_manual/talk/files_integration.rst
+++ b/user_manual/talk/files_integration.rst
@@ -19,7 +19,7 @@ You can then chat or have a call with other participants, even when you start ed
 .. image:: images/text-and-talk.png
     :width: 700px
 
-In Talk, a conversation will be created for the file. You can chat from there, or go back to the file using the ``...`` menu in the top-right.
+In Talk, a conversation will be created for the file. You can chat from there, or go back to the file using the ``...`` menu at the top of the conversation.
 
 .. image:: images/file-room.png
     :width: 400px

--- a/user_manual/talk/guest.rst
+++ b/user_manual/talk/guest.rst
@@ -14,7 +14,7 @@ If you received a link to a chat conversation, you can open it in your browser t
 .. image:: images/guest-view.png
     :width: 400px
 
-You can also change your name later by clicking the ``Edit`` button, located top-right.
+You can also change your name later by clicking the ``Edit`` button in the top bar.
 
 .. image:: images/change-name.png
     :width: 400px
@@ -42,7 +42,7 @@ During a call, you can find the Camera and Microphone settings in the ``...`` me
 .. image:: images/guest-call-menu.png
     :width: 300px
 
-During a call, you can mute your microphone and disable your video with the buttons in the top-right, or using the shortcuts ``M`` to mute audio and ``V`` to disable video. You can also use the ``space bar`` to toggle mute. When you are muted, pressing space will unmute you so you can speak until you let go of the space bar. If you are unmuted, pressing space will mute you until you let go.
+During a call, you can mute your microphone and disable your video with the mute and camera toggle buttons in the call toolbar, or using the shortcuts ``M`` to mute audio and ``V`` to disable video. You can also use the ``space bar`` to toggle mute. When you are muted, pressing space will unmute you so you can speak until you let go of the space bar. If you are unmuted, pressing space will mute you until you let go.
 
 You can hide your video (useful during a screen share) with the little arrow just above the video stream. Bring it back with the little arrow again.
 

--- a/user_manual/userpreferences.rst
+++ b/user_manual/userpreferences.rst
@@ -6,15 +6,15 @@ As a user, you can manage your personal settings.
 
 To access your personal settings:
 
-1. Click your profile picture in the top right corner of your Nextcloud instance to open the menu.
+1. Click your profile picture to open the menu.
 
    .. figure:: images/oc_personal_settings_dropdown.png
-      :alt: screenshot of user menu at top-right of Nextcloud Web GUI
+      :alt: Nextcloud account menu showing Settings, Help, and Log out options
 
 2. Click **Settings** in the dropdown menu to open your personal settings.
 
    .. figure:: images/personal_settings.png
-      :alt: screenshot of users Personal settings page
+      :alt: Nextcloud personal settings page listing profile, security, and notification options
 
 .. note::
    If you are an administrator, you can also manage users and administer
@@ -61,7 +61,7 @@ You can change what personal data is shared by setting the scope of your data.
 Click the lock icon to open the following dropdown next to each entry:
 
    .. figure:: images/userdata-scope.png
-      :alt: screenshot of scope dropdown on personal information form field
+      :alt: Visibility scope dropdown on a personal information field with Private, Local, Federated, and Published options
 
 
 If you set your data to **Private**, nobody but you will be able to see it.
@@ -92,10 +92,10 @@ In your personal settings, find the profile visibility button:
 
    .. figure:: images/userdata-visibility-toggle.png
       :figwidth: 50 %
-      :alt: screenshot of the profile visibility button in personal settings
+      :alt: Profile visibility toggle button in personal settings
 
 
 This allows you to configure the visibility for each profile attribute:
 
    .. figure:: images/userdata-visibility.png
-      :alt: screenshot of scope dropdown on personal information form field
+      :alt: Visibility scope dropdown on a personal information field with Private, Local, Federated, and Published options

--- a/user_manual/webinterface.rst
+++ b/user_manual/webinterface.rst
@@ -51,7 +51,7 @@ Each app also has its own **left sidebar** with filters and actions specific to 
 Settings and profile
 --------------------
 
-Click your profile picture in the top-right corner to access your account options:
+Click your profile picture to access your account options:
 
 .. figure:: images/webinterface_profile_menu.png
    :alt: The profile menu showing options for settings, status, appearance, and logging out.


### PR DESCRIPTION
## Resolves

fix https://github.com/nextcloud/documentation/issues/9672

WCAG 1.3.3 / BITV 9.1.3.3: instructions must not rely solely on sensory
characteristics such as visual position.

## What changed

- Replaced position-only phrases ("in the top right", "bottom-left corner",
  "X in the top right corner", etc.) with element names or labels across
  26 files in user_manual, admin_manual, and developer_manual.
- Reworded alt text that started with "Screenshot of" or used positional
  descriptions like "top-right" without naming the element.

## Screenshots

N/A — text-only changes.

## Checklist

- [x] Read [Contribution Guidelines](https://github.com/nextcloud/documentation/blob/master/CONTRIBUTING.md)
- [x] Documentation change