### PR TITLE
fix(occ): clarify occ upgrade only runs migrations, not code replacement

### DIFF
--- a/admin_manual/occ_system.rst
+++ b/admin_manual/occ_system.rst
@@ -893,6 +893,21 @@ Command line upgrade
 These commands are available after downloading an upgraded package or tarball,
 and before completing the upgrade.
 
+.. important::
+   ``occ upgrade`` only runs the **migration phase**: database schema updates and
+   app upgrades. It does **not** download or replace Nextcloud's code files.
+
+   Before running ``occ upgrade`` you must first replace the code using one of:
+
+   * The built-in updater: ``sudo -E -u www-data php /var/www/nextcloud/updater/updater.phar``
+   * A manually extracted tarball (see :doc:`../maintenance/manual_upgrade`)
+
+   If ``occ upgrade`` reports *"Nextcloud is up to date"* when you expect an upgrade
+   to run, the code files have not been replaced yet — run the updater or extract
+   the new tarball first.
+
+   See :doc:`../maintenance/upgrade` for the full upgrade process.
+
 When performing an upgrade, use ``occ upgrade`` instead of the web-based
 upgrader to avoid PHP timeout limits (the web interface enforces a 3600-second
 limit). On large installations this may not be sufficient, leaving the system


### PR DESCRIPTION
### ☑️ Resolves

* Fix #8837

### Summary

The `occ upgrade` "Command line upgrade" section was misleading: users would run `occ upgrade` before updating code files and get "Nextcloud is up to date" — technically correct but confusing since the *code* update hadn't happened yet.

Added an `.. important::` block that:
- Explicitly states `occ upgrade` handles **DB migrations and app upgrades only** — it does not download or replace code files
- Lists prerequisites (run `updater.phar` or extract a tarball first)
- Explains the "Nextcloud is up to date" false negative and how to resolve it
- Links to the full upgrade docs

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues