### PR TITLE
fix(a11y): add dark-theme overrides for hardcoded light-theme colours

### DIFF
--- a/_shared_assets/static/custom.css
+++ b/_shared_assets/static/custom.css
@@ -164,6 +164,31 @@ html[data-theme="dark"] .rst-content img {
 	box-shadow: 0 2px 8px rgba(255, 255, 255, 0.15);
 }
 
+/* Dark-theme overrides — sphinx-rtd-dark-mode sets data-theme="dark" on
+   <html>. The selectors below restore proper contrast for values that
+   were hardcoded for the light (white) background. */
+
+/* Content links: #2474a4 gives only ~3.6:1 on the dark #141414 bg.
+   Defer to the plugin's own variable (= #249ee8, ~6:1 on dark bg). */
+html[data-theme="dark"] .rst-content a,
+html[data-theme="dark"] .rst-content a:visited {
+	color: var(--dark-link-color, #249ee8);
+}
+
+/* Inline code: #c0392b (dark red) gives ~2.4:1 on the #2d2d2d code bg,
+   and the !important above defeats the plugin's dark-mode rule entirely.
+   Use a lighter coral-red (~4.9:1 on #2d2d2d). */
+html[data-theme="dark"] .rst-content code,
+html[data-theme="dark"] .rst-content tt,
+html[data-theme="dark"] code {
+	color: #ff7878 !important;
+}
+
+/* Search icon: #555 is near-invisible on the dark #0b152d sidebar bg. */
+html[data-theme="dark"] .wy-form-search-icon {
+	color: #aaa;
+}
+
 /* ICONS LIST */
 div#list-of-available-icons > blockquote {
 	margin: 0;


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to https://github.com/nextcloud/documentation/pull/14831#issuecomment-4437695419

The recent BITV contrast fixes (#14827, #14828, #14829, #14830) hardcoded colours chosen for the white/light background. The `sphinx-rtd-dark-mode` plugin switches backgrounds to `#141414` (content) and `#2d2d2d` (code), making those values fail WCAG AA in dark mode:

| Element | Colour | Dark bg | Contrast | Issue |
|---|---|---|---|---|
| `.rst-content a` | `#2474a4` | `#141414` | 3.6:1 | needs 4.5:1; also overrides plugin's `--dark-link-color` |
| `code` | `#c0392b !important` | `#2d2d2d` | 2.4:1 | `!important` defeats plugin's `html[data-theme="dark"]` rule |
| `.wy-form-search-icon` | `#555` | `#0b152d` | ~1.7:1 | icon invisible |

Adds `html[data-theme="dark"]` overrides scoped to dark mode only — no changes to existing light-theme rules:
- Links → `var(--dark-link-color, #249ee8)` (~6.1:1 on `#141414`)
- Inline code → `#ff7878` (~4.9:1 on `#2d2d2d`)
- Search icon → `#aaa`

### 🖼️ Screenshots

<!-- Please add a screenshot of your changed or added page(s). -->

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues