### PR TITLE
chore(build-index.php): update for PHP >=8.5

### DIFF
--- a/build/build-index.php
+++ b/build/build-index.php
@@ -36,6 +36,12 @@ function is_version_released(int $version): bool {
 	]);
 	
 	$response = @file_get_contents($url, false, $context);
+
+	// FIXME: function_exists conditional can be dropped once we don't need to support <8.4.0
+	if (function_exists('http_get_last_response_headers')) {
+		/** @var array|null */
+		$http_response_header = \http_get_last_response_headers();
+	}
 	
 	if (isset($http_response_header) && is_array($http_response_header)) {
 		return strpos($http_response_header[0] ?? '', '200') !== false;


### PR DESCRIPTION
### ☑️ Resolves

Use `http_get_last_response_headers()` (available in PHP >=8.4.0) instead of DEPRECATED (in PHP >= 8.5.0) `$http_response_header`.

Refs:

- https://www.php.net/manual/en/reserved.variables.httpresponseheader.php
- https://www.php.net/manual/en/function.http-get-last-response-headers.php

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
