### PR TITLE
Clarify autocomplete share type values

### DIFF
--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -253,7 +253,10 @@ It can be an option for filtering on a later stage but you can also leave them o
 
      curl -i -u master -X GET -H "OCS-APIRequest: true" 'https://my.nextcloud/ocs/v2.php/core/autocomplete/get?search=JOANNE%40EMAIL.ISP&shareTypes[]=8&limit=2'
 
-The shareType defaults to regular users if you left it out), the limit defaults to 10.
+The ``shareTypes`` filter uses the sharing API type values: ``0`` for users, ``1`` for groups,
+``4`` for email, ``6`` for federated cloud shares, ``7`` for circles, ``8`` for guest accounts,
+and ``10`` for Talk conversations. If ``shareTypes`` is left out it defaults to regular users;
+the limit defaults to 10.
 
 Filtering the auto-complete results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/developer_manual/client_apis/OCS/ocs-api-overview.rst
+++ b/developer_manual/client_apis/OCS/ocs-api-overview.rst
@@ -253,10 +253,28 @@ It can be an option for filtering on a later stage but you can also leave them o
 
      curl -i -u master -X GET -H "OCS-APIRequest: true" 'https://my.nextcloud/ocs/v2.php/core/autocomplete/get?search=JOANNE%40EMAIL.ISP&shareTypes[]=8&limit=2'
 
-The ``shareTypes`` filter uses the sharing API type values: ``0`` for users, ``1`` for groups,
-``4`` for email, ``6`` for federated cloud shares, ``7`` for circles, ``8`` for guest accounts,
-and ``10`` for Talk conversations. If ``shareTypes`` is left out it defaults to regular users;
-the limit defaults to 10.
+The ``shareTypes`` parameter filters results by share type. If omitted, it defaults to regular
+users (``0``). The limit defaults to ``10``.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Value
+     - Share type
+   * - ``0``
+     - Users (default)
+   * - ``1``
+     - Groups
+   * - ``4``
+     - Email
+   * - ``6``
+     - Federated cloud shares
+   * - ``7``
+     - Circles
+   * - ``8``
+     - Guest accounts
+   * - ``10``
+     - Talk conversations
 
 Filtering the auto-complete results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This clarifies the autocomplete API documentation by listing the valid `shareTypes` values next to the guest-account example, including `8` for guest accounts and the default user value. It also fixes the surrounding wording so readers can tell which query parameter to use and what happens when it is omitted.
