### PR TITLE
chore(admin): update ownCloud migration guide

### DIFF
--- a/admin_manual/maintenance/migrating_owncloud.rst
+++ b/admin_manual/maintenance/migrating_owncloud.rst
@@ -15,48 +15,44 @@ See the table below for a version map, where migrating is easily possible:
 +-------------------+-------------------------------+
 | ownCloud          | Nextcloud                     |
 +===================+===============================+
-| 10.13.x           | 25.0.13                       |
-| 10.14.x           | 25.0.13                       |
-| 10.15.x           | 25.0.13                       |
-| 10.16.x           | 25.0.13                       |
+| 10.13.x           | 34.0.0                        |
+| 10.14.x           | 34.0.0                        |
+| 10.15.x           | 34.0.0                        |
+| 10.16.x           | 34.0.0                        |
 +-------------------+-------------------------------+
 
 .. note:: Since ownCloud does not and will not support PHP 8.0 or higher, you
-          need to migrate from ownCloud 10.13.x to Nextcloud 25 and then
-          further upgrade from there. We urge you to migrate to Nextcloud
-          since PHP versions prior PHP 8 are end of life, see
+          need to upgrade your PHP instance first, after which, ownCloud won't
+          be accessible anymore. See :doc:`../installation/system_requirements`
+          about PHP versions supported by Nextcloud. We urge you to migrate to
+          Nextcloud since PHP versions prior PHP 8 are end of life, see
           `<https://www.php.net/supported-versions.php>`_.
 
-1. First download the correct version of Nextcloud from our `older releases page <https://nextcloud.com/changelog/>`_,
+1. First download the correct version of Nextcloud from our `releases page <https://nextcloud.com/changelog/>`_,
 
 2. Make sure to have do a :doc:`backup<backup>` before migrating.
 
-3. Follow the upgrade instructions described in the :doc:`manual_upgrade` manual.
+3. Upgrade PHP to a version supported by the downloaded Nextcloud version.
 
-4. When migrating to Nextcloud 20.0 or later, you will also need to run the following commands after ``occ upgrade``:
+4. Follow the upgrade instructions described in the :doc:`manual_upgrade` manual.
+
+5. Run the following commands after ``occ upgrade``:
 
   * ``occ db:convert-filecache-bigint``
   * ``occ db:add-missing-columns``
   * ``occ db:add-missing-indices``
   * ``occ db:add-missing-primary-keys``
 
-5. If system cron was used, please verify if crontab entry was using the command ``occ system:cron``.
+6. If system cron was used, please verify if crontab entry was using the command ``occ system:cron``.
    If yes, please adjust it to use the ``php`` command instead according to :ref:`the background jobs configuration documentation<system-cron-configuration-label>`
 
-6. As Nextcloud 25 is the last Nextcloud version supporting PHP 7 you need to upgrade your PHP installation afterwards to continue updating to current Nextcloud release.
-   We recommend to update PHP to version 8.1 before continuing with the updates.
-
-7. Use the :doc:`Nextcloud built-in updater<update>` to update your instance to the newest version.
+7. In case, use the :doc:`Nextcloud built-in updater<update>` to update your instance to the newest version.
    This must be done for every major version, since updates between multiple major versions are not supported.
-   So the update path would be: 26 → 27.1 → 28 → 29 → 30 → 31.
 
-8. When reaching Nextcloud 30 or 31 we recommend to update PHP again to a current version like PHP 8.3.
-   You can do so also in between, as PHP 8.2 is already supported since Nextcloud 26 and PHP 8.3 since Nextcloud 28,
-   but in most cases it is easier to first complete the Nextcloud version updates.
+8. If multiple major version upgrades are done, it might be needed to upgrade PHP again in between.
 
 9. Make sure to also verify the "Security & setup warnings" in the "Overview" section on the settings page.
 
 10. In some cases, apps installed from the ownCloud Market might have been disabled as incompatible
     (ex: calendar and contacts), so you should reinstall the Nextcloud ones using
     ``occ app:enable calendar``, ``occ app:enable contacts``, etc
-


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/59677 fixes direct migration from ownCloud to latest Nextcloud.

It does not change something about the fact that latest ownCloud 10 does not support any PHP version supported by Nextcloud. But while keeping PHP 7.4 during the migration to Nextcloud 25 makes it easier to revert to ownCloud in case of an issue, that path requires manually patching `version.php`, a lot of major version upgrades, and intermediate PHP upgrade steps. Overall the efforts are a lot higher than migration directly to latest Nextcloud, and upgrade PHP only once prior to that.

Another reason to prefer direct migration to latest Nextcloud is, that Nextcloud 25 migrations are not maintained anymore. There is hence a chance that some recent ownCloud 10 version introduces a change that causes a major or subtil issue during the migration, that is fixed only in Nextcloud versions which are not EOL.

The migration steps have been adjusted to reflect the direct migration path to the upcoming Nextcloud 34.0.0.

The table itself, to in case list different migration paths for different ownCloud versions, has been left in place, including the optional/conditional migration steps to further upgrade Nextcloud and in case PHP afterwards. However, to reduce maintenance efforts and simplify/clarify things, I'd vote for removing support for migration to any older Nextcloud versions entirely, and remove the target version and post-migration upgrade steps from the docs. Once latest Nextcloud removes support for migrations from ownCloud 10.13.x, it is probably better to simply remove this migration path from the docs, and require admins to upgrade ownCloud first. IMO, keeping support for (and documenting) migrations to Nextcloud versions, which themselves are not supported, and hence do not get possibly needed fixes for migration scripts and `version.php`, does not make sense.

Let me know if you agree to the last point, then I'll adjust the commit accordingly.

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

Before:

<img width="933" height="848" alt="{26547216-C39A-42B0-BF9B-B4612EF9AB19}" src="https://github.com/user-attachments/assets/e2394ba3-7dec-48df-830f-f55dc556ee29" />

After:

<img width="931" height="764" alt="{4F886D4D-9769-4F0E-A391-40C7CD6195BC}" src="https://github.com/user-attachments/assets/a10ab86d-6fd1-4302-988f-f3cc4104d01b" />

_Would it make sense to split each ownCloud-Nextcloud version pair into their own table row, when keeping the table at all?_

### ✅ Checklist

- [x] I <s>have built</s> let github-actions build the documentation <s>locally</s> and reviewed the output (😅)
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
