### PR TITLE
feat: add epub output for all three manuals (NC32+)

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -78,6 +78,58 @@ jobs:
           path: ${{ matrix.manual.directory }}/${{ matrix.manual.build_path }}
 
   # ============================================================================
+  # BUILD EPUB
+  # ============================================================================
+  # Builds epub documentation for all three manuals. No LaTeX required —
+  # runs in the same plain Python environment as build-html.
+  # ============================================================================
+  build-epub:
+    name: Building ${{ matrix.manual.name }} ePub
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        manual:
+          - name: "user_manual"
+            directory: "user_manual"
+            build_epub_path: "_build/epub/Nextcloud_User_Manual.epub"
+
+          - name: "admin_manual"
+            directory: "admin_manual"
+            build_epub_path: "_build/epub/Nextcloud_Server_Administration_Manual.epub"
+
+          - name: "developer_manual"
+            directory: "developer_manual"
+            build_epub_path: "_build/epub/Nextcloud_Developer_Manual.epub"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install pip dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Build epub documentation
+        run: |
+          set -e
+          cd ${{ matrix.manual.directory }}
+          make epub
+          ls -la ${{ matrix.manual.build_epub_path }}
+
+      - name: Upload ePub documentation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.manual.name }}-epub
+          path: ${{ matrix.manual.directory }}/${{ matrix.manual.build_epub_path }}
+
+  # ============================================================================
   # PREPARE PDF IMAGE
   # ============================================================================
   # Detects whether .devcontainer/Dockerfile changed in this run.
@@ -222,7 +274,7 @@ jobs:
   # ============================================================================
   stage-and-check:
     name: Stage and check documentation
-    needs: [build-html, build-pdf]
+    needs: [build-html, build-pdf, build-epub]
     runs-on: ubuntu-latest
 
     outputs:
@@ -363,13 +415,13 @@ jobs:
             fi
           done
 
-          # Move PDF files to the root of the branch folder for cleaner structure
-          echo "Looking for PDF files to move..."
-          find "stage/${branch}/" -maxdepth 2 -name "*.pdf" -type f
-          for pdf in "stage/${branch}"/*/*.pdf; do
-            if [ -f "$pdf" ]; then
-              echo "Moving PDF: $pdf"
-              mv "$pdf" "stage/${branch}/"
+          # Move PDF and ePub files to the root of the branch folder for cleaner structure
+          echo "Looking for PDF and ePub files to move..."
+          find "stage/${branch}/" -maxdepth 2 \( -name "*.pdf" -o -name "*.epub" \) -type f
+          for f in "stage/${branch}"/*/*.pdf "stage/${branch}"/*/*.epub; do
+            if [ -f "$f" ]; then
+              echo "Moving: $f"
+              mv "$f" "stage/${branch}/"
             fi
           done
 
@@ -498,13 +550,13 @@ jobs:
             fi
           done
 
-          # Move pdf files to the root of the branch folder
-          echo "Looking for PDF files to copy..."
-          find stage/${branch}/ -name "*.pdf" -type f
-          for pdf in stage/${branch}/*.pdf; do
-            if [ -f "$pdf" ]; then
-              echo "Copying PDF: $pdf"
-              cp "$pdf" server/${branch}/
+          # Copy PDF and ePub files to the root of the branch folder
+          echo "Looking for PDF and ePub files to copy..."
+          find stage/${branch}/ -maxdepth 1 \( -name "*.pdf" -o -name "*.epub" \) -type f
+          for f in stage/${branch}/*.pdf stage/${branch}/*.epub; do
+            if [ -f "$f" ]; then
+              echo "Copying: $f"
+              cp "$f" server/${branch}/
             fi
           done
 
@@ -641,8 +693,8 @@ jobs:
             fi
           done
 
-          # PDF files (kept at root of deploy dir)
-          find "stage/${branch}" -maxdepth 1 -name "*.pdf" -exec cp {} netlify-deploy/ \;
+          # PDF and ePub files (kept at root of deploy dir)
+          find "stage/${branch}" -maxdepth 1 \( -name "*.pdf" -o -name "*.epub" \) -exec cp {} netlify-deploy/ \;
 
           # Minimal root index linking to the deployed content
           cat > netlify-deploy/index.html <<'EOF'
@@ -660,8 +712,9 @@ jobs:
               <li><a href="admin_manual/">Administration Manual</a></li>
               <li><a href="developer_manual/">Developer Manual</a></li>
               <li><a href="user_manual/en/">User Manual (English)</a></li>
-              <li><a href="Nextcloud_User_Manual.pdf">User Manual PDF</a></li>
-              <li><a href="Nextcloud_Server_Administration_Manual.pdf">Administration Manual PDF</a></li>
+              <li><a href="Nextcloud_User_Manual.pdf">User Manual PDF</a> / <a href="Nextcloud_User_Manual.epub">ePub</a></li>
+              <li><a href="Nextcloud_Server_Administration_Manual.pdf">Administration Manual PDF</a> / <a href="Nextcloud_Server_Administration_Manual.epub">ePub</a></li>
+              <li><a href="Nextcloud_Developer_Manual.epub">Developer Manual ePub</a></li>
             </ul>
           </body>
           </html>

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-all: html pdf
+all: html pdf epub
 
 html: admin-manual-html user-manual-html developer-manual-html
 pdf: admin-manual-pdf user-manual-pdf
+epub: admin-manual-epub user-manual-epub developer-manual-epub
 
 admin-manual-html:
 	rm -rf admin_manual/_build/html/com
@@ -25,6 +26,18 @@ admin-manual-pdf:
 user-manual-pdf:
 	cd user_manual && make latexpdf
 	@echo "User manual build finished; PDF is updated"
+
+admin-manual-epub:
+	cd admin_manual && make epub
+	@echo "Admin manual build finished; epub is updated"
+
+user-manual-epub:
+	cd user_manual && make epub
+	@echo "User manual build finished; epub is updated"
+
+developer-manual-epub: openapi-spec
+	cd developer_manual && make epub
+	@echo "Developer manual build finished; epub is updated"
 
 get-server-sources:
 	cd build && sh get-server-sources.sh $(DRONE_BRANCH)

--- a/admin_manual/conf.py
+++ b/admin_manual/conf.py
@@ -73,6 +73,7 @@ htmlhelp_basename = 'NextcloudServerAdminManual'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-epub-output
 
 epub_title = u'Nextcloud Server Administration Manual'
+epub_basename = u'Nextcloud_Server_Administration_Manual'
 epub_author = u'The Nextcloud developers'
 epub_publisher = u'The Nextcloud developers'
 epub_copyright = u'2012-2025, The Nextcloud developers'

--- a/build/server-block.php
+++ b/build/server-block.php
@@ -26,16 +26,26 @@ function generate_section(string $version, ?int $index = null): string {
 		$userManualUrl .= 'en/';
 	}
 
+	$hasEpub = $version >= 32;
+	$userManualDownloads = '<a class="reference external" href="server/' . $label . '/Nextcloud_User_Manual.pdf">PDF</a>';
+	$adminManualDownloads = '<a class="reference external" href="server/' . $label . '/Nextcloud_Server_Administration_Manual.pdf">PDF</a>';
+	$developerManualDownloads = '';
+	if ($hasEpub) {
+		$userManualDownloads .= ', <a class="reference external" href="server/' . $label . '/Nextcloud_User_Manual.epub">ePub</a>';
+		$adminManualDownloads .= ', <a class="reference external" href="server/' . $label . '/Nextcloud_Server_Administration_Manual.epub">ePub</a>';
+		$developerManualDownloads = ' (<a class="reference external" href="server/' . $label . '/Nextcloud_Developer_Manual.epub">ePub</a>)';
+	}
+
 	return <<<HTML
 		<div class="section" id="nextcloud-$label">
 			<h2>Nextcloud $version<a class="headerlink" href="#nextcloud-$label" title="Permalink to this headline">¶</a></h2>
 			$note
 			<ul class="simple">
 				<li><a class="reference external" href="$userManualUrl">User Manual</a>
-					(<a class="reference external" href="server/$label/Nextcloud_User_Manual.pdf">Download PDF</a>)</li>
+					($userManualDownloads)</li>
 				<li><a class="reference external" href="server/$label/admin_manual/">Administration Manual</a>
-					(<a class="reference external" href="server/$label/Nextcloud_Server_Administration_Manual.pdf">Download PDF</a>)</li>
-				<li><a class="reference external" href="server/$label/developer_manual/">Developer Manual</a></li>
+					($adminManualDownloads)</li>
+				<li><a class="reference external" href="server/$label/developer_manual/">Developer Manual</a>$developerManualDownloads</li>
 			</ul>
 		</div>
 HTML;

--- a/developer_manual/conf.py
+++ b/developer_manual/conf.py
@@ -92,6 +92,7 @@ StandaloneHTMLBuilder.supported_image_types = [
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-epub-output
 
 epub_title = "Nextcloud Developer Manual"
+epub_basename = "Nextcloud_Developer_Manual"
 epub_author = "The Nextcloud developers"
 epub_publisher = "The Nextcloud developers"
 epub_copyright = "2012-2024, The Nextcloud developers"

--- a/user_manual/conf.py
+++ b/user_manual/conf.py
@@ -83,6 +83,7 @@ htmlhelp_basename = 'NextcloudUserManual'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-epub-output
 
 epub_title = u'Nextcloud User Manual'
+epub_basename = u'Nextcloud_User_Manual'
 epub_author = u'The Nextcloud developers'
 epub_publisher = u'The Nextcloud developers'
 epub_copyright = u'2012-2025, The Nextcloud developers'


### PR DESCRIPTION
### ☑️ Resolves

* Fixes #1240

### What changed and why

Sphinx has built-in epub support and all three manuals already had epub metadata in `conf.py` (title, author, publisher, copyright) — the builder just wasn't wired up.

This PR:
- Sets `epub_basename` in each `conf.py` so the output filename is stable regardless of the version string embedded in `project` (e.g. avoids `Nextcloud_32_Administration_Manual.epub`)
- Adds `epub` make targets to the root `Makefile` and per-manual Makefiles
- Adds a `build-epub` CI job (plain Python env, no LaTeX/Docker needed) that builds and uploads all three epub artifacts
- Extends `stage-and-check`, `deploy`, and the Netlify preview job to handle `.epub` files alongside existing `.pdf` handling
- Updates `build/server-block.php` to show ePub download links in the docs index for NC **32 and newer** — older versions keep their existing PDF-only links unchanged

Output filenames:
- `Nextcloud_User_Manual.epub`
- `Nextcloud_Server_Administration_Manual.epub`
- `Nextcloud_Developer_Manual.epub`

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues

### 🖼️ Screenshots

Index entry for NC32+ (epub links alongside PDF):

```
User Manual (PDF, ePub)
Administration Manual (PDF, ePub)
Developer Manual (ePub)
```

Index entry for NC31 and older (unchanged):

```
User Manual (Download PDF)
Administration Manual (Download PDF)
Developer Manual
```