### PR TITLE
Document preview provider dependencies

### DIFF
--- a/admin_manual/configuration_files/previews_configuration.rst
+++ b/admin_manual/configuration_files/previews_configuration.rst
@@ -23,6 +23,14 @@ By default, Nextcloud can generate previews for the following filetypes:
    disabled by default) can be found under the ``enabledPreviewProviders``
    :doc:`configuration parameter </configuration_server/config_sample_php_parameters>`.
 
+
+Some preview providers depend on external binaries on the server. Video
+previews such as ``OC\Preview\Movie`` and ``OC\Preview\MKV`` require
+``ffmpeg``. Office document previews such as ``OC\Preview\OpenDocument``
+and ``OC\Preview\MSOfficeDoc`` require LibreOffice. Image formats handled
+through ImageMagick, such as ``OC\Preview\Illustrator``, ``OC\Preview\SVG``
+and ``OC\Preview\TIFF``, require the corresponding ImageMagick support.
+
 Parameters
 ----------
 


### PR DESCRIPTION
This updates the preview configuration documentation to call out the external binaries required by the video, Office document, and ImageMagick-backed preview providers. The change keeps the existing provider guidance intact and adds the dependency details admins need before enabling those providers. I verified the updated RST content with targeted text checks and `git diff --check`. Fixes #222.