### PR TITLE
docs(admin): warn about Configuration Active before LDAP testing

### DIFF
--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -630,6 +630,12 @@ Username-LDAP User Mapping
 Testing the configuration
 -------------------------
 
+.. warning:: Before testing, make sure the **Configuration Active** checkbox is
+   enabled under the **Advanced** tab. It is disabled by default and will cause
+   authentication to fail with a "wrong password" error even if all other settings
+   are correct. Nextcloud only enables it automatically after a successful test
+   connection.
+
 The **Test Configuration** button checks the values as currently given in the
 input fields. You do not need to save before testing. By clicking on the
 button, Nextcloud will try to bind to the Nextcloud server using the

--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -631,10 +631,9 @@ Testing the configuration
 -------------------------
 
 .. warning:: Before testing, make sure the **Configuration Active** checkbox is
-   enabled under the **Advanced** tab. It is disabled by default and will cause
-   authentication to fail with a "wrong password" error even if all other settings
-   are correct. Nextcloud only enables it automatically after a successful test
-   connection.
+   enabled. It is disabled by default and will cause authentication to fail with
+   a "wrong password" error even if all other settings are correct. Nextcloud
+   only enables it automatically after a successful test connection.
 
 The **Test Configuration** button checks the values as currently given in the
 input fields. You do not need to save before testing. By clicking on the


### PR DESCRIPTION
### ☑️ Resolves

* Fix #912

### Summary

LDAP authentication silently fails with "wrong password" when **Configuration Active** is
not enabled, even if all other settings are correct. This checkbox lives under the Advanced
tab and is off by default — it's easy to miss and can waste hours of troubleshooting.

Added a `.. warning::` block at the top of the "Testing the configuration" section to
surface this requirement before the user clicks **Test Configuration**.

### 🖼️ Screenshots

No visual layout change — text-only addition to an existing section.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues