### PR TITLE
docs(admin): document smtp_saves_sent config for Exchange duplicate prevention

### DIFF
--- a/admin_manual/groupware/mail.rst
+++ b/admin_manual/groupware/mail.rst
@@ -30,6 +30,23 @@ To enable anti-abuse alerts, you'll have to set a few configuration options :doc
     # Alert when more than 100 messages are sent in one day
     occ config:app:set mail abuse_number_of_messages_per_1d --value=100
 
+Avoid duplicate sent messages (Exchange / Office 365)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 5.8 Nextcloud 32 or newer
+
+Microsoft Exchange and Office 365 automatically save a copy of sent messages to the *Sent* folder
+on the server. If the Mail app saves a copy too, users will see duplicates in their *Sent* folder.
+
+To avoid this, you can enable a check that skips the client-side copy when the server has already
+saved one. The check is disabled by default as it adds an IMAP round-trip to every send::
+
+    occ config:app:set mail smtp_saves_sent --value=true
+
+To disable it again::
+
+    occ config:app:delete mail smtp_saves_sent
+
 Attachment size limit
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/mail/pull/12932

### 🖼️ Screenshots

<img width="1041" height="537" alt="Bildschirmfoto vom 2026-05-27 09-09-54" src="https://github.com/user-attachments/assets/ff7cc7d7-ec78-4c61-a02d-83f07046dc38" />


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
