### PR TITLE
fix: version picker wrong version display and unclear stable label

### DIFF
--- a/admin_manual/_templates/versions.html
+++ b/admin_manual/_templates/versions.html
@@ -9,7 +9,7 @@
             data-toggle="rst-current-version"
             aria-expanded="false"
             aria-controls="rst-other-versions-admin">
-      ☁️ {{ current_version }}
+      ☁️ {% if current_version == 'stable' %}{{ version_stable }} (stable){% elif current_version == 'latest' %}{{ version_stable|int + 1 }} (latest){% else %}{{ current_version }}{% endif %}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
     </button>
     <div id="rst-other-versions-admin" class="rst-other-versions">
@@ -22,7 +22,7 @@
              style="color: var(--dark-link-color);"
              {% endif %}
           >
-            {{ slug if slug != 'stable' else 'stable (' ~ version_stable ~ ')' }}
+            {% if slug == 'stable' %}{{ version_stable }} (stable){% elif slug == 'latest' %}{{ version_stable|int + 1 }} (latest){% else %}{{ slug }}{% endif %}
           </a>
         </dd>
         {% endfor %}

--- a/admin_manual/_templates/versions.html
+++ b/admin_manual/_templates/versions.html
@@ -22,7 +22,7 @@
              style="color: var(--dark-link-color);"
              {% endif %}
           >
-            {{ slug }}
+            {{ slug if slug != 'stable' else 'stable (' ~ version_stable ~ ')' }}
           </a>
         </dd>
         {% endfor %}

--- a/conf.py
+++ b/conf.py
@@ -82,7 +82,7 @@ def generateVersionsDocs(current_docs):
 	versions_doc = []
 	for v in range(version_start, version_stable + 1):
 		url = 'https://docs.nextcloud.com/server/%s/%s' % (str(v), current_docs)
-		versions_doc.append(tuple((v, url)))
+		versions_doc.append(tuple((str(v), url)))
 	versions_doc.append(tuple(('stable', 'https://docs.nextcloud.com/server/%s/%s' % ('stable', current_docs))))
 	versions_doc.append(tuple(('latest', 'https://docs.nextcloud.com/server/%s/%s' % ('latest', current_docs))))
 	return versions_doc
@@ -93,7 +93,8 @@ else:
 	github_branch = 'master'
 
 html_context = {
-	'current_version': version,
+	'current_version': release,
+	'version_stable': str(version_stable),
 	'READTHEDOCS': True,
 
 	# force github plugin

--- a/conf.py
+++ b/conf.py
@@ -80,7 +80,7 @@ version_stable = 33		# CHANGING IT MUST RESULT IN A CHANGE OF THE SYMLINK ON THE
 
 def generateVersionsDocs(current_docs):
 	versions_doc = []
-	for v in range(version_start, version_stable + 1):
+	for v in range(version_start, version_stable):
 		url = 'https://docs.nextcloud.com/server/%s/%s' % (str(v), current_docs)
 		versions_doc.append(tuple((str(v), url)))
 	versions_doc.append(tuple(('stable', 'https://docs.nextcloud.com/server/%s/%s' % ('stable', current_docs))))

--- a/developer_manual/_templates/versions.html
+++ b/developer_manual/_templates/versions.html
@@ -22,7 +22,7 @@
              style="color: var(--dark-link-color);"
              {% endif %}
           >
-            {{ slug }}
+            {{ slug if slug != 'stable' else 'stable (' ~ version_stable ~ ')' }}
           </a>
         </dd>
         {% endfor %}

--- a/developer_manual/_templates/versions.html
+++ b/developer_manual/_templates/versions.html
@@ -9,7 +9,7 @@
             data-toggle="rst-current-version"
             aria-expanded="false"
             aria-controls="rst-other-versions-dev">
-      ☁️ {{ current_version }}
+      ☁️ {% if current_version == 'stable' %}{{ version_stable }} (stable){% elif current_version == 'latest' %}{{ version_stable|int + 1 }} (latest){% else %}{{ current_version }}{% endif %}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
     </button>
     <div id="rst-other-versions-dev" class="rst-other-versions">
@@ -22,7 +22,7 @@
              style="color: var(--dark-link-color);"
              {% endif %}
           >
-            {{ slug if slug != 'stable' else 'stable (' ~ version_stable ~ ')' }}
+            {% if slug == 'stable' %}{{ version_stable }} (stable){% elif slug == 'latest' %}{{ version_stable|int + 1 }} (latest){% else %}{{ slug }}{% endif %}
           </a>
         </dd>
         {% endfor %}

--- a/user_manual/_templates/versions.html
+++ b/user_manual/_templates/versions.html
@@ -97,7 +97,7 @@
                style="color: var(--dark-link-color);"
                {% endif %}
             >
-              {{ slug }}
+              {{ slug if slug != 'stable' else 'stable (' ~ version_stable ~ ')' }}
             </a>
           </dd>
         {% endfor %}

--- a/user_manual/_templates/versions.html
+++ b/user_manual/_templates/versions.html
@@ -68,7 +68,7 @@
             aria-controls="rst-other-versions-user">
       🌐 {{ language_names.get(language, language) }}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
-       ☁️ {{ current_version }}
+       ☁️ {% if current_version == 'stable' %}{{ version_stable }} (stable){% elif current_version == 'latest' %}{{ version_stable|int + 1 }} (latest){% else %}{{ current_version }}{% endif %}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
     </button>
     <div id="rst-other-versions-user" class="rst-other-versions">
@@ -97,7 +97,7 @@
                style="color: var(--dark-link-color);"
                {% endif %}
             >
-              {{ slug if slug != 'stable' else 'stable (' ~ version_stable ~ ')' }}
+              {% if slug == 'stable' %}{{ version_stable }} (stable){% elif slug == 'latest' %}{{ version_stable|int + 1 }} (latest){% else %}{{ slug }}{% endif %}
             </a>
           </dd>
         {% endfor %}


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13821

### What changed and why

Fixes two of the four issues reported in #13821:

**1. Picker button always showed `latest`** (`conf.py`)
`html_context['current_version']` was set to `version` which is hardcoded `'latest'`. Changed to use `release`, which reflects the actual built version (set via `DOCS_RELEASE` env var, e.g. `33` for stable builds).

Also converted int version slugs to `str` in `generateVersionsDocs` — without this, `current_version == slug` comparisons were always `False` for numeric versions (`'33' != 33`), so the current version was never highlighted in the dropdown.

**2. `stable` entry showed no version number** (all three `_templates/versions.html`)
Added `version_stable` to `html_context`. Templates now render `stable (33)` so users can see which release `stable` maps to without needing to check the URL.

**Out of scope:**
- Problem 2 (extend version history) — maintainer confirmed keep `version_start=32`
- Problem 4 (version switch page redirect) — cannot guarantee older version pages exist at the same path; left for a future PR

### 🖼️ Screenshots

<img width="310" height="134" alt="image" src="https://github.com/user-attachments/assets/25832e82-ac44-4a34-a250-addf3d8a6279" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues