### PR TITLE
chore(admin): remove outdated harden_server data note

### DIFF
--- a/admin_manual/installation/harden_server.rst
+++ b/admin_manual/installation/harden_server.rst
@@ -70,10 +70,6 @@ It is highly recommended to place your data directory outside of the Web root
 (i.e. outside of ``/var/www``). It is easiest to do this on a new
 installation.
 
-.. Doc on moving data dir coming soon
-.. You may also move your data directory on an existing
-.. installation; see :doc:``
-
 .. _harden_config_dir:
 
 Place config directory outside of the web root


### PR DESCRIPTION
Removed notes about moving data directory from existing installation.

Seems unnecessary 

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
