### PR TITLE
[stable33] chore: update `.github/workflows/sphinxbuild.yml` from master + fix lychee CI

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -475,6 +475,10 @@ jobs:
       # - mailto: links: These are not valid URLs and will always fail
       # - 404.html: This is not necessary
       # - latest/stable/xx links from the version selector
+      # - /builds and /projects: These absolute paths come from the sphinx_rtd_theme when
+      #   READTHEDOCS=True is set. They appear in the generated HTML as navigation links
+      #   to ReadTheDocs build/project pages, but don't correspond to actual staged files.
+      # - openapi.html: Swagger UI pages with JavaScript-rendered anchors that lychee cannot verify
       - name: Check for broken links with lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
@@ -484,9 +488,11 @@ jobs:
           args: |
             --root-dir "$(pwd)/stage"
             --offline --no-progress
+            ${{ needs.stage-and-check.outputs.additional_deployment != '' && format('--remap "https://docs.nextcloud.com/server/{0}/ file://$(pwd)/stage/{1}/"', needs.stage-and-check.outputs.additional_deployment, needs.stage-and-check.outputs.branch_name) || '' }}
             --remap "https://docs.nextcloud.com/server/latest/ file://$(pwd)/stage/${{ needs.stage-and-check.outputs.branch_name }}/"
             --remap "https://docs.nextcloud.com/server/ file://$(pwd)/stage/"
-            --exclude 'go\.php' --exclude 'mailto:' --exclude-path '.*/404\.html' --exclude-path '.*/_static/.*'
+            --exclude 'go\.php' --exclude 'mailto:' --exclude 'openapi\.html' --exclude-path '.*/404\.html' --exclude-path '.*/_static/.*'
+            --exclude '^file://.*/stage/(builds|projects)'
             --exclude "/user_manual/" --include "/user_manual/en/"
             --exclude '^file://.*/stage/(latest|stable|[0-9]+)/(developer_manual|admin_manual|user_manual)/?$'
             'stage/${{ needs.stage-and-check.outputs.branch_name }}/user_manual/en/**/*.html'

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - stable*
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC daily — full build + deploy
 
 permissions:
   contents: read
@@ -473,10 +475,6 @@ jobs:
       # - mailto: links: These are not valid URLs and will always fail
       # - 404.html: This is not necessary
       # - latest/stable/xx links from the version selector
-      # - /builds and /projects: These absolute paths come from the sphinx_rtd_theme when
-      #   READTHEDOCS=True is set. They appear in the generated HTML as navigation links
-      #   to ReadTheDocs build/project pages, but don't correspond to actual staged files.
-      # - openapi.html: Swagger UI pages with JavaScript-rendered anchors that lychee cannot verify
       - name: Check for broken links with lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
@@ -486,11 +484,9 @@ jobs:
           args: |
             --root-dir "$(pwd)/stage"
             --offline --no-progress
-            ${{ needs.stage-and-check.outputs.additional_deployment != '' && format('--remap "https://docs.nextcloud.com/server/{0}/ file://$(pwd)/stage/{1}/"', needs.stage-and-check.outputs.additional_deployment, needs.stage-and-check.outputs.branch_name) || '' }}
             --remap "https://docs.nextcloud.com/server/latest/ file://$(pwd)/stage/${{ needs.stage-and-check.outputs.branch_name }}/"
             --remap "https://docs.nextcloud.com/server/ file://$(pwd)/stage/"
-            --exclude 'go\.php' --exclude 'mailto:' --exclude 'openapi\.html' --exclude-path '.*/404\.html' --exclude-path '.*/_static/.*'
-            --exclude '^file://.*/stage/(builds|projects)'
+            --exclude 'go\.php' --exclude 'mailto:' --exclude-path '.*/404\.html' --exclude-path '.*/_static/.*'
             --exclude "/user_manual/" --include "/user_manual/en/"
             --exclude '^file://.*/stage/(latest|stable|[0-9]+)/(developer_manual|admin_manual|user_manual)/?$'
             'stage/${{ needs.stage-and-check.outputs.branch_name }}/user_manual/en/**/*.html'
@@ -511,7 +507,7 @@ jobs:
   deploy:
     name: Deploy documentation for gh-pages
     needs: stage-and-check
-    if: github.event_name == 'push'
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
 
     permissions:
@@ -859,9 +855,13 @@ jobs:
         run: |
           if ${{ github.event_name == 'pull_request' }}
           then
-            echo "This workflow ran for a pull request. We need stage-and-check, link-check, and netlify-preview to succeed, and deploy must be skipped"
-            if ${{ needs.stage-and-check.result != 'success' || needs.link-check.result != 'success' || needs.deploy.result != 'skipped' || needs.netlify-preview.result != 'success' }}; then exit 1; fi
+            echo "This workflow ran for a pull request. We need stage-and-check and link-check to succeed, deploy must be skipped, and netlify-preview must succeed or fail (non-fatal on forks)"
+            if ${{ needs.stage-and-check.result != 'success' || needs.link-check.result != 'success' || needs.deploy.result != 'skipped' || (needs.netlify-preview.result != 'success' && needs.netlify-preview.result != 'failure') }}; then exit 1; fi
+          elif ${{ github.event_name == 'push' }}
+          then
+            echo "This workflow ran for a push. We need stage-and-check and link-check to succeed; deploy and netlify-preview must be skipped"
+            if ${{ needs.stage-and-check.result != 'success' || needs.link-check.result != 'success' || needs.deploy.result != 'skipped' || needs.netlify-preview.result != 'skipped' }}; then exit 1; fi
           else
-            echo "This workflow ran for a push. We need stage-and-check, link-check, and deploy to succeed; netlify-preview must be skipped"
+            echo "This workflow ran on schedule. We need stage-and-check, link-check, and deploy to succeed; netlify-preview must be skipped"
             if ${{ needs.stage-and-check.result != 'success' || needs.link-check.result != 'success' || needs.deploy.result != 'success' || needs.netlify-preview.result != 'skipped' }}; then exit 1; fi
           fi

--- a/user_manual/_templates/versions.html
+++ b/user_manual/_templates/versions.html
@@ -95,22 +95,6 @@
           </dd>
         {% endfor %}
       </dl>
-      <dl>
-        <dt>{{ _('Downloads') }}</dt>
-        {% for type, url in downloads %}
-          <dd><a href="{{ url }}">{{ type }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        {# Translators: The phrase "Read the Docs" is not translated #}
-        <dt>{{ _('On Read the Docs') }}</dt>
-        <dd>
-          <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
-        </dd>
-        <dd>
-          <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
-        </dd>
-      </dl>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
Updates `.github/workflows/sphinxbuild.yml` from the master branch while restoring stable33-specific configurations required for lychee link validation.

## Background

The automated update from master removed several configurations that are essential for stable33's deployment structure where the highest stable branch is deployed to both `server/stable/` and `server/<N>/` (numeric version) locations.

## Changes Made

Updates sphinxbuild.yml from master and restores the following stable33-specific configurations for lychee link checking:

- **Conditional remap for `additional_deployment`**: Adds version-specific remaps when deploying the highest stable branch (e.g., `--remap "https://docs.nextcloud.com/server/33/ file://$(pwd)/stage/33/"`)
- **Restored exclusions**:
  - `openapi\.html`: Excludes Swagger UI pages with JavaScript-rendered anchors that lychee cannot verify
  - `^file://.*/stage/(builds|projects)`: Excludes ReadTheDocs navigation paths that don't correspond to staged files
- **Restored documentation comments**: Clarifies why these exclusions are necessary

## Impact

This fix ensures that lychee link validation correctly handles:
- Version-specific links in the highest stable branch documentation
- JavaScript-rendered anchors in API documentation
- ReadTheDocs-specific navigation paths that don't apply to the staged environment

Addresses the lychee CI failure that occurred after the master branch update.