### PR TITLE
ci: deploy gh-pages once per day via schedule

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - stable*
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC daily — full build + deploy
 
 permissions:
   contents: read
@@ -505,7 +507,7 @@ jobs:
   deploy:
     name: Deploy documentation for gh-pages
     needs: stage-and-check
-    if: github.event_name == 'push'
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
 
     permissions:
@@ -855,7 +857,11 @@ jobs:
           then
             echo "This workflow ran for a pull request. We need stage-and-check and link-check to succeed, deploy must be skipped, and netlify-preview must succeed or fail (non-fatal on forks)"
             if ${{ needs.stage-and-check.result != 'success' || needs.link-check.result != 'success' || needs.deploy.result != 'skipped' || (needs.netlify-preview.result != 'success' && needs.netlify-preview.result != 'failure') }}; then exit 1; fi
+          elif ${{ github.event_name == 'push' }}
+          then
+            echo "This workflow ran for a push. We need stage-and-check and link-check to succeed; deploy and netlify-preview must be skipped"
+            if ${{ needs.stage-and-check.result != 'success' || needs.link-check.result != 'success' || needs.deploy.result != 'skipped' || needs.netlify-preview.result != 'skipped' }}; then exit 1; fi
           else
-            echo "This workflow ran for a push. We need stage-and-check, link-check, and deploy to succeed; netlify-preview must be skipped"
+            echo "This workflow ran on schedule. We need stage-and-check, link-check, and deploy to succeed; netlify-preview must be skipped"
             if ${{ needs.stage-and-check.result != 'success' || needs.link-check.result != 'success' || needs.deploy.result != 'success' || needs.netlify-preview.result != 'skipped' }}; then exit 1; fi
           fi


### PR DESCRIPTION
### ☑️ Resolves

relates to ongoing concern about gh-pages branch size growth

### Summary

Every push to `master`/`stable*` currently triggers a full build and deploy to `gh-pages`,
committing large binary artifacts (PDFs, epubs) on each push. The branch will grow
unboundedly over time.

**Changes in `.github/workflows/sphinxbuild.yml`:**
- Added `schedule: cron: '0 2 * * *'` trigger (02:00 UTC daily)
- `deploy` job now gates on `github.event_name == 'schedule'` instead of `'push'`
- `summary` job updated with 3-way logic: `pull_request` / `push` (deploy skipped) / `schedule` (deploy required)

Push and PR events still run the full build pipeline (HTML + epub + PDF) for CI validation.
Only the deploy to gh-pages is deferred to the daily schedule.

### 🖼️ Screenshots

N/A — CI workflow change only.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues