### PR TITLE
docs(admin): explain relationship between bruteforcesettings and fail2ban

### DIFF
--- a/admin_manual/configuration_server/bruteforce_configuration.rst
+++ b/admin_manual/configuration_server/bruteforce_configuration.rst
@@ -172,11 +172,12 @@ Nextcloud's built-in brute force protection and fail2ban are complementary tools
 operate at different layers of the stack. Using both together is recommended for
 production servers.
 
-**Nextcloud brute force protection** (the ``bruteforcesettings`` app) works at the
-**application layer**. It detects suspicious login patterns and adds progressively
-longer delays to requests from the offending IP address. It has full context about
-Nextcloud-specific endpoints and credentials, and it activates automatically without
-any operating system configuration.
+**Nextcloud brute force protection** is built into Nextcloud Server itself (the
+``bruteforcesettings`` app provides the admin UI and exclusion settings, but the
+protection runs regardless). It works at the **application layer**: it detects
+suspicious login patterns and adds progressively longer delays to requests from the
+offending IP address. It has full context about Nextcloud-specific endpoints and
+credentials, and it activates automatically without any operating system configuration.
 
 **fail2ban** works at the **OS/network layer**. It watches log files for failed login
 entries and instructs the system firewall (e.g. ``iptables`` or ``nftables``) to

--- a/admin_manual/configuration_server/bruteforce_configuration.rst
+++ b/admin_manual/configuration_server/bruteforce_configuration.rst
@@ -164,3 +164,30 @@ It's possible to exclude IP addresses from the brute force protection.
 
    Any excluded IP address can perform authentication attempts without any throttling.
    It's best to exclude as few IP addresses as you can, or even none at all.
+
+Brute force protection vs fail2ban
+-----------------------------------
+
+Nextcloud's built-in brute force protection and fail2ban are complementary tools that
+operate at different layers of the stack. Using both together is recommended for
+production servers.
+
+**Nextcloud brute force protection** (the ``bruteforcesettings`` app) works at the
+**application layer**. It detects suspicious login patterns and adds progressively
+longer delays to requests from the offending IP address. It has full context about
+Nextcloud-specific endpoints and credentials, and it activates automatically without
+any operating system configuration.
+
+**fail2ban** works at the **OS/network layer**. It watches log files for failed login
+entries and instructs the system firewall (e.g. ``iptables`` or ``nftables``) to
+block the offending IP outright. Blocked requests are dropped before they reach the
+web server, PHP, or the database, saving server resources entirely.
+
+The two approaches are not mutually exclusive:
+
+- Nextcloud brute force protection handles application-level throttling transparently,
+  including for API clients and mobile apps, with no system configuration required.
+- fail2ban reduces server load by blocking repeat offenders at the network level
+  before their requests consume any application resources.
+
+For setup instructions for fail2ban with Nextcloud, see :ref:`setup_fail2ban`.

--- a/admin_manual/configuration_server/bruteforce_configuration.rst
+++ b/admin_manual/configuration_server/bruteforce_configuration.rst
@@ -91,8 +91,11 @@ addresses and ranges to exempt from brute force protection.
 Additional enhancements may be made in the future, within this app and/or in combination with Nextcloud Server for
 additional monitoring or behavior adjustments related to brute force protection.
 
-.. warning:: Disabling the ``bruteforcesettings`` app does **not** disable brute force protection
-   - it merely removes your ability to adjust brute force related settings from the Web interface.
+.. warning::
+
+   Disabling the ``bruteforcesettings`` app does **not** disable brute force protection.
+   The protection is built into Nextcloud Server core and is always active. Disabling the app
+   only removes the ability to manage brute force settings from the Web interface.
 
 .. danger::
 

--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -306,6 +306,8 @@ Depending on your server setup, these are the possible connections:
 .. _detailed field list: https://github.com/nextcloud/survey_client
 
 
+.. _setup_fail2ban:
+
 Setup fail2ban
 --------------
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11425

### Summary

The documentation for Nextcloud's built-in brute force protection and for fail2ban
existed in separate pages with no cross-reference or explanation of how they relate.
Admins frequently wonder whether to use one or both.

Added a **Brute force protection vs fail2ban** section to `bruteforce_configuration.rst`
explaining:
- Nextcloud brute force protection (application layer): rate-limits suspicious IPs
  transparently, no OS configuration required
- fail2ban (OS/network layer): drops packets in the firewall before they reach the
  web server, reducing resource consumption
- They are complementary — using both is recommended for production servers

Also added a missing `.. _setup_fail2ban:` reference label to the fail2ban section in
`harden_server.rst` so the new cross-reference link resolves correctly.

cc @FernandoMarques-Santos @paolosg

### 🖼️ Screenshots

<img width="972" height="719" alt="image" src="https://github.com/user-attachments/assets/eb81cf43-0443-4f3f-a009-2f5fedcaf752" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues