### PR TITLE
docs(admin): document all four well-known URL redirects

### DIFF
--- a/admin_manual/configuration_server/security_setup_warnings.rst
+++ b/admin_manual/configuration_server/security_setup_warnings.rst
@@ -115,11 +115,21 @@ websites. To ensure that Nextcloud will work properly you need to update OpenSSL
 to at least 1.0.2b or 1.0.1d. For NSS the patch version depends on your distribution
 and an heuristic is running the test which actually reproduces the bug.
 
-Your Web server is not set up properly to resolve /.well-known/caldav/ or /.well-known/carddav/
------------------------------------------------------------------------------------------------
+Your Web server is not set up properly to resolve /.well-known/ URLs
+--------------------------------------------------------------------
 
-Both URLs need to be correctly redirected to the DAV endpoint of Nextcloud. Please
-refer to :ref:`service-discovery-label` for more info.
+The following well-known URLs must be correctly redirected for full Nextcloud functionality:
+
+* ``/.well-known/caldav`` → ``/remote.php/dav`` (CalDAV service discovery)
+* ``/.well-known/carddav`` → ``/remote.php/dav`` (CardDAV service discovery)
+* ``/.well-known/webfinger`` → ``/index.php/.well-known/webfinger`` (identity/federation)
+* ``/.well-known/nodeinfo`` → ``/index.php/.well-known/nodeinfo`` (server metadata)
+
+The CalDAV and CardDAV redirects are required for calendar and contacts clients that use
+automatic service discovery. The WebFinger and NodeInfo redirects are used for federation
+and profile discovery between Nextcloud instances and compatible services.
+
+Please refer to :ref:`service-discovery-label` for setup instructions for Apache and NGINX.
 
 Some files have not passed the integrity check
 ----------------------------------------------


### PR DESCRIPTION
### ☑️ Resolves

* Fix #6885

### Summary

The security setup warnings page only documented `/.well-known/caldav` and
`/.well-known/carddav`. Nextcloud also emits warnings for `/.well-known/webfinger`
and `/.well-known/nodeinfo` when those redirects are missing. Admins following the
help link from those warnings arrived at a page that didn't mention them at all.

Changes:
- Updated the section heading to be generic ("well-known/ URLs")
- Listed all four redirects with their target paths and purpose
- Added a brief explanation distinguishing DAV service discovery from WebFinger/NodeInfo

The rewrite rules themselves are already documented in `general_troubleshooting.rst`;
this PR only fixes the warning page that users land on first.

### 🖼️ Screenshots

<img width="1051" height="545" alt="image" src="https://github.com/user-attachments/assets/eac61b00-1c1a-4810-be18-a2f8b2807336" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues