### PR TITLE
PHP OPcache replaced dead link

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -149,7 +149,7 @@ should allow more processes to run in parallel to handle requests.
 Enable PHP OPcache
 ------------------
 
-The `OPcache <https://php.net/manual/en/intro.opcache.php>`_ improves the performance of PHP applications by caching precompiled bytecode.
+The `OPcache <https://www.php.net/manual/en/book.opcache.php>`_ improves the performance of PHP applications by caching precompiled bytecode.
 
 Revalidation
 ^^^^^^^^^^^^


### PR DESCRIPTION
https://www.php.net/manual/en/intro.opcache.php is dead https://www.php.net/manual/en/book.opcache.php is alive

### ☑️ Resolves

A dead link

### 🖼️ Screenshots

The diff is literraly just one line it's ok

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues

I did nothing just changed a dead link. No test. 
Could be nice to create something to automatically detect dead link tho 