### PR TITLE
fix(a11y): add meaningful alt text to images missing it

### DIFF
--- a/admin_manual/configuration_files/default_files_configuration.rst
+++ b/admin_manual/configuration_files/default_files_configuration.rst
@@ -19,10 +19,12 @@ affecting the originals.
 This screenshot shows a set of photos in the ``skeleton`` directory.
 
 .. image:: ../images/skeleton-files.png
+   :alt: Set of photos in the Nextcloud skeleton directory
 
 They appear on the user's Nextcloud Files page just like any other files.
 
 .. image:: ../images/skeleton-files1.png
+   :alt: Nextcloud Files page showing default skeleton files visible after first login
 
 .. note:: Overwriting the files in ``core/skeleton`` is not recommended,
   because those changes will be overwritten on the next update of the Nextcloud

--- a/admin_manual/exapps_management/AdvancedDeployOptions.rst
+++ b/admin_manual/exapps_management/AdvancedDeployOptions.rst
@@ -9,6 +9,7 @@ AppAPI allows optionally to configure environment variables and mounts for the E
 It is available via "Deploy options" modal next to "Deploy and Enable" button in the sidebar of the ExApp page on the Apps management page:
 
 .. image:: ./img/advanced_deploy_options_1.png
+   :alt: AppAPI apps page showing the Deploy options button next to Deploy and Enable in the ExApp sidebar
 
 Or via CLI (:ref:`advanced_deploy_options_cli`).
 
@@ -23,6 +24,7 @@ only these variables will be available for configuration.
 By default there are only mounts available for configuration.
 
 .. image:: ./img/advanced_deploy_options_2.png
+   :alt: AppAPI Deploy options modal showing environment variables configuration
 
 When ExApp installed the list of set environment variables will be displayed.
 
@@ -35,3 +37,4 @@ For example, it will be useful for some apps to provide a folder with SSL certs 
 so the app can handle HTTPS correctly without any additional re-installation of the ExApp.
 
 .. image:: ./img/advanced_deploy_options_3.png
+   :alt: AppAPI Deploy options modal showing mounts configuration

--- a/admin_manual/exapps_management/AppAPIAndExternalApps.rst
+++ b/admin_manual/exapps_management/AppAPIAndExternalApps.rst
@@ -89,6 +89,7 @@ Docker Socket Proxy
     For remote DSP setup, it should expose the ports on the host.
 
 .. image:: ./img/app_api_3.png
+   :alt: AppAPI admin settings showing Deploy Daemon configuration form with Check connection button
 
 Deployment configuration examples can be found :doc:`here <./DeployConfigurations>`.
 
@@ -99,6 +100,7 @@ You can now install ExApps from the Nextcloud App Store by clicking "Install" on
 If successful, the ExApp will be displayed under the "Your apps" list.
 
 .. image:: ./img/exapp_list_example.png
+   :alt: Nextcloud Apps page showing installed ExApps in the Your apps list
 
 FAQ
 ---

--- a/admin_manual/exapps_management/DeployConfigurations.rst
+++ b/admin_manual/exapps_management/DeployConfigurations.rst
@@ -74,6 +74,7 @@ Create a HaRP container with either ``--network host`` option or expose the port
 Go to AppAPI admin settings and register a ``HaRP Proxy (Host)`` daemon.
 
 .. image:: ./img/harp_host.png
+   :alt: AppAPI admin settings showing registration of HaRP Proxy (Host) daemon
 
 Finally, test the whole setup with "Test deploy" in the 3-dots menu of the deploy daemon.
 
@@ -99,6 +100,7 @@ Create a HaRP container with ``--network <nextcloud_docker_network_name>`` optio
 Go to AppAPI admin settings and register a ``HaRP Proxy (Docker)`` daemon. Take note of the ``<nextcloud_docker_network_name>`` value in the ``Docker network`` field.
 
 .. image:: ./img/harp_docker.png
+   :alt: AppAPI admin settings showing registration of HaRP Proxy (Docker) daemon
 
 Finally, test the whole setup with "Test deploy" in the 3-dots menu of the deploy daemon.
 
@@ -126,6 +128,7 @@ A setup with the HaRP container itself on the remote is not supported.
 2. Create a matching deploy daemon with ``Docker socket proxy port`` set to ``24001``.
 
   .. image:: ./img/harp_remote_24001.png
+     :alt: AppAPI deploy daemon configuration with Docker socket proxy port set to 24001
 
 3. The FRP generated client certificates should be present in the ``certs`` folder locally. Copy the files ``client.crt``, ``client.key`` and ``ca.crt`` inside the ``certs`` folder to the remote host.
 4. Create a folder structure on the remote host: ``mkdir -p certs/frp`` and copy the files ``client.crt``, ``client.key`` and ``ca.crt`` to the ``certs/frp`` folder.

--- a/admin_manual/exapps_management/TestDeploy.rst
+++ b/admin_manual/exapps_management/TestDeploy.rst
@@ -6,6 +6,7 @@ Test Deploy Daemon
 You can test each Daemon configuration deployment from the AppAPI Admin settings.
 
 .. image:: ./img/test_deploy.png
+   :alt: AppAPI admin settings showing daemon configuration with Test deploy option in three-dots menu
 
 
 Status Checks
@@ -21,6 +22,7 @@ for each compute device, there is a separate Docker image.
     The Docker images are also not removed from the Daemon; you can clean up unused images with the ``docker image prune`` command.
 
 .. image:: ./img/test_deploy_modal_4.png
+   :alt: AppAPI test deploy modal showing deployment status checks
 
 
 Register

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -123,14 +123,17 @@ steps:
 This is how the web based update would continue:
 
 .. image:: images/updater-7-disable-maintenance.png
+   :alt: Nextcloud web updater showing option to disable maintenance mode after upgrade
 
 .. image:: images/updater-9-upgrade-page.png
+   :alt: Nextcloud upgrade page displayed after the web updater completes
 
 **Command line based upgrade**
 
 This is how the command line based update would continue:
 
 .. image:: images/updater-8-keep-maintenance.png
+   :alt: Nextcloud command line updater asking whether to keep maintenance mode active
 
 
 .. code::
@@ -172,6 +175,7 @@ The steps are basically the same as for the web based updater:
     notification app is enabled in the apps management.
 
 .. image:: images/updater-1-update-available.png
+   :alt: Nextcloud admin settings Version section showing an update available notification
 
 2. Instead of clicking that button you can now invoke the command line based
    updater by going into the `updater/` directory in the Nextcloud directory
@@ -179,14 +183,17 @@ The steps are basically the same as for the web based updater:
    ``sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar``)
 
 .. image:: images/updater-cli-2-start-updater.png
+   :alt: Terminal showing Nextcloud command line updater starting and displaying update information
    :class: terminal-image
 
 3.  Verify the information that is shown and enter "Y" to start the update.
 
 .. image:: images/updater-cli-3-running-step.png
+   :alt: Terminal showing Nextcloud command line updater executing update steps
    :class: terminal-image
 
 .. image:: images/updater-cli-4-failed-step.png
+   :alt: Terminal showing Nextcloud command line updater with a failed step and error feedback
    :class: terminal-image
 
 4.  In case an error happens or the check failed the updater stops processing
@@ -195,6 +202,7 @@ The steps are basically the same as for the web based updater:
     It will not re-run the previous succeeded steps.
 
 .. image:: images/updater-cli-5-continue-update.png
+   :alt: Terminal showing Nextcloud command line updater ready to continue after resolving an error
    :class: terminal-image
 
 6. Once all steps are executed the updater will ask you a final question:
@@ -204,12 +212,14 @@ The steps are basically the same as for the web based updater:
    `Please now execute "./occ upgrade" to finish the upgrade.`.
 
 .. image:: images/updater-cli-6-run-command.png
+   :alt: Terminal showing Nextcloud command line updater asking whether to run the occ upgrade command
    :class: terminal-image
 
 7. Once the ``occ upgrade`` is done you get asked if the maintenance mode
    should be kept active.
 
 .. image:: images/updater-cli-7-maintenance.png
+   :alt: Terminal showing Nextcloud command line updater asking whether to keep maintenance mode active
    :class: terminal-image
 
 Batch mode for command line based updater
@@ -226,6 +236,7 @@ To execute this, run the command with the ``--no-interaction`` option. (i.e.
 ``sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar --no-interaction``)
 
 .. image:: images/updater-cli-8-no-interaction.png
+   :alt: Terminal showing Nextcloud command line updater running in non-interactive batch mode
    :class: terminal-image
 
 Troubleshooting

--- a/admin_manual/office/index.rst
+++ b/admin_manual/office/index.rst
@@ -3,6 +3,7 @@ Office
 ===============
 
 .. image:: ../images/office.png
+   :alt: Nextcloud Office document editing interface with collaborative editing
 
 Nextcloud Office supports editing your documents in real time with multiple other editors, showing high fidelity, WYSIWYG rendering and preserving the layout and formatting of your documents.
 

--- a/user_manual/collectives/getting_started.rst
+++ b/user_manual/collectives/getting_started.rst
@@ -8,6 +8,7 @@ knowledge. You can even embed task boards, whiteboards and calendars. Collective
 emphasizes horizontal and non-hierarchical workflows.
 
 .. image:: images/screenshot.png
+   :alt: Nextcloud Collectives app showing a list of pages and collaborative editing interface
 
 Why use Collectives?
 --------------------
@@ -27,6 +28,7 @@ expects that you open Collectives in a desktop browser (i.e. not on mobile).
 1. Select the Collectives app in the app menu on the top:
 
    .. image:: images/open_app.png
+      :alt: Nextcloud app menu showing the Collectives app icon
       :width: 100px
 2. Click on “New collective”.
 3. Enter the name ``My first collective`` and choose an emoji (or keep the preselected one).

--- a/user_manual/groupware/sync_gnome.rst
+++ b/user_manual/groupware/sync_gnome.rst
@@ -11,6 +11,7 @@ This can be done by following these steps:
 #. Under "Add an account" pick ``Nextcloud``:
 
    .. image:: ../images/gnome-online-accounts.png
+      :alt: GNOME Settings Online Accounts page with Nextcloud listed under available providers
 
 #. Enter your server URL, username, and password.
    If you have enabled two-factor authentication (2FA), you need to generate an application password/token, because GNOME Online Accounts
@@ -18,11 +19,13 @@ This can be done by following these steps:
    (:ref:`Learn more <managing_devices>`):
 
    .. image:: ../images/goa-add-nextcloud-account.png
+      :alt: GNOME Online Accounts dialog to add a Nextcloud account with server URL and credentials fields
 
 #. In the next window, select which resources GNOME should access and
    press the **Close** button to close the dialog:
 
    .. image:: ../images/goa-nextcloud-select.png
+      :alt: GNOME Online Accounts dialog to select which Nextcloud resources to synchronize
 
 Nextcloud tasks, calendars, and contacts should now be visible in the Evolution PIM, as well as the Task, Contacts, and Calendars apps.
 

--- a/user_manual/groupware/sync_thunderbird.rst
+++ b/user_manual/groupware/sync_thunderbird.rst
@@ -32,6 +32,7 @@ Calendars
 #. Choose **On the network**:
 
    .. image:: ../images/new_calendar.png
+      :alt: Thunderbird new calendar dialog with "On the network" option selected
 
 #. Type your **Username** and **Location** (Server URL), then click on **Find Calendars**.
 #. Choose which calendars you want to add and click **Subscribe**
@@ -47,6 +48,7 @@ Alternative: Using the CardBook add-on (Contacts only)
 #. Click the CardBook icon in the upper right corner of Thunderbird:
 
    .. image:: ../images/cardbook_icon.png
+      :alt: CardBook icon in Thunderbird toolbar
 
 #. In CardBook:
 
@@ -54,11 +56,14 @@ Alternative: Using the CardBook add-on (Contacts only)
    -  Select **CardDAV**, fill in the address of your Nextcloud server, your user name and password
 
    .. image:: ../images/new_addressbook.png
+      :alt: CardBook new address book dialog with CardDAV option selected
 
 #. Click on "Validate", click Next, then choose the name of the address book and click Next again:
 
    .. image:: ../images/addressbook_name.png
+      :alt: CardBook dialog to enter a name for the new address book
 
 #. When you are finished, CardBook synchronizes your address books. You can always trigger a synchronization manually by clicking the **Synchronize** button in CardBook:
 
    .. image:: ../images/synchronize_cardbook.png
+      :alt: CardBook address book view with Synchronize button


### PR DESCRIPTION
### ☑️ Resolves

* Fix #9663

Remaining images from the BITV 9.1.1.1b audit where informative images lacked `:alt:` options — causing Sphinx to render the file path as the `alt` attribute value (e.g. `alt="../_images/anonym_click_sharing.png"`).

**Files fixed (34 images total):**
- `user_manual/groupware/sync_thunderbird.rst` — 5 images (Thunderbird calendar/CardBook dialogs)
- `user_manual/groupware/sync_gnome.rst` — 3 images (GNOME Online Accounts dialogs)
- `user_manual/collectives/getting_started.rst` — 2 images (Collectives overview, app menu)
- `admin_manual/office/index.rst` — 1 image (Nextcloud Office interface)
- `admin_manual/configuration_files/default_files_configuration.rst` — 2 images (skeleton files)
- `admin_manual/maintenance/update.rst` — 11 images (web and CLI updater steps)
- `admin_manual/exapps_management/AdvancedDeployOptions.rst` — 3 images
- `admin_manual/exapps_management/DeployConfigurations.rst` — 3 images
- `admin_manual/exapps_management/TestDeploy.rst` — 2 images
- `admin_manual/exapps_management/AppAPIAndExternalApps.rst` — 2 images

Alt text describes what is depicted in each image based on surrounding context.

### 🖼️ Screenshots

N/A — only RST `:alt:` option additions, no visual page layout changes.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes — N/A, text-only change
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues