### PR TITLE
docs: clarify htaccess.RewriteBase is a backend path, not public URL

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -191,8 +191,18 @@ if your setup is available on ``https://example.org/nextcloud`` or::
     'overwrite.cli.url' => 'https://example.org/',
     'htaccess.RewriteBase' => '/',
 
-if it isn't installed in a subfolder. Finally run this occ-command to update
-your .htaccess file::
+if it isn't installed in a subfolder.
+
+.. note::
+
+   ``htaccess.RewriteBase`` must match the path relative to Apache's DocumentRoot
+   where Nextcloud is served on the backend, not the public URL prefix. In a direct
+   Apache setup these are identical. Behind a reverse proxy that strips the URL
+   prefix — for example ``https://domain.com/nextcloud/`` forwarded to
+   ``http://localhost:8080/`` — the correct value is ``/`` even though the public
+   URL contains ``/nextcloud``.
+
+Finally run this occ-command to update your ``.htaccess`` file::
 
     sudo -E -u www-data php /var/www/nextcloud/occ maintenance:update:htaccess
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13428

### What changed and why

The previous description of `htaccess.RewriteBase` implied the value should
mirror the public URL (e.g. `/nextcloud` for `https://domain.com/nextcloud/`).
This is wrong in reverse-proxy setups where the proxy strips the URL prefix
before forwarding to the backend server. A user with `domain.com/nextcloud/`
forwarded to `localhost:8080/` (Nextcloud at DocumentRoot) must set the value
to `/`, not `/nextcloud` — using `/nextcloud` causes infinite redirects.

The fix:
- Explicitly states the value is the path relative to Apache's DocumentRoot
  on the backend, not the public URL prefix
- Adds a `.. note::` in the Pretty URLs section of `source_installation.rst`
  with the same clarification

cc @hwalinga

### 🖼️ Screenshots

No visual/layout changes — text-only.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues