### PR TITLE
docs(user): add slow WebDAV performance to Known Problems section

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -372,6 +372,26 @@ Known problems
 
 Problem
 ^^^^^^^
+
+WebDAV access is very slow or times out.
+
+Solution
+^^^^^^^^
+
+When using a third-party WebDAV client (including your operating system's built-in
+client), you should authenticate with an **application password** rather than your
+regular account password. Using a regular password carries a significant performance
+penalty because Nextcloud must perform additional work to verify it on every request.
+Using an application password removes this overhead and can improve transfer speeds
+substantially.
+
+To create an application password, log in to the Nextcloud web interface, click your
+avatar, choose **Personal settings**, then open the **Security** section in the left
+sidebar and scroll to the bottom. Create an app password there and use it in your
+WebDAV client instead of your main password.
+
+Problem
+^^^^^^^
 Windows does not connect using HTTPS.
 
 Solution 1


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13920

### Summary

Using a regular account password with a WebDAV client carries a significant server-side
performance penalty (see nextcloud/server#32729). The existing documentation mentioned
this only as a small note near the top of the page — users troubleshooting slow transfers
or timeouts would not find it by scrolling to Known Problems.

Added a dedicated **Problem / Solution** entry in the Known Problems section with
relevant keywords (slow, times out) so that users land on the solution when they search
for performance issues.

cc @toluschr @jose1711


### 🖼️ Screenshots

No visual layout change — text-only addition to Known Problems section.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues