### PR TITLE
fix(admin): restore proper anchor IDs for APCu, Redis and Memcached sections

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -22,18 +22,18 @@ every time they are called. PHP bundles the Zend OPcache in core since version
 caching backends, so you can choose the type of memcache that best fits your
 needs. The supported caching backends are:
 
-* `APCu <https://pecl.php.net/package/APCu>`_ (APCu 4.0.6 and up required).
+* `APCu <https://pecl.php.net/package/APCu>`__ (APCu 4.0.6 and up required).
 
   A local cache for systems.
 
-* `Redis <https://redis.io/open-source/>`_ (4.0.0 and up required);
-  `Valkey <https://valkey.io/>`_ and `KeyDB <https://docs.keydb.dev/>`_ are expected to work as Redis-compatible backends.
+* `Redis <https://redis.io/open-source/>`__ (4.0.0 and up required);
+  `Valkey <https://valkey.io/>`__ and `KeyDB <https://docs.keydb.dev/>`__ are expected to work as Redis-compatible backends.
 
   .. note:: Automated/formal testing currently only occurs against Redis Open Source.
 
   For local and distributed caching, as well as transactional file locking.
 
-* `Memcached <https://www.memcached.org/>`_
+* `Memcached <https://www.memcached.org/>`__
 
   For distributed caching.
 
@@ -110,7 +110,6 @@ Additional notes for Redis vs. APCu on memory caching
 APCu is faster for local caching than Redis. If you have enough memory, use
 APCu for Memory Caching and Redis for File Locking. If you are low on memory,
 use Redis for both.
-
 
 APCu
 ----
@@ -341,8 +340,7 @@ prevent session corruption when using Redis as your session handler: ::
 More information on configuration of phpredis session handler can be found on the
 `PhpRedis GitHub page <https://github.com/phpredis/phpredis>`_
 
-..  _install_redis_label:
-
+.. _install_redis_label:
 
 Memcached
 ---------


### PR DESCRIPTION
### ☑️ Resolves

* Fix #6878

### Summary

The APCu, Redis, and Memcached section headings on the memory caching page were generating
non-descriptive HTML IDs (`id1`, `id2`, ...) instead of the expected anchors
(`#apcu`, `#redis`, `#memcached`). This broke direct links to those sections.

**Root cause:** the bullet-list entries at the top of the page used named external hyperlink
references (`` `APCu <url>`_ ``). A trailing single underscore in RST creates a *named*
target — consuming "apcu", "redis", and "memcached" before the section headings are
processed. Sphinx then falls back to sequential IDs (`id1`, `id2`, …) for the headings.

**Fix:** change those three inline links to anonymous references (double underscore
`` `APCu <url>`__ ``). Anonymous refs do not register a named target, so the section
headings can claim the correct IDs.

**Before:** `caching_configuration.html#id1`, `#id2`
**After:** `caching_configuration.html#apcu`, `#redis`, `#memcached`

### 🖼️ Screenshots

No visual layout change — heading text is unchanged, only anchor IDs are fixed.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues