### PR TITLE
docs(admin): document mail preview_enhancement_interval

### DIFF
--- a/admin_manual/groupware/mail.rst
+++ b/admin_manual/groupware/mail.rst
@@ -50,6 +50,23 @@ Configure how often Mail keeps users' mailboxes updated in the background in sec
 
     'app.mail.background-sync-interval' => 7200,
 
+Preview enhancement interval
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Configure how often the preview-enhancement background job runs in seconds. Defaults to 3600, minimum 60.
+
+This job populates the ``imip_message`` flag on incoming messages. The iMIP background job, which turns calendar
+invitations into actual events, only picks up messages once that flag is set, so this interval is the upper bound
+on how long an inbound invitation can take to appear in the user's calendar. Smaller setups that want invitations
+to feel live can lower this to the 60–300 second range; larger installations should keep the default to avoid
+extra database load.
+
+::
+
+    occ config:app:set mail preview_enhancement_interval --value=300 --type=integer
+
+The new value takes effect on the next scheduler tick — no service restart required.
+
 Disable TLS verification for IMAP/SMTP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### 🔗 Dependency

This is the docs companion to **nextcloud/mail#12791**, which makes the
preview-enhancement background-job interval configurable. Marked as draft
until that lands so we don't ship docs for a key that doesn't exist yet.
The key name and \`occ\` syntax in this PR matches the post-review state of
that PR (\`IAppConfig\`-style \`preview_enhancement_interval\`, no dots).

### 📄 Change

Adds a new \"Preview enhancement interval\" subsection under
\`admin_manual/groupware/mail.rst\` → Configuration, immediately after the
existing \"Background sync interval\" section. Wording mirrors that
section's structure (what it does, default, minimum, when to change),
adds the iMIP context that motivated making it configurable, and uses
\`occ config:app:set mail …\` to match the new IAppConfig backing.

Requested by @ChristophWurst on the upstream PR review.

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes — n/a, prose-only addition next to an existing analogous section
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run \`codespell\` or similar and addressed any spelling issues