### PR TITLE
docs: add file permissions guidance to hardening page

### DIFF
--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -108,6 +108,47 @@ Also set it for CLI work (``occ``, cron):
 .. seealso:: :doc:`../configuration_server/config_sample_php_parameters` for full details on
    ``NEXTCLOUD_CONFIG_DIR`` and other configuration loading behaviour.
 
+Set strong file permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Strong file system permissions reduce the attack surface if an attacker gains
+access to the web server process. The recommended baseline restricts world
+access to the Nextcloud installation directory:
+
+.. code-block:: bash
+
+   # Set ownership to the web server user and group
+   sudo chown -R www-data:www-data /var/www/nextcloud/
+
+   # Files: owner read/write, group read-only, no world access
+   sudo find /var/www/nextcloud/ -type f -print0 | sudo xargs -0 chmod 0640
+
+   # Directories: owner full, group read+execute, no world access
+   sudo find /var/www/nextcloud/ -type d -print0 | sudo xargs -0 chmod 0750
+
+The **data directory** must remain writable by the web server user:
+
+.. code-block:: bash
+
+   sudo chown -R www-data:www-data /path/to/nextcloud-data/
+
+If you install or update apps via the Nextcloud **app store**, the ``apps/``
+directory also needs to be writable by the web server:
+
+.. code-block:: bash
+
+   sudo chown -R www-data:www-data /var/www/nextcloud/apps/
+
+.. note::
+
+   The built-in **web updater** requires write access to the entire Nextcloud
+   installation directory. If you apply stricter permissions that prevent
+   web server writes, the web updater will fail. Disable it first by adding the following to
+   ``config/config.php``, then use the command-line updater or package
+   manager instead::
+
+      'upgrade.disable-web' => true,
+
 Disable preview image generation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #1353

### Summary

The hardening page had no file permission guidance. The permissions section was removed in PR #431 because the web updater requires write access to the Nextcloud directory, but no replacement guidance was added and the tradeoff was never documented.

This adds a new **"Set strong file permissions"** subsection to the Deployment section covering:
- Baseline `chown`/`chmod` commands to make the install directory read-only for the web server user
- Note that `data/` must remain writable by the web server user
- Note that `apps/` must remain writable if using the app store
- Warning that the built-in web updater requires write access to the install dir, and that `'upgrade.disable-web' => true` must be set before applying stricter permissions

Note: regarding the paths used, there is a discussion to unify those here: https://github.com/nextcloud/documentation/issues/11447

### 🖼️ Screenshots

<img width="1081" height="740" alt="image" src="https://github.com/user-attachments/assets/b6cde9d6-dd01-443e-86a9-acef51f8ce7f" />
<img width="1081" height="285" alt="image" src="https://github.com/user-attachments/assets/02b50744-4482-49a5-ad89-2beadd12026c" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (n/a — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues