### PR TITLE
fix(db): update MySQL collation recommendation to utf8mb4_bin

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -89,7 +89,7 @@ Your :file:`/etc/mysql/my.cnf` could look like this:
 
   [mysqld]
   character_set_server = utf8mb4
-  collation_server = utf8mb4_general_ci
+  collation_server = utf8mb4_bin
   transaction_isolation = READ-COMMITTED
   binlog_format = ROW
   innodb_large_prefix=on
@@ -142,7 +142,7 @@ Then a **mysql>** or **MariaDB [root]>** prompt will appear. Now enter the follo
 ::
 
   CREATE USER 'username'@'localhost' IDENTIFIED BY 'password';
-  CREATE DATABASE IF NOT EXISTS nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+  CREATE DATABASE IF NOT EXISTS nextcloud CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
   GRANT ALL PRIVILEGES on nextcloud.* to 'username'@'localhost';
 
 You can quit the prompt by entering::


### PR DESCRIPTION
### ☑️ Resolves

* Fix #1565

### What changed and why

The docs recommended `utf8mb4_general_ci` in two places:
- `my.cnf` snippet (`collation_server`)
- `CREATE DATABASE` example

The server actually uses `utf8mb4_bin` — both `lib/private/Setup/MySQL.php` (database creation) and `lib/private/Repair/Collation.php` (collation migration) target `utf8mb4_bin`. Admins following the docs end up with a mismatched collation that the server then tries to migrate away from.

### 🖼️ Screenshots

No visual changes (code block only).

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues