### PR TITLE
chore: current dev version is 35, so branch-off release notes

### DIFF
--- a/developer_manual/release_notes/critical_changes.rst
+++ b/developer_manual/release_notes/critical_changes.rst
@@ -13,12 +13,12 @@ Critical changes
 info.xml requirements
 ---------------------
 
-Update info.xml to add Nextcloud 34 to the support range:
+Update info.xml to add Nextcloud 35 to the support range:
 
 .. code-block:: xml
 
   <dependencies>
-    <nextcloud min-version="34" max-version="34" />
+    <nextcloud min-version="35" max-version="35" />
   </dependencies>
 
 To allow installation on older versions too, just keep the previous min-version.
@@ -26,89 +26,10 @@ To allow installation on older versions too, just keep the previous min-version.
 Removed front-end APIs and libraries
 ------------------------------------
 
-- ``OC.Dialogs.fileexists`` was deprecated and is now removed.
-  Use the conflict picker from the ``@nextcloud/dialogs`` library instead.
-- ``OC.Notifications`` was deprecated and is now removed.
-  Use the notification API from the ``@nextcloud/dialogs`` library instead.
-- ``OC.Apps`` was deprecated and is now removed.
-  Use Vue components from the ``@nextcloud/vue`` instead.
-- ``OC.*menu*`` methods were deprecated and are now removed.
-  Use Vue components from the ``@nextcloud/vue`` instead.
-- Magic handling of ``.live-relative-timestamp`` (elements with this class were automatically updated to show relative timestamps) was removed.
-  Use the ``NcDateTime`` component from the ``@nextcloud/vue`` library instead
-- The global ``snapper`` was deprecated and is now removed.
-  For the app navigation please migrate your app to Vue
-  and use the ``NcAppNavigation`` component from the ``@nextcloud/vue`` library instead.
-- Some deprecated globally shared libraries were removed. If you still rely on them, you need to bundle them with your app:
-
-  - ``jQuery`` was deprecated and scheduled for removal since Nextcloud 19.
-  - ``jQuery UI`` was deprecated and scheduled for removal since Nextcloud 19.
-  - ``Backbone`` was deprecated and scheduled for removal since Nextcloud 19.
-  - ``OC.Files.Client`` as it was extending the ``Backbone``.
-  - ``Handlebars`` was deprecated and scheduled for removal since Nextcloud 19.
+- TBD
 
 
 Removed back-end APIs
 ---------------------
 
-- ``\OCP\Share_Backend``, ``\OCP\Share_Backend_Collection``, ``\OCP\Share_Backend_File_Dependent`` were removed. This old
-  share backend was replaced in Nextcloud 9 with a new backend system based on ``IShareProvider``.
-- All these methods were deprecated since before Nextcloud 20 and were removed:
-
-  - ``\OCP\AppFramework\Http\EmptyContentSecurityPolicy::allowEvalScript``
-  - ``\OCP\AppFramework\Http\EmptyContentSecurityPolicy::addAllowedChildSrcDomain``
-  - ``\OCP\AppFramework\Http\EmptyContentSecurityPolicy::disallowChildSrcDomain``
-  - ``\OCP\Collaboration\Resources\IManager::registerResourceProvider``
-  - ``\OCP\Notification\IManager::registerNotifier``
-  - ``\OCP\Util::recursiveArraySearch``
-- All these classes were deprecated since before Nextcloud 20 and were removed:
-
-  - ``\OCP\AppFramework\Http\StrictContentSecurityPolicy``
-  - ``\OCP\AppFramework\Http\StrictEvalContentSecurityPolicy``
-  - ``\OCP\AppFramework\Http\StrictInlineContentSecurityPolicy``
-- Various methods from the legacy ``OC_Util`` static class were removed:
-
-  - Instead of ``\OC_Util::encodePath`` use ``\OCP\Util::encodePath``.
-  - Instead of ``\OC_Util::sanitizeHTML`` use ``\OCP\Util::sanitizeHTML``
-  - Instead of ``\OC_Util::redirectToDefaultPage`` and  ``\OC_Util::getDefaultPageUrl`` use ``\OCP\IUrlGenerator::linkToDefaultPageUrl``
-  - Instead of ``\OC_Util::checkAdminUser`` use ``IGroupManager::class::isAdmin``
-
-
-Unified sharing
----------------
-
-.. todo::
-
-    This is work in progress and needs an update when the changes have been finalized.
-
-Changes to sharing APIs and user interface are planned. This includes both a new general API for sharing of entities and updates to the sharing user interface. See `nextcloud/server#51803 <https://github.com/nextcloud/server/issues/51803>`_ for details and mockups.
-
-
-Navigation styling revisions
-----------------------------
-
-.. todo::
-
-    This is work in progress and needs an update when the changes have been finalized.
-
-Styling of navigation components will be revised. See `nextcloud-libraries/nextcloud-vue#7222 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7222>`_ for details.
-
-
-Sidebar tabs redesign
----------------------
-
-.. todo::
-
-    This is work in progress and needs an update when the changes have been finalized.
-
-Sidebar tab components will be redesigned. See `nextcloud-libraries/nextcloud-vue#7520 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7520>`_ for details.
-
-
-Settings title left-alignment
------------------------------
-
-.. todo::
-
-    This is work in progress and needs an update when the changes have been finalized.
-
-The title alignment of settings pages will be changed to left-aligned. See `nextcloud-libraries/nextcloud-vue#7641 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7641>`_ for details.
+- TBD

--- a/developer_manual/release_notes/deprecations.rst
+++ b/developer_manual/release_notes/deprecations.rst
@@ -20,11 +20,7 @@ New deprecations
 
 .. todo:: This page needs a section for every new deprecation.
 
-- ``\OCP\Util::setChannel`` is now deprecated and you need to use ``\OCP\ServerVersion::setChannel`` instead.
-- ``\OCP\Util::linkToAbsolute`` is now deprecated and you need to use ``\OCP\IUrlGenerator::getAbsoluteUrl`` and ``\OCP\IUrlGenerator::linkTo`` instead.
-- ``\OCP\Util::linkToRemove`` is now deprecated and you need to use ``\OCP\IUrlGenerator::linkToRemote`` instead.
-- ``\OCP\Util::isPublicLinkPasswordRequired`` is now deprecated and you need to use ``\OCP\Share\IManager::shareApiLinkEnforcePassword`` instead.
-- ``\OCP\Util::isDefaultExpireDateEnforced`` is now deprecated and you need to use ``\OCP\Share\IManager::shareApiLinkDefaultExpireDateEnforced`` instead.
+- TBD
 
 Older deprecations
 ------------------

--- a/developer_manual/release_notes/previous/index.rst
+++ b/developer_manual/release_notes/previous/index.rst
@@ -15,6 +15,7 @@ These sub pages will cover the most important changes in Nextcloud, as well as s
 .. toctree::
    :maxdepth: 1
 
+   upgrade_to_34.rst
    upgrade_to_33.rst
    upgrade_to_32.rst
    upgrade_to_31.rst

--- a/developer_manual/release_notes/previous/upgrade_to_34.rst
+++ b/developer_manual/release_notes/previous/upgrade_to_34.rst
@@ -1,0 +1,102 @@
+=======================
+Upgrade to Nextcloud 34
+=======================
+
+Deprecations
+------------
+
+- ``\OCP\Util::setChannel`` is now deprecated and you need to use ``\OCP\ServerVersion::setChannel`` instead.
+- ``\OCP\Util::linkToAbsolute`` is now deprecated and you need to use ``\OCP\IUrlGenerator::getAbsoluteUrl`` and ``\OCP\IUrlGenerator::linkTo`` instead.
+- ``\OCP\Util::linkToRemove`` is now deprecated and you need to use ``\OCP\IUrlGenerator::linkToRemote`` instead.
+- ``\OCP\Util::isPublicLinkPasswordRequired`` is now deprecated and you need to use ``\OCP\Share\IManager::shareApiLinkEnforcePassword`` instead.
+- ``\OCP\Util::isDefaultExpireDateEnforced`` is now deprecated and you need to use ``\OCP\Share\IManager::shareApiLinkDefaultExpireDateEnforced`` instead.
+
+Removed front-end APIs and libraries
+------------------------------------
+
+- ``OC.Dialogs.fileexists`` was deprecated and is now removed.
+  Use the conflict picker from the ``@nextcloud/dialogs`` library instead.
+- ``OC.Notifications`` was deprecated and is now removed.
+  Use the notification API from the ``@nextcloud/dialogs`` library instead.
+- ``OC.Apps`` was deprecated and is now removed.
+  Use Vue components from the ``@nextcloud/vue`` instead.
+- ``OC.*menu*`` methods were deprecated and are now removed.
+  Use Vue components from the ``@nextcloud/vue`` instead.
+- Magic handling of ``.live-relative-timestamp`` (elements with this class were automatically updated to show relative timestamps) was removed.
+  Use the ``NcDateTime`` component from the ``@nextcloud/vue`` library instead
+- The global ``snapper`` was deprecated and is now removed.
+  For the app navigation please migrate your app to Vue
+  and use the ``NcAppNavigation`` component from the ``@nextcloud/vue`` library instead.
+- Some deprecated globally shared libraries were removed. If you still rely on them, you need to bundle them with your app:
+
+  - ``jQuery`` was deprecated and scheduled for removal since Nextcloud 19.
+  - ``jQuery UI`` was deprecated and scheduled for removal since Nextcloud 19.
+  - ``Backbone`` was deprecated and scheduled for removal since Nextcloud 19.
+  - ``OC.Files.Client`` as it was extending the ``Backbone``.
+  - ``Handlebars`` was deprecated and scheduled for removal since Nextcloud 19.
+
+
+Removed back-end APIs
+---------------------
+
+- ``\OCP\Share_Backend``, ``\OCP\Share_Backend_Collection``, ``\OCP\Share_Backend_File_Dependent`` were removed. This old
+  share backend was replaced in Nextcloud 9 with a new backend system based on ``IShareProvider``.
+- All these methods were deprecated since before Nextcloud 20 and were removed:
+
+  - ``\OCP\AppFramework\Http\EmptyContentSecurityPolicy::allowEvalScript``
+  - ``\OCP\AppFramework\Http\EmptyContentSecurityPolicy::addAllowedChildSrcDomain``
+  - ``\OCP\AppFramework\Http\EmptyContentSecurityPolicy::disallowChildSrcDomain``
+  - ``\OCP\Collaboration\Resources\IManager::registerResourceProvider``
+  - ``\OCP\Notification\IManager::registerNotifier``
+  - ``\OCP\Util::recursiveArraySearch``
+- All these classes were deprecated since before Nextcloud 20 and were removed:
+
+  - ``\OCP\AppFramework\Http\StrictContentSecurityPolicy``
+  - ``\OCP\AppFramework\Http\StrictEvalContentSecurityPolicy``
+  - ``\OCP\AppFramework\Http\StrictInlineContentSecurityPolicy``
+- Various methods from the legacy ``OC_Util`` static class were removed:
+
+  - Instead of ``\OC_Util::encodePath`` use ``\OCP\Util::encodePath``.
+  - Instead of ``\OC_Util::sanitizeHTML`` use ``\OCP\Util::sanitizeHTML``
+  - Instead of ``\OC_Util::redirectToDefaultPage`` and  ``\OC_Util::getDefaultPageUrl`` use ``\OCP\IUrlGenerator::linkToDefaultPageUrl``
+  - Instead of ``\OC_Util::checkAdminUser`` use ``IGroupManager::class::isAdmin``
+
+
+Unified sharing
+---------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+Changes to sharing APIs and user interface are planned. This includes both a new general API for sharing of entities and updates to the sharing user interface. See `nextcloud/server#51803 <https://github.com/nextcloud/server/issues/51803>`_ for details and mockups.
+
+
+Navigation styling revisions
+----------------------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+Styling of navigation components will be revised. See `nextcloud-libraries/nextcloud-vue#7222 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7222>`_ for details.
+
+
+Sidebar tabs redesign
+---------------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+Sidebar tab components will be redesigned. See `nextcloud-libraries/nextcloud-vue#7520 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7520>`_ for details.
+
+
+Settings title left-alignment
+-----------------------------
+
+.. todo::
+
+    This is work in progress and needs an update when the changes have been finalized.
+
+The title alignment of settings pages will be changed to left-aligned. See `nextcloud-libraries/nextcloud-vue#7641 <https://github.com/nextcloud-libraries/nextcloud-vue/issues/7641>`_ for details.


### PR DESCRIPTION
### ☑️ Resolves

Was forgotten when stable34 was branched off.
Current developing version is NC35, so the release notes need to reflect that.

### 🖼️ Screenshots

<img width="2560" height="2627" alt="Screenshot 2026-06-03 at 15-00-36 Upgrade to Nextcloud 34 — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/52076c70-cc21-45a9-a32b-5182ad3741c5" />
<img width="1571" height="891" alt="Bildschirmfoto_20260603_150024" src="https://github.com/user-attachments/assets/4fcf2448-d266-4651-a1ac-4de25ddb87f2" />
<img width="1571" height="891" alt="Bildschirmfoto_20260603_150004" src="https://github.com/user-attachments/assets/04640302-ba47-4cdb-bb47-0f71e6b44f09" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
