### PR TITLE
fix: replace sed -i with perl -pi for macOS compatibility

### DIFF
--- a/user_manual/Makefile
+++ b/user_manual/Makefile
@@ -68,8 +68,8 @@ merge-folders:
 	cd $(BUILDDIR)/html/ && rm -rf `find -type d -name _images`
 	mv ./_static $(BUILDDIR)/html/
 	mv ./_images $(BUILDDIR)/html/
-	cd $(BUILDDIR)/html/ && find ./ -type f -exec sed -i -e 's/_images/..\/_images/g' {} \;
-	cd $(BUILDDIR)/html/ && find ./ -type f -exec sed -i -e 's/_static/..\/_static/g' {} \;
+	cd $(BUILDDIR)/html/ && find ./ -type f -exec perl -pi -e 's|_images|../_images|g' {} \;
+	cd $(BUILDDIR)/html/ && find ./ -type f -exec perl -pi -e 's|_static|../_static|g' {} \;
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/user_manual/Makefile
+++ b/user_manual/Makefile
@@ -69,8 +69,8 @@ merge-folders:
 	cd $(BUILDDIR)/html/ && rm -rf `find -type d -name _images`
 	mv ./_static $(BUILDDIR)/html/
 	mv ./_images $(BUILDDIR)/html/
-	cd $(BUILDDIR)/html/ && find ./ -type f -exec sed -i -e 's/_images/..\/_images/g' {} \;
-	cd $(BUILDDIR)/html/ && find ./ -type f -exec sed -i -e 's/_static/..\/_static/g' {} \;
+	cd $(BUILDDIR)/html/ && find ./ -type f -exec perl -pi -e 's|_images|../_images|g' {} \;
+	cd $(BUILDDIR)/html/ && find ./ -type f -exec perl -pi -e 's|_static|../_static|g' {} \;
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml


### PR DESCRIPTION
### ☑️ Resolves

* Fix #13186

### Summary

`merge-folders` in `user_manual/Makefile` used `sed -i -e` to rewrite
`_images` and `_static` paths in the built HTML. macOS BSD sed requires
a backup-extension argument with `-i` (e.g. `sed -i ''`), while GNU sed
does not accept an empty extension — there is no single flag spelling
that works on both.

Replace both invocations with `perl -pi -e`, which handles in-place
edits portably on Linux and macOS.

Before:
```makefile
find ./ -type f -exec sed -i -e 's/_images/..\/_images/g' {} \;
find ./ -type f -exec sed -i -e 's/_static/..\/_static/g' {} \;
```

After:
```makefile
find ./ -type f -exec perl -pi -e 's|_images|../_images|g' {} \;
find ./ -type f -exec perl -pi -e 's|_static|../_static|g' {} \;
```

> Note: the `add-lang-to-versions-template-%` target mentioned in the
> issue title was already removed in a prior refactor commit
> (`c40d359041`). The remaining `sed -i` usage (in `merge-folders`) is
> the last occurrence of this macOS-incompatible pattern.

### 🖼️ Screenshots

N/A — Makefile change only, no visual output affected.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues