### PR TITLE
docs: replace removed updateAttributesInterval with current LDAP sync behavior

### DIFF
--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -645,26 +645,17 @@ Additional configuration options via occ
 
 Few configuration settings can only be set on command line via ``occ``.
 
-Attribute update interval
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Background sync interval
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-The LDAP backend will update user information that is used within Nextcloud
-with the values provided by the LDAP server. For instance these are email,
-quota or the avatar. This happens on every login, the first detection of a user
-from LDAP and regularly by a background job.
+The LDAP backend updates user attributes (email, quota, avatar, and others) on
+every login, on first detection of a new user, and periodically via a background
+job.
 
-The interval value determines the time between updates of the values and is
-used to avoid frequent overhead, including time-expensive write actions to
-the database.
-
-The interval is described in seconds and it defaults to 86400 equalling a day.
-It is not a per-configuration option.
-
-The value can be modified by::
-
-  sudo -E -u www-data php occ config:app:set user_ldap updateAttributesInterval --value=86400
-
-A value of 0 will update it on every of the named occasions.
+The background job recalculates its run interval after each cycle. The goal is
+to process every known LDAP user approximately once per day. The interval is
+derived from the total number of mapped users and the smallest configured LDAP
+paging size, then clamped to a minimum of 30 minutes and a maximum of 12 hours.
 
 Administrative Group mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### ☑️ Resolves

* Fix #11088

### What changed and why

The `updateAttributesInterval` occ config key was removed in Nextcloud 20 via
`RemoveRefreshTime` migration (nextcloud/server#22583). The section in the
LDAP docs was still documenting this removed parameter and its `occ` command.

The background sync interval is now auto-calculated in `Jobs/Sync.php`:
- Goal: process every mapped user approximately once per day
- Formula: `24h / (mappedUsers / minPagingSize)`
- Clamped to 30 minutes (min) – 12 hours (max)
- Recalculated automatically after each background run

The "Attribute update interval" section is replaced with a short "Background
sync interval" section describing the current behavior. The `occ` command
referencing the removed config key is removed.

### 🖼️ Screenshots

Text-only change, no screenshots needed.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues