### PR TITLE
chore(DevContainer): Add Python 3.13 to devcontainer and remove composer call

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,11 @@
 			]
 		}
 	},
-	"postCreateCommand": "python3 -m pip install -r requirements.txt && python3 -m pip install sphinx-autobuild && cd build && composer install --ignore-platform-reqs"
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.13"
+		}
+	},
+	"postCreateCommand": "python3 -m pip install -r requirements.txt && python3 -m pip install sphinx-autobuild",
+	"waitFor": "postCreateCommand"
 }


### PR DESCRIPTION
The devcontainer doesn't work anymore since https://github.com/nextcloud/documentation/pull/14653. The reason is being [described in my comment there](https://github.com/nextcloud/documentation/pull/14653#issuecomment-4352076327).

To fix that, I've manually added the appropriate devcontainer feature to install Python 3.13 and removed the `composer` call in the `postCreateCommand`, as all PHP dependencies doesn't seem to be used anymore (? - Please correct me if I'm wrong!). That way, the `Dockerfile` isn't touched by myself - which is quite important, as it's being used by the CI pipeline.