### PR TITLE
fix(email): correct link text for email template customization example

### DIFF
--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -118,7 +118,7 @@ This is the interface of the class that needs to be implemented: https://github.
 
 That is the implementation that could be extended and used to see how it works: https://github.com/nextcloud/server/blob/master/lib/private/Mail/EMailTemplate.php
 
-An example from `a GitHub issue <https://portal.nextcloud.com/article/customized-email-templates-29.html>`_:
+An example from `a Nextcloud portal article <https://portal.nextcloud.com/article/customized-email-templates-29.html>`_:
 
 1. Look at the source code of extended class `OC\\Mail\\EMailTemplate::class <https://github.com/nextcloud/server/blob/master/lib/private/Mail/EMailTemplate.php>`_
 


### PR DESCRIPTION
## Summary

- Fix link text on `email_configuration.rst` line 121: was labeled "a GitHub issue" but pointed to a Nextcloud portal article.

Fixes #9403

🤖 Generated with [Claude Code](https://claude.com/claude-code)