### PR TITLE
fix(Groupware): Apply continuous version schema for groupware apps

### DIFF
--- a/admin_manual/groupware/calendar.rst
+++ b/admin_manual/groupware/calendar.rst
@@ -12,7 +12,7 @@ calendar, and sending email notifications about upcoming events.
 .. figure:: images/settings_calendar-server.png
   :scale: 60%
 
-.. versionadded:: 30 The section will be hidden if no app makes use of the CalDAV backend.
+.. versionadded:: 30.0.0 The section will be hidden if no app makes use of the CalDAV backend.
 
 Starting from Nextcloud 30, the calendar server settings section will be hidden if no app uses the
 CalDAV backend.

--- a/admin_manual/groupware/contacts.rst
+++ b/admin_manual/groupware/contacts.rst
@@ -9,7 +9,7 @@ Nextcloud ships a CardDAV backend for users to store and share their address boo
 System Address Book
 -------------------
 
-.. versionchanged:: 27
+.. versionchanged:: 27.0.0
     The system address book is now accessible to all Nextcloud users
 
 Nextcloud maintains a read-only address book containing contact information of all users of the instance.
@@ -57,7 +57,7 @@ The address book is updated automatically with every added, modified, disabled o
 Shared items
 ------------
 
-.. versionadded:: 5.5.0
+.. versionadded:: 5.5.0 Nextcloud 25 or newer
 
 For this feature, the shipped `related resources app <https://apps.nextcloud.com/apps/related_resources>`_ needs to be enabled.
 

--- a/admin_manual/groupware/mail.rst
+++ b/admin_manual/groupware/mail.rst
@@ -197,7 +197,7 @@ Users can share mailboxes with each other. So far, there is no UI for users to c
 User Interface Preference Defaults
 ----------------------------------
 
-.. versionadded:: 5.2
+.. versionadded:: 5.2 Nextcloud 30 or newer
 
 The Mail app allows administrators to set default user interface preferences for all users, these preferences can be changed by the user afterwards. This can be useful to ensure a consistent experience across the application.
 
@@ -224,7 +224,7 @@ Administration settings > Groupware > Mail app > Enable text processing through 
 Thread Summary
 --------------
 
-.. versionchanged:: 3.6.0
+.. versionchanged:: 3.6.0 Nextcloud 26 or newer
     This configuration option was merged into :ref:`mail_llm_processing`
 
 The mail app supports summarizing message threads that contain 3 or more messages.
@@ -238,7 +238,7 @@ Administration settings > Groupware > Mail app > Enable thread summary
 Follow-up reminders
 -------------------
 
-.. versionadded:: 4.0
+.. versionadded:: 4.0 Nextcloud 30 or newer
 
 The Mail app will automatically remind users when their outgoing emails remain unanswered for
 multiple days.
@@ -249,14 +249,14 @@ The feature can be enabled through the global :ref:`mail_llm_processing` setting
 Translation
 -----------
 
-.. versionadded:: 4.2
+.. versionadded:: 4.2 Nextcloud 30 or newer
 
 The mail app can optionally provide translations for messages if the :ref:`translation API <machine_translation>` is enabled.
 
 User migration
 --------------
 
-.. versionadded:: 5.9
+.. versionadded:: 5.9 Nextcloud 30 or newer
 
 .. important::
    The `User Migration App <https://apps.nextcloud.com/apps/user_migration>`_ must be installed and enabled on both

--- a/admin_manual/groupware/troubleshooting.rst
+++ b/admin_manual/groupware/troubleshooting.rst
@@ -161,7 +161,7 @@ The Nextcloud Mail app offers an extensive logging system to make it easier iden
 
 Per mail account
 ~~~~~~~~~~~~~~~~
-.. versionadded:: 5.1.0
+.. versionadded:: 5.1.0 Nextcloud 30 or newer
 
 Starting with version 5.1.0 of the mail app, you can enable logging of outgoing IMAP/SMTP/Sieve connections limited to a specific mail account. As that saves a lot of resources on your system, this is the preferred method for debugging issues regarding IMAP/SMTP/Sieve connections.
 
@@ -185,7 +185,7 @@ Globally
 ~~~~~~~~
 This enables logging of the IMAP/SMTP/Sieve connections for **all** mail accounts configured on the server. This should be used with caution as it can put a lot of strain on large environments.
 
-.. versionadded:: 5.1.0
+.. versionadded:: 5.1.0 Nextcloud 30 or newer
 
 To enable the global debug logging on versions 5.1.0 and above, just run the following command on the server:
 
@@ -202,7 +202,7 @@ The global debug logging can be disabled once you've collected the necessary dat
     sudo -E -u www-data php occ config:system:set app.mail.debug --value false --type bool
 
 .. note:: The following steps only apply to version 1.6.2 up to 5.0.8. Restrict logging of outgoing connections to a specific mail account is not available there.
-.. versionadded:: 1.6.2
+.. versionadded:: 1.6.2 Nextcloud 20 or newer
 
 To enable the global debug logging, it's necessary to enable both the debug mode as well as debug logging for the whole nextcloud instance by running the following commands on the server:
 

--- a/developer_manual/digging_deeper/groupware/calendar_provider.rst
+++ b/developer_manual/digging_deeper/groupware/calendar_provider.rst
@@ -95,7 +95,7 @@ Please be aware that there are some security considerations to take into account
 Access through CalDAV
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 27
+.. versionadded:: 27.0.0
 
 As with the built-in calendars, calendars provided by ``ICalendarProvider`` can be accessed using CalDAV. Therefore, permissions of the ``ICalendar`` are automatically mapped to the DAV object.
 Write support is also supported. Please note that deleting entities is currently implemented by setting the entity to the canceled state and passing it to the ``createFromString`` method.

--- a/user_manual/groupware/calendar.rst
+++ b/user_manual/groupware/calendar.rst
@@ -175,7 +175,7 @@ Finished. Your calendar subscriptions will be updated regularly.
 Subscribe to a Holiday Calendar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 4.4
+.. versionadded:: 4.4 Nextcloud 25 or newer
 
 You can subscribe to a read-only holiday calendar provided by `Thunderbird <https://www.thunderbird.net/calendar/holidays/>`_.
 
@@ -252,7 +252,7 @@ Attendees may be other users on your Nextcloud instances, contacts in your addre
 .. figure:: images/calendar_event_invitation_level.png
    :scale: 80%
 
-.. versionchanged:: 25
+.. versionchanged:: 25.0.0
    Attendee email response links no longer offer inputs to add a comment or invite additional guests to the event.
 
 .. tip:: When adding other Nextcloud users as attendees to an event, you may access their free-busy information if available, helping you determine when the best time slot for your event is. Set your :ref:`working hours<calendar-working-hours>` to let others know when you are available. Free-busy information is only available for other users on the same Nextcloud instance.
@@ -289,7 +289,7 @@ Similar to attendees you can add rooms and resources to your events. The system 
 
 Room availability
 ~~~~~~~~~~~~~~~~~
-.. versionadded:: 5.0
+.. versionadded:: 5.0 Nextcloud 30 or newer
 
 If the "Calendar Rooms and Resources" app is installed on your instance, you can now find ``Room availability``  the ``Resources`` section. It lists all the existing rooms. You can check the availability of each room in a manner similar to checking the free/busy status of event attendees.
 
@@ -494,7 +494,7 @@ You can create a Talk room directly from the calendar app for a booked appointme
 Proposals
 ---------
 
-.. versionadded:: 6.0.0
+.. versionadded:: 6.0 Nextcloud 32 or newer
 
 Finding a meeting time for a group of participants can be challenging. As of Calendar v6, a new feature was introduced that allows users to create proposals for meeting times.
 This means that instead of just booking a time, or searching for a available time in the free busy view, participants can vote on a set of proposed times for a meeting.

--- a/user_manual/groupware/contacts.rst
+++ b/user_manual/groupware/contacts.rst
@@ -246,7 +246,7 @@ When this option is enabled, the team can no longer be directly added as a membe
 
 Shared items
 ~~~~~~~~~~~~
-.. versionadded:: 5.5
+.. versionadded:: 5.5 Nextcloud  25 or newer
 
 .. figure:: ./images/shared-items.png
 

--- a/user_manual/groupware/mail.rst
+++ b/user_manual/groupware/mail.rst
@@ -13,7 +13,7 @@ Managing your mail account
 Switch layout
 ~~~~~~~~~~~~~
 
-.. versionadded:: 3.6
+.. versionadded:: 3.6 Nextcloud 26 or newer
 
 1. Visit mail settings
 2. Choose between *List*, *Vertical split* and *Horizontal split*
@@ -22,7 +22,7 @@ Switch layout
 
 Use Compact Mode
 ~~~~~~~~~~~~~~~~
-.. versionadded:: 5.7.0
+.. versionadded:: 5.7 Nextcloud 32 or newer
 
 Compact mode offers a cleaner and more efficient way to view your messages. Avatars are hidden, selection checkboxes are always visible, and the preview of messages is removed. It saves space allowing you to see more emails at once.
 
@@ -35,7 +35,7 @@ Compact mode offers a cleaner and more efficient way to view your messages. Avat
 Message Display / Operation Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
+.. versionadded:: 5.2 Nextcloud 30 or newer
 
 Mail has the ability to switch between two different message view and operation modes: *Threaded* and *Singleton*.
 
@@ -60,7 +60,7 @@ Add a new mail account
 Change sort order
 ~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.5
+.. versionadded:: 3.5 Nextcloud 26 or newer
 
 1. Visit mail settings
 2. Go to *Sorting*
@@ -121,7 +121,7 @@ Can be found in the action menu of a mail account. There you can edit, add or re
 Move messages to Junk folder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.4
+.. versionadded:: 3.4 Nextcloud 26 or newer
 
 Mail can move a message to a different folder when it is marked as junk.
 
@@ -152,7 +152,7 @@ use the folder search feature in the app.
 Search in folder
 ~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.1
+.. versionadded:: 2.1 Nextcloud 25 or newer
 
 At the top of the envelope list in any mail layout, there is a search field shortcut for searching email subjects. Starting from ``version 3.7``, this shortcut allows you to search by subject, recipient (to), or sender (from) by default.
 
@@ -160,14 +160,14 @@ At the top of the envelope list in any mail layout, there is a search field shor
 Advanced search in folder
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.4
+.. versionadded:: 3.4 Nextcloud 26 or newer
 
 You can access our advanced search feature through a modal located at the end of the search shortcut.
 
 Enable mail body search
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.5
+.. versionadded:: 3.5 Nextcloud 26 or newer
 
 Mail bodies can now be searched, this feature is opt-in because of potential performance issues.
 
@@ -196,7 +196,7 @@ The app allows account delegation so that one user can send emails from the addr
 Automatic trash deletion
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.4
+.. versionadded:: 3.4 Nextcloud 26 or newer
 
 The Mail app can automatically delete messages in the trash folder after a certain number of days.
 
@@ -219,7 +219,7 @@ Compose messages
 Minimize the composer modal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.2
+.. versionadded:: 3.2 Nextcloud 26 or newer
 
 The composer modal can be minimized while writing a new message, editing an existing draft or a message from the outbox. Simply click the **Minimize** button on the modal or click anywhere outside the modal.
 
@@ -235,7 +235,7 @@ Press the **Close** button on the modal or on the minimized composer indicator t
 Recipient info on composer
 --------------------------
 
-.. versionadded:: 4.2
+.. versionadded:: 4.2 Nextcloud 30 or newer
 
 When you add your first recipient or contact in the "To" field, a right pane will appear displaying the saved profile details of that contact.
 Adding a second contact will collapse the list, allowing you to select and expand any contact you added to view their details.
@@ -245,7 +245,7 @@ To show the right pane again, simply click the **Minimize** icon in the same too
 Mention contacts
 ----------------
 
-.. versionadded:: 4.2
+.. versionadded:: 4.2 Nextcloud 30 or newer
 
 You can mention contacts in your message by typing ``@`` and then selecting the contact from the list.
 By doing so the contact will be automatically added as a recipient.
@@ -255,7 +255,7 @@ By doing so the contact will be automatically added as a recipient.
 Text blocks
 -----------
 
-.. versionadded:: 5.2
+.. versionadded:: 5.2 Nextcloud 30 or newer
 
 Text blocks are predefined snippets of text that can be inserted into your email. They can be created and managed in the mail settings.
 They can be inserted into the composer by typing ``!`` and then selecting the block from the list or from the composer actions.
@@ -318,7 +318,7 @@ Create an event for a certain message/thread directly via mail app
 Create a task
 ~~~~~~~~~~~~~
 
-.. versionadded:: 3.2
+.. versionadded:: 3.2 Nextcloud 26 or newer
 
 Create an task for a certain message/thread directly via mail app
 
@@ -337,7 +337,7 @@ Edit tags
 Change color for tags
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.5
+.. versionadded:: 3.5 Nextcloud 26 or newer
 
 .. figure:: images/change-tag-color.png
 
@@ -346,7 +346,7 @@ Upon creating a tag, a randomly assigned color is automatically chosen. Once the
 Delete tags
 ~~~~~~~~~~~
 
-.. versionadded:: 3.5
+.. versionadded:: 3.5 Nextcloud 26 or newer
 
 .. figure:: images/delete-tag.png
 
@@ -361,7 +361,7 @@ You now have the ability to delete tags that you have previously created. To acc
 AI summary
 ~~~~~~~~~~
 
-.. versionadded:: 4.2
+.. versionadded:: 4.2 Nextcloud 30 or newer
 
 When looking through your folder you will see a short AI generated summary of your emails as a preview.
 
@@ -369,7 +369,7 @@ When looking through your folder you will see a short AI generated summary of yo
 
 Quick actions
 -------------
-.. versionadded:: 5.5 (Nextcloud 30)
+.. versionadded:: 5.5 Nextcloud 30 or newer
 
 Allows you to group action steps that you would normally perform on envelopes such as tagging, moving, marking as read ... into quick actions that can be executed with a single click.
 Quick actions are scoped to one mail account and can be created and managed in the mail settings under "Quick actions" or directly from the envelope action menu.
@@ -384,14 +384,14 @@ Message actions
 Unsubscribe from a mailing list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 3.1
+.. versionadded:: 3.1 Nextcloud 26 or newer
 
 Some mailing lists and newsletters allow to be unsubscribed easily. If the Mail app detects messages from such a sender, it will show an *Unsubscribe* button next to the sender information. Click and confirm to unsubscribe from the list.
 
 Snooze
 ~~~~~~
 
-.. versionadded:: 3.4
+.. versionadded:: 3.4 Nextcloud 26 or newer
 
 Snoozing a message or thread moves it into a dedicated folder until the selected snooze date is reached and the message or thread is moved back to the original folder.
 
@@ -402,7 +402,7 @@ Snoozing a message or thread moves it into a dedicated folder until the selected
 Smart replies
 ~~~~~~~~~~~~~
 
-.. versionadded:: 3.6
+.. versionadded:: 3.6 Nextcloud 26 or newer
 
 When you open a message in the Mail app, it proposes AI-generated replies. By simply clicking on a suggested reply, the composer opens with the response pre-filled.
 
@@ -413,7 +413,7 @@ When you open a message in the Mail app, it proposes AI-generated replies. By si
 Mail translation
 ~~~~~~~~~~~~~~~~
 
-.. versionadded:: 4.2
+.. versionadded:: 4.2 Nextcloud 30 or newer
 
 You are able to translate messages to your configured languages similarly to Talk.
 
@@ -426,7 +426,7 @@ Thread summary
 
 The mail app supports summarizing message threads that contain 3 or more messages.
 
-.. versionadded:: 3.4
+.. versionadded:: 3.4 Nextcloud 26 or newer
 
 .. note:: Please note that the feature has to be enabled by the administrator
 
@@ -440,14 +440,14 @@ The Mail app has a editor for Sieve scripts, an interface to configure autorespo
 Autoresponders
 ~~~~~~~~~~~~~~
 
-.. versionadded:: 3.5 Autoresponder can follow system settings.
+.. versionadded:: 3.5 Nextcloud 26 or newer
 
 The autoresponder is off by default. It can be set manually, or follow the system settings. Following system settings means that the long absence message entered on the :ref:`Absence settings section <groupware-absence>` is applied automatically.
 
 Filter
 ~~~~~~
 
-.. versionadded:: 4.1
+.. versionadded:: 4.1 Nextcloud 30 or newer
 
 Mail 4.1 includes a simple editor to configure filter rules.
 
@@ -492,7 +492,7 @@ Actions are triggered when the specified tests are true. The following actions a
 Create a filter from a message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 5.2
+.. versionadded:: 5.2 Nextcloud 30 or newer
 
 To create a filter from a given message, open the message and then open the menu by clicking on the three dots. Next, click on "More actions" followed by "Create mail filter."
 
@@ -504,7 +504,7 @@ In the dialog, please select the conditions to match incoming messages and conti
 Follow-up reminders
 -------------------
 
-.. versionadded:: 4.0
+.. versionadded:: 4.0 Nextcloud 30 or newer
 
 The Mail app will automatically remind you when an outgoing email did not receive a response.
 Each sent email will be analyzed by an AI to check whether a reply is expected.
@@ -521,7 +521,7 @@ Security
 Phishing detection
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 4.0
+.. versionadded:: 4.0 Nextcloud 30 or newer
 
 The Mail app will check for potential phishing attempts and will display a warning to the user.
 
@@ -538,7 +538,7 @@ The checks are the following:
 Internal addresses
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 4.0
+.. versionadded:: 4.0 Nextcloud 30 or newer
 
 The Mail app allows adding internal addresses and domains, and will warn the user if the address is not in the list, when sending and upon receiving a message.
 
@@ -553,7 +553,7 @@ To add an internal address:
 Dashboard integration
 ---------------------
 
-.. versionadded:: 1.8
+.. versionadded:: 1.8 Nextcloud 20 or newer
 
 The mail app offers two widgets designed for integration with Nextcloud's dashboard:
 
@@ -592,7 +592,7 @@ Meeting invitation automation
 
 When a meeting organizer sends updates to an existing event (such as time changes or location updates), the Mail app processes these automatically and updates the corresponding event in your calendar.
 
-.. versionadded:: 5.7 (Nextcloud 32 or newer)
+.. versionadded:: 5.7 Nextcloud 32 or newer
 
 You can also configure Mail to automatically add all new meeting invitations to your calendar without requiring manual acceptance. The invitations will be added to the calendar as tentative.
 


### PR DESCRIPTION
As suggested by @kesselb in #13813, the groupware apps documentation isn't that easy to understand right now as sometimes the app version number is being used and sometimes the Nextcloud version. Unfortunately, there is no Sphinx command out-of-the-box that would allow for something like "Added in {app_name} App version {app_version} / Nextcloud {nextcloud_version}`, so, we have to work around that part.

This PR applies the RFC #13813 to all applicable lines and uses the versioning schema (x.y.z if the mentioned version number is a Nextcloud release and x.y if a app release is being mentioned).

Follow-up to #14873. I can only apply the change to this PR if there is more discussion needed before doing it kinda "globally".

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
