### PR TITLE
fix(docs): move app management API to Apps section

### DIFF
--- a/admin_manual/apps_management_api.rst
+++ b/admin_manual/apps_management_api.rst
@@ -1,6 +1,6 @@
-========================
-Instruction set for apps
-========================
+===================
+Apps management API
+===================
 
 Get list of apps
 ----------------
@@ -173,4 +173,3 @@ XML output
       <status>ok</status>
     </meta>
   </ocs>
-

--- a/admin_manual/conf.py
+++ b/admin_manual/conf.py
@@ -153,4 +153,6 @@ redirects = {
     "desktop/accountcommand": "desktop/massdeployment",
     # Moved 2026-03
     "configuration_server/automatic_configuration": "../installation/automatic_configuration.html",
+    # Moved to Apps section 2026-05
+    "configuration_user/instruction_set_for_apps": "../apps_management_api.html",
 }

--- a/admin_manual/configuration_user/user_provisioning_api.rst
+++ b/admin_manual/configuration_user/user_provisioning_api.rst
@@ -5,9 +5,7 @@ User provisioning API
 The Provisioning API application enables a set of APIs that external systems can use to create,
 edit, delete and query user attributes, query, set and remove groups, set quota
 and query total storage used in Nextcloud. Group admin users can also query
-Nextcloud and perform the same functions as an admin for groups they manage. The
-API also enables an admin to query for active Nextcloud applications, application
-info, and to enable or disable an app remotely. HTTP
+Nextcloud and perform the same functions as an admin for groups they manage. HTTP
 requests can be used via a Basic Auth header to perform any of the functions
 listed above. The Provisioning API app is enabled by default.
 
@@ -22,4 +20,3 @@ All POST requests require the ``Content-Type: application/x-www-form-urlencoded`
 
     instruction_set_for_users
     instruction_set_for_groups
-    instruction_set_for_apps

--- a/admin_manual/contents.rst
+++ b/admin_manual/contents.rst
@@ -44,6 +44,7 @@ Table of contents
     :caption: Apps
 
     apps_management
+    apps_management_api
     exapps_management/index
     ai/index
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11874

### What changed and why

The `instruction_set_for_apps` page documenting the OCS Provisioning API for apps (list, get info, enable, disable) was located under **User Management** for historical reasons. It has no relationship to user management — it belongs in the **Apps** section.

Changes:
- Renamed and moved `configuration_user/instruction_set_for_apps.rst` → `apps_management_api.rst` ("Apps management API")
- Added `apps_management_api` to the Apps toctree in `contents.rst`
- Removed `instruction_set_for_apps` from `user_provisioning_api.rst` toctree and trimmed the intro sentence that mentioned app management
- Added `sphinx_reredirects` entry so the old URL redirects to the new page

### 🖼️ Screenshots

N/A — structural/navigation change only, page content is unchanged.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did) — redirect added in `conf.py`
- [x] I have run `codespell` or similar and addressed any spelling issues