### PR TITLE
docs(admin): clarify SYS_NICE capability is Docker-specific

### DIFF
--- a/admin_manual/installation/server_tuning.rst
+++ b/admin_manual/installation/server_tuning.rst
@@ -252,8 +252,10 @@ Nextcloud to use Imaginary by editing your ``config.php`` file:
 
    Make sure to start Imaginary with the ``-return-size`` command line parameter. Otherwise, there will be a
    minor performance impact. The flag requires a recent version of Imaginary (newer than v1.2.4).
-   Also, ensure to add the capability ``SYS_NICE`` via ``--cap-add=sys_nice`` or (for Compose)
-   ``cap_add: - SYS_NICE``, as it is required by Imaginary to generate HEIC previews.
+   Also, if running Imaginary in Docker, ensure to add the Docker container capability ``SYS_NICE``
+   via ``--cap-add=sys_nice`` (Docker CLI) or ``cap_add: - SYS_NICE`` (Docker Compose), as it is
+   required by Imaginary to generate HEIC previews. This is not applicable when running Imaginary
+   outside of Docker.
 
 .. note::
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11083

### Summary

The warning about adding the `SYS_NICE` capability for Imaginary HEIC preview support
(`--cap-add=sys_nice` / `cap_add: - SYS_NICE`) is a Docker-only instruction, but it was
written as if it applied universally. Users running Imaginary as a native binary were
confused by a Docker-specific step that is irrelevant to their setup.

Changes:
- Added "if running Imaginary in Docker" qualifier
- Changed "the capability" to "the Docker container capability" for clarity
- Named both Docker CLI (`--cap-add=sys_nice`) and Compose (`cap_add: - SYS_NICE`) explicitly
- Added a closing sentence confirming this does not apply outside Docker

### 🖼️ Screenshots

No visual layout change — text-only edit to an existing warning block.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues