### PR TITLE
fix: open Follow us footer links in a new tab

### DIFF
--- a/build/index-template.html
+++ b/build/index-template.html
@@ -283,14 +283,14 @@
 			<div class="col-sm-2">
 				<h1>Follow us</h1>
 				<ul>
-					<li><a href="https://nextcloud.com/blog/">Blog</a></li>
-					<li><a href="https://www.facebook.com/Nextclouders/">Facebook</a></li>
-					<li><a href="https://x.com/nextclouders">X</a></li>
-					<li><a href="https://instagram.com/nextclouders">Instagram</a></li>
-					<li><a href="https://www.linkedin.com/company/10827569/">LinkedIn</a></li>
-					<li><a href="https://youtube.com/nextcloud">YouTube</a></li>
-					<li><a href="https://mastodon.xyz/@nextcloud">Mastodon</a></li>
-					<li><a href="https://nextcloud.com/feed/">Feed</a></li>
+					<li><a href="https://nextcloud.com/blog/" target="_blank" rel="noopener noreferrer">Blog</a></li>
+					<li><a href="https://www.facebook.com/Nextclouders/" target="_blank" rel="noopener noreferrer">Facebook</a></li>
+					<li><a href="https://x.com/nextclouders" target="_blank" rel="noopener noreferrer">X</a></li>
+					<li><a href="https://instagram.com/nextclouders" target="_blank" rel="noopener noreferrer">Instagram</a></li>
+					<li><a href="https://www.linkedin.com/company/10827569/" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+					<li><a href="https://youtube.com/nextcloud" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+					<li><a href="https://mastodon.xyz/@nextcloud" target="_blank" rel="noopener noreferrer">Mastodon</a></li>
+					<li><a href="https://nextcloud.com/feed/" target="_blank" rel="noopener noreferrer">Feed</a></li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #12322

### What changed and why

The "Follow us" footer links (Blog, Facebook, X, Instagram, LinkedIn, YouTube,
Mastodon, Feed) previously navigated the user away from the docs page. Added
`target="_blank" rel="noopener noreferrer"` so they open in a new tab, keeping
the docs page open.

`rel="noopener noreferrer"` is included alongside `target="_blank"` to prevent
the opened page from accessing `window.opener` (security best practice).

### 🖼️ Screenshots

Footer-only HTML change, no visual layout change.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A — no layout change)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues