### PR TITLE
docs(updater): document --url option for offline/air-gapped installs

### DIFF
--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -265,14 +265,14 @@ Point the updater at any HTTP/HTTPS URL:
 .. code-block:: bash
 
     sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
-        --url https://mirror.example.com/nextcloud-30.0.0.tar.bz2
+        --url https://download.nextcloud.com/server/releases/nextcloud-33.0.0.zip
 
 For a locally staged archive, use a ``file://`` URL:
 
 .. code-block:: bash
 
     sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
-        --url file:///tmp/nextcloud-30.0.0.tar.bz2
+        --url file:///tmp/nextcloud-33.0.0.zip
 
 Signature verification
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -288,7 +288,7 @@ automatically. You have two options:
   .. code-block:: bash
 
       sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
-          --url file:///tmp/nextcloud-30.0.0.tar.bz2 \
+          --url file:///tmp/nextcloud-33.0.0.zip \
           --signature "BASE64_SIGNATURE_HERE"
 
 * **Skip verification** — pass ``--no-verify`` to disable integrity checking
@@ -298,7 +298,7 @@ automatically. You have two options:
   .. code-block:: bash
 
       sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
-          --url file:///tmp/nextcloud-30.0.0.tar.bz2 \
+          --url file:///tmp/nextcloud-33.0.0.zip \
           --no-verify
 
 .. warning::
@@ -312,7 +312,7 @@ runs:
 .. code-block:: bash
 
     sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
-        --url file:///tmp/nextcloud-30.0.0.tar.bz2 \
+        --url file:///tmp/nextcloud-33.0.0.zip \
         --signature "BASE64_SIGNATURE_HERE" \
         --no-interaction
 

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -239,6 +239,68 @@ To execute this, run the command with the ``--no-interaction`` option. (i.e.
    :alt: Terminal showing Nextcloud command line updater running in non-interactive batch mode
    :class: terminal-image
 
+Using a custom download URL (offline / air-gapped installs)
+------------------------------------------------------------
+
+By default the updater fetches the Nextcloud release archive from the official
+download servers. In environments without internet access — or when you want to
+serve the archive from an internal mirror — you can point the updater at any
+HTTP/HTTPS URL with the ``--url`` option:
+
+.. code-block:: bash
+
+    sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+        --url https://mirror.example.com/nextcloud-30.0.0.tar.bz2
+
+For local file access you can use a ``file://`` URL:
+
+.. code-block:: bash
+
+    sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+        --url file:///tmp/nextcloud-30.0.0.tar.bz2
+
+Signature verification
+~~~~~~~~~~~~~~~~~~~~~~
+
+When ``--url`` is used the updater cannot look up the official signature
+automatically. You have two options:
+
+* **Provide the signature** — pass the base64-encoded signature with
+  ``--signature``. You can get the signature from
+  https://nextcloud.com/changelog/ or from the same mirror that hosts the
+  archive:
+
+  .. code-block:: bash
+
+      sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+          --url file:///tmp/nextcloud-30.0.0.tar.bz2 \
+          --signature "BASE64_SIGNATURE_HERE"
+
+* **Skip verification** — pass ``--no-verify`` to disable integrity checking
+  entirely. Only do this if you fully trust the source of the archive and the
+  transfer channel:
+
+  .. code-block:: bash
+
+      sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+          --url file:///tmp/nextcloud-30.0.0.tar.bz2 \
+          --no-verify
+
+.. warning::
+   Skipping signature verification (``--no-verify``) removes the integrity
+   check that protects against corrupted or tampered archives. Only use it
+   when the archive comes from a fully trusted, controlled source.
+
+These options can be combined with ``--no-interaction`` for fully automated
+offline update runs:
+
+.. code-block:: bash
+
+    sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+        --url file:///tmp/nextcloud-30.0.0.tar.bz2 \
+        --signature "BASE64_SIGNATURE_HERE" \
+        --no-interaction
+
 Troubleshooting
 ---------------
 

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -239,20 +239,35 @@ To execute this, run the command with the ``--no-interaction`` option. (i.e.
    :alt: Terminal showing Nextcloud command line updater running in non-interactive batch mode
    :class: terminal-image
 
-Using a custom download URL (offline / air-gapped installs)
-------------------------------------------------------------
+Using a custom download URL
+---------------------------
 
-By default the updater fetches the Nextcloud release archive from the official
-download servers. In environments without internet access — or when you want to
-serve the archive from an internal mirror — you can point the updater at any
-HTTP/HTTPS URL with the ``--url`` option:
+The ``--url`` option lets you override the archive the updater downloads.
+Common use cases:
+
+* **Pinning a specific version** — install an exact patch release rather than
+  whatever the update check resolves to.
+* **Internal mirrors** — serve the archive from a company mirror or proxy.
+* **Offline / air-gapped environments** — stage the archive locally and
+  supply it via a ``file://`` URL.
+
+.. warning::
+   The normal update rules still apply when using ``--url``:
+
+   * **Downgrading is not supported** and risks data corruption.
+   * **Skipping major versions is not supported.** You must update one major
+     version at a time (e.g. 28 → 29 → 30, not 28 → 30).
+
+   Passing ``--url`` does not bypass these constraints.
+
+Point the updater at any HTTP/HTTPS URL:
 
 .. code-block:: bash
 
     sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
         --url https://mirror.example.com/nextcloud-30.0.0.tar.bz2
 
-For local file access you can use a ``file://`` URL:
+For a locally staged archive, use a ``file://`` URL:
 
 .. code-block:: bash
 
@@ -292,7 +307,7 @@ automatically. You have two options:
    when the archive comes from a fully trusted, controlled source.
 
 These options can be combined with ``--no-interaction`` for fully automated
-offline update runs:
+runs:
 
 .. code-block:: bash
 

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -138,7 +138,7 @@ This is how the command line based update would continue:
 
 .. code::
 
-    $ sudo -E -u www-data php ./occ upgrade
+    $ sudo -u www-data php ./occ upgrade
     Nextcloud or one of the apps require upgrade - only a limited number of commands are available
     You may use your browser or the occ upgrade command to do the upgrade
     Set log level to debug
@@ -180,7 +180,7 @@ The steps are basically the same as for the web based updater:
 2. Instead of clicking that button you can now invoke the command line based
    updater by going into the `updater/` directory in the Nextcloud directory
    and executing the `updater.phar` as the web server user. (i.e.
-   ``sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar``)
+   ``sudo -u www-data php /var/www/nextcloud/updater/updater.phar``)
 
 .. image:: images/updater-cli-2-start-updater.png
    :alt: Terminal showing Nextcloud command line updater starting and displaying update information
@@ -233,7 +233,7 @@ except an error occurred during the ``occ upgrade`` or the replacement of the
 code.
 
 To execute this, run the command with the ``--no-interaction`` option. (i.e.
-``sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar --no-interaction``)
+``sudo -u www-data php /var/www/nextcloud/updater/updater.phar --no-interaction``)
 
 .. image:: images/updater-cli-8-no-interaction.png
    :alt: Terminal showing Nextcloud command line updater running in non-interactive batch mode
@@ -264,7 +264,7 @@ Point the updater at any HTTP/HTTPS URL:
 
 .. code-block:: bash
 
-    sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+    sudo -u www-data php /var/www/nextcloud/updater/updater.phar \
         --url https://download.nextcloud.com/server/releases/nextcloud-33.0.0.zip
 
 
@@ -274,7 +274,7 @@ For a locally staged archive, use a ``file://`` URL:
 
 .. code-block:: bash
 
-    sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+    sudo -u www-data php /var/www/nextcloud/updater/updater.phar \
         --url file:///tmp/nextcloud-33.0.0.zip
 
 Signature verification
@@ -290,31 +290,38 @@ automatically. You have two options:
 
   .. code-block:: bash
 
-      sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+      sudo -u www-data php /var/www/nextcloud/updater/updater.phar \
           --url file:///tmp/nextcloud-33.0.0.zip \
           --signature "BASE64_SIGNATURE_HERE"
 
 * **Skip verification** — pass ``--no-verify`` to disable integrity checking
-  entirely. Only do this if you fully trust the source of the archive and the
-  transfer channel:
+  entirely. Only do this if you fully trust the source and transfer channel,
+  or if you have already verified the archive yourself (e.g. by checking the
+  SHA-512 checksum):
 
   .. code-block:: bash
 
-      sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+      sha512sum -c nextcloud-33.0.0.zip.sha512
+
+  Then run the updater without signature checking:
+
+  .. code-block:: bash
+
+      sudo -u www-data php /var/www/nextcloud/updater/updater.phar \
           --url file:///tmp/nextcloud-33.0.0.zip \
           --no-verify
 
-.. warning::
-   Skipping signature verification (``--no-verify``) removes the integrity
-   check that protects against corrupted or tampered archives. Only use it
-   when the archive comes from a fully trusted, controlled source.
+  .. warning::
+     ``--no-verify`` removes the integrity check that protects against
+     corrupted or tampered archives. Always verify the archive through an
+     independent channel before using this option.
 
 These options can be combined with ``--no-interaction`` for fully automated
 runs:
 
 .. code-block:: bash
 
-    sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
+    sudo -u www-data php /var/www/nextcloud/updater/updater.phar \
         --url file:///tmp/nextcloud-33.0.0.zip \
         --signature "BASE64_SIGNATURE_HERE" \
         --no-interaction

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -254,7 +254,7 @@ Common use cases:
 .. warning::
    The normal update rules still apply when using ``--url``:
 
-   * **Downgrading is not supported** and risks data corruption.
+   * **Downgrading is not supported**.
    * **Skipping major versions is not supported.** You must update one major
      version at a time (e.g. 28 → 29 → 30, not 28 → 30).
 
@@ -266,6 +266,9 @@ Point the updater at any HTTP/HTTPS URL:
 
     sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar \
         --url https://download.nextcloud.com/server/releases/nextcloud-33.0.0.zip
+
+
+.. versionadded:: 34
 
 For a locally staged archive, use a ``file://`` URL:
 


### PR DESCRIPTION
| 1 | 2 |
|:---------:|:------:|
|<img width="975" height="801" alt="2026-05-13_16-11" src="https://github.com/user-attachments/assets/ebfa2c20-f37a-49f6-a125-e367fafc8de9" />|<img width="976" height="748" alt="2026-05-13_16-11_1" src="https://github.com/user-attachments/assets/f0007e7f-bb87-44b5-bc8d-586833ab0d7e" />|

### ☑️ Resolves

Relates to the `--url` option added to `updater.phar`.

### What changed and why

Adds a new section **"Using a custom download URL (offline / air-gapped installs)"** to `admin_manual/maintenance/update.rst`.

The `updater.phar` supports a `--url` option that lets admins point the updater at any HTTP/HTTPS or `file://` URL instead of the official download servers. This is useful for:
- Air-gapped / offline environments where the server has no internet access
- Internal mirrors in enterprise setups

The section covers:
- `--url` with HTTP/HTTPS mirror example
- `--url` with `file://` for locally staged archives
- `--signature` to supply the base64 archive signature when using a custom URL
- `--no-verify` as an escape hatch (with a warning)
- Combined `--no-interaction` example for fully automated offline runs

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues