### PR TITLE
fix(docs): add dedicated MariaDB backup/restore sections

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -40,27 +40,27 @@ Backup database
 
 .. warning:: Before restoring a backup see :doc:`restore`
 
-MySQL
-^^^^^
-
-MySQL is the recommended database engine. To backup MySQL::
-
-    mysqldump --single-transaction -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
-
-If you have enabled MySQL 4-byte support (:doc:`../configuration_database/mysql_4byte_support`, needed for emoji), add ``--default-character-set=utf8mb4``::
-
-    mysqldump --single-transaction --default-character-set=utf8mb4 -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
-
 MariaDB
 ^^^^^^^
 
-To backup MariaDB using `mariadb-dump <https://mariadb.com/docs/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump>`_::
+MariaDB is the recommended database engine. To backup MariaDB using `mariadb-dump <https://mariadb.com/docs/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump>`_::
 
     mariadb-dump --single-transaction -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
 If you have enabled MariaDB 4-byte support (:doc:`../configuration_database/mysql_4byte_support`, needed for emoji), add ``--default-character-set=utf8mb4``::
 
     mariadb-dump --single-transaction --default-character-set=utf8mb4 -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
+
+MySQL
+^^^^^
+
+To backup MySQL::
+
+    mysqldump --single-transaction -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
+
+If you have enabled MySQL 4-byte support (:doc:`../configuration_database/mysql_4byte_support`, needed for emoji), add ``--default-character-set=utf8mb4``::
+
+    mysqldump --single-transaction --default-character-set=utf8mb4 -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
 SQLite
 ^^^^^^

--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -40,19 +40,27 @@ Backup database
 
 .. warning:: Before restoring a backup see :doc:`restore`
 
-MySQL/MariaDB
-^^^^^^^^^^^^^
+MySQL
+^^^^^
 
-MySQL or MariaDB, which is a drop-in MySQL replacement, is the recommended
-database engine. To backup **MySQL**::
+MySQL is the recommended database engine. To backup MySQL::
 
     mysqldump --single-transaction -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
-If you use enabled MySQL/MariaDB 4-byte support (:doc:`../configuration_database/mysql_4byte_support`, needed for emoji), you will need to add ``--default-character-set=utf8mb4`` like this::
+If you have enabled MySQL 4-byte support (:doc:`../configuration_database/mysql_4byte_support`, needed for emoji), add ``--default-character-set=utf8mb4``::
 
     mysqldump --single-transaction --default-character-set=utf8mb4 -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
-To backup **MariaDB**, replace `mysqldump` with `mariadb-dump` in the above commands.
+MariaDB
+^^^^^^^
+
+To backup MariaDB using `mariadb-dump <https://mariadb.com/docs/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump>`_::
+
+    mariadb-dump --single-transaction -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
+
+If you have enabled MariaDB 4-byte support (:doc:`../configuration_database/mysql_4byte_support`, needed for emoji), add ``--default-character-set=utf8mb4``::
+
+    mariadb-dump --single-transaction --default-character-set=utf8mb4 -h [server] -u [username] -p[password] [db_name] > nextcloud-sqlbkp_`date +"%Y%m%d"`.bak
 
 SQLite
 ^^^^^^

--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -48,7 +48,7 @@ If you use UTF8 with multibyte support (e.g. for emojis in filenames), use::
 MariaDB
 ^^^^^^^
 
-To restore MariaDB using the `mariadb <https://mariadb.com/kb/en/mariadb-command-line-client/>`_ client::
+To restore MariaDB using the `mariadb <https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client>`_ client::
 
    mariadb -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
    mariadb -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud"
@@ -82,7 +82,7 @@ MySQL is the recommended database engine. To restore MySQL::
 MariaDB
 ^^^^^^^
 
-To restore MariaDB using the `mariadb <https://mariadb.com/kb/en/mariadb-command-line-client/>`_ client::
+To restore MariaDB using the `mariadb <https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client>`_ client::
 
     mariadb -h [server] -u [username] -p[password] [db_name] < nextcloud-sqlbkp.bak
 

--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -32,23 +32,10 @@ Restore database
 The easiest way to do this is to drop and recreate the database.
 SQLite does this automatically.
 
-MySQL
-^^^^^
-
-MySQL is the recommended database engine. To restore MySQL::
-
-   mysql -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
-   mysql -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud"
-
-If you use UTF8 with multibyte support (e.g. for emojis in filenames), use::
-
-   mysql -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
-   mysql -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
-
 MariaDB
 ^^^^^^^
 
-To restore MariaDB using the `mariadb <https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client>`_ client::
+MariaDB is the recommended database engine. To restore MariaDB using the `mariadb <https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client>`_ client::
 
    mariadb -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
    mariadb -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud"
@@ -57,6 +44,19 @@ If you use UTF8 with multibyte support (e.g. for emojis in filenames), use::
 
    mariadb -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
    mariadb -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
+
+MySQL
+^^^^^
+
+To restore MySQL::
+
+   mysql -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
+   mysql -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud"
+
+If you use UTF8 with multibyte support (e.g. for emojis in filenames), use::
+
+   mysql -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
+   mysql -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
 
 
 PostgreSQL
@@ -72,19 +72,19 @@ Restoring
 .. note:: This guide assumes that your previous backup is called
    "nextcloud-sqlbkp.bak"
 
-MySQL
-^^^^^
-
-MySQL is the recommended database engine. To restore MySQL::
-
-    mysql -h [server] -u [username] -p[password] [db_name] < nextcloud-sqlbkp.bak
-
 MariaDB
 ^^^^^^^
 
-To restore MariaDB using the `mariadb <https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client>`_ client::
+MariaDB is the recommended database engine. To restore MariaDB using the `mariadb <https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client>`_ client::
 
     mariadb -h [server] -u [username] -p[password] [db_name] < nextcloud-sqlbkp.bak
+
+MySQL
+^^^^^
+
+To restore MySQL::
+
+    mysql -h [server] -u [username] -p[password] [db_name] < nextcloud-sqlbkp.bak
 
 SQLite
 ^^^^^^

--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -45,6 +45,19 @@ If you use UTF8 with multibyte support (e.g. for emojis in filenames), use::
    mysql -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
    mysql -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
 
+MariaDB
+^^^^^^^
+
+To restore MariaDB using the `mariadb <https://mariadb.com/kb/en/mariadb-command-line-client/>`_ client::
+
+   mariadb -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
+   mariadb -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud"
+
+If you use UTF8 with multibyte support (e.g. for emojis in filenames), use::
+
+   mariadb -h [server] -u [username] -p[password] -e "DROP DATABASE nextcloud"
+   mariadb -h [server] -u [username] -p[password] -e "CREATE DATABASE nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
+
 
 PostgreSQL
 ^^^^^^^^^^
@@ -65,6 +78,13 @@ MySQL
 MySQL is the recommended database engine. To restore MySQL::
 
     mysql -h [server] -u [username] -p[password] [db_name] < nextcloud-sqlbkp.bak
+
+MariaDB
+^^^^^^^
+
+To restore MariaDB using the `mariadb <https://mariadb.com/kb/en/mariadb-command-line-client/>`_ client::
+
+    mariadb -h [server] -u [username] -p[password] [db_name] < nextcloud-sqlbkp.bak
 
 SQLite
 ^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13420

### What changed and why

Split the combined `MySQL/MariaDB` section in both `backup.rst` and `restore.rst` into separate **MySQL** and **MariaDB** subsections.

Previously the docs told users to "replace `mysqldump` with `mariadb-dump`" — a one-liner that gave no commands, no context, and no link to MariaDB docs. The official MariaDB project recommends using their native tooling (`mariadb-dump` / `mariadb`) rather than the MySQL aliases.

Changes:
- `backup.rst`: separate MySQL and MariaDB sections, MariaDB uses `mariadb-dump` with link to [official MariaDB docs](https://mariadb.com/docs/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump), includes 4-byte support variant
- `restore.rst`: separate MySQL and MariaDB sections in both the drop/create block and the import block, MariaDB uses `mariadb` client with link to [MariaDB KB](https://mariadb.com/kb/en/mariadb-command-line-client/), includes utf8mb4 variant

### 🖼️ Screenshots



| backup | restore |
|:---------:|:------:|
|<img width="1102" height="848" alt="image" src="https://github.com/user-attachments/assets/fdb8ab32-c6fe-4891-9218-62bed1cea779" />|<img width="1102" height="848" alt="image" src="https://github.com/user-attachments/assets/238270b3-9104-49f8-ba72-a5dc9e67298f" />|

cc @theking2

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues