### PR TITLE
docs: document NEXTCLOUD_CONFIG_DIR environment variable

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -149,6 +149,30 @@ whatever parameters you specify in it will be merged with your ``config/config.p
    named ``(ANYTHING).config.php``, it will be loaded as part of your live configuration and override
    your ``config/config.php`` values!
 
+Environment Variables
+---------------------
+
+The ``NEXTCLOUD_CONFIG_DIR`` environment variable overrides the default config directory path.
+When set, Nextcloud loads ``config.php`` (and any ``*.config.php`` files) from that path instead
+of the ``config/`` directory inside the webroot.
+
+.. code-block:: bash
+
+   NEXTCLOUD_CONFIG_DIR=/etc/nextcloud php /var/www/nextcloud/cron.php
+
+This is useful for:
+
+- Moving ``config.php`` outside the webroot as a hardening measure — credentials are not
+  accessible via HTTP even if directory listing is enabled or misconfigured.
+- Running multiple Nextcloud instances that share a single codebase but require separate
+  config directories.
+
+.. note:: ``NEXTCLOUD_CONFIG_DIR`` must be set for **both** the web server process and any CLI
+   invocations (``occ``, cron jobs). Set it in your web server virtual host configuration and
+   in the shell environment used for CLI work.
+
+.. seealso:: :ref:`harden_config_dir` in the hardening guide for a deployment recommendation.
+
 Examples
 --------
 

--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -74,6 +74,40 @@ installation.
 .. You may also move your data directory on an existing
 .. installation; see :doc:``
 
+.. _harden_config_dir:
+
+Place config directory outside of the web root
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can move the ``config/`` directory outside the web root using the ``NEXTCLOUD_CONFIG_DIR``
+environment variable. This ensures ``config.php`` — which contains database credentials,
+secret keys, and other sensitive values — is not accessible via HTTP even in the event of a
+web server misconfiguration.
+
+Set the variable in your web server virtual host configuration:
+
+.. code-block:: apache
+
+   # Apache
+   SetEnv NEXTCLOUD_CONFIG_DIR /etc/nextcloud
+
+.. code-block:: nginx
+
+   # nginx — set via fastcgi_param or the PHP-FPM pool's env[] setting
+   fastcgi_param NEXTCLOUD_CONFIG_DIR /etc/nextcloud;
+
+Also set it for CLI work (``occ``, cron):
+
+.. code-block:: bash
+
+   export NEXTCLOUD_CONFIG_DIR=/etc/nextcloud
+
+.. note:: The variable must be set for **both** the web server process and CLI invocations.
+   Verify with ``occ config:list system`` after changing it.
+
+.. seealso:: :doc:`../configuration_server/config_sample_php_parameters` for full details on
+   ``NEXTCLOUD_CONFIG_DIR`` and other configuration loading behaviour.
+
 Disable preview image generation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #399

### What changed and why

`NEXTCLOUD_CONFIG_DIR` has been in the Nextcloud codebase for 8+ years and is actively used
(e.g. by the Snap package) but was never documented. This PR adds it in two places:

1. **`admin_manual/configuration_server/config_sample_php_parameters.rst`** — new
   "Environment Variables" section explaining what the variable does, when to use it, and
   the requirement to set it for both the web server and CLI. Cross-references the hardening page.

2. **`admin_manual/installation/harden_server.rst`** — new "Place config directory outside
   of the web root" subsection under Deployment, with Apache and nginx snippets and a
   reference back to the config parameters page for full details.

### 🖼️ Screenshots

<img width="1081" height="756" alt="image" src="https://github.com/user-attachments/assets/72ddb642-74aa-490b-9a0a-4e725e92cb77" />
<img width="1081" height="881" alt="image" src="https://github.com/user-attachments/assets/dc892d57-1fb2-4596-bacf-7026c91cacf5" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — text only)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues