### PR TITLE
docs(admin): clarify web server user and file ownership requirements

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -237,6 +237,16 @@ your HTTP user::
 
     chown -R www-data:www-data /var/www/nextcloud/
 
+.. note:: ``www-data`` is the default web server user on Debian/Ubuntu systems.
+   On RHEL/CentOS/Fedora use ``apache``. The key requirement is that the web
+   server process user has **read and write access** to all Nextcloud directories
+   — ownership is not strictly necessary. In environments where changing ownership
+   is not possible (shared hosting, Docker bind-mounts, etc.), it is sufficient to
+   add the web server user to the group that owns the directories and ensure the
+   directories are group-writable, for example::
+
+       usermod -a -G vboxsf www-data
+
 .. note:: Admins of SELinux-enabled distributions may need to write new SELinux
    rules to complete their Nextcloud installation; see
    :ref:`selinux_tips_label`.


### PR DESCRIPTION
### ☑️ Resolves

* Fix #1239

### Summary

The installation docs showed `chown -R www-data:www-data /var/www/nextcloud/`
without explaining that `www-data` is the Debian/Ubuntu web server user, or that
strict ownership is not actually required — only read/write access by the web server
process user is.

This causes confusion for users on:
- RHEL/CentOS/Fedora (web server user is `apache`, not `www-data`)
- Docker setups with bind-mounts whose ownership cannot be changed
- Shared hosting environments
- Environments like VirtualBox where data lives on a `vboxsf`-mounted volume

Added a note clarifying:
1. `www-data` is Debian/Ubuntu specific; RHEL/CentOS uses `apache`
2. The real requirement is read/write access, not literal `www-data:www-data` ownership
3. In constrained environments, adding the web server user to the owning group is sufficient

### 🖼️ Screenshots

No visual layout change — text-only addition to an existing section.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues