### PR TITLE
Suggest optional security hardening in systemd service

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -139,7 +139,7 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   ExecStart=/usr/bin/php -f /var/www/nextcloud/cron.php
   KillMode=process
 
-  # Optional security hardening, all of the below entries are optional, but their existence improves the security of your system
+  # Optional security hardening, the below entries improve the security of your system
   # More info can be found at https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html
   CapabilityBoundingSet=
   DevicePolicy=closed
@@ -147,9 +147,7 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   NoNewPrivileges=yes
   PrivateDevices=yes
   PrivateIPC=yes
-  PrivateMounts=yes
   PrivateTmp=yes
-  PrivateUsers=yes
   ProcSubset=pid
   ProtectClock=yes
   ProtectControlGroups=yes
@@ -169,7 +167,17 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   SystemCallFilter=@system-service
   SystemCallFilter=~@privileged
   SystemCallFilter=~@resources
-  UMask=0077
+
+  # Further hardening, requires specifying valid paths for usage
+  #ProtectSystem=strict
+  #ReadWritePaths=/path/to/nextcloud/root /path/to/nextcloud/data
+
+  # Further hardening, if no mounts can be found within nextcloud directories
+  #PrivateMounts=yes
+
+  # Further hardening, if all files within nextcloud directories are owned by the nextcloud user (or root)
+  #PrivateUsers=yes
+  #UMask=0077
 
 Replace the user ``www-data`` with the user of your http server and ``/var/www/nextcloud/cron.php`` with the location of **cron.php** in your nextcloud directory.
 

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -139,7 +139,8 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   ExecStart=/usr/bin/php -f /var/www/nextcloud/cron.php
   KillMode=process
 
-  # Optional security hardening
+  # Optional security hardening, all of the below entries are optional, but their existence improves the security of your system
+  # More info can be found at https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html
   CapabilityBoundingSet=
   DevicePolicy=closed
   LockPersonality=yes

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -139,6 +139,38 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   ExecStart=/usr/bin/php -f /var/www/nextcloud/cron.php
   KillMode=process
 
+  # Optional security hardening
+  CapabilityBoundingSet=
+  DevicePolicy=closed
+  LockPersonality=yes
+  NoNewPrivileges=yes
+  PrivateDevices=yes
+  PrivateIPC=yes
+  PrivateMounts=yes
+  PrivateTmp=yes
+  PrivateUsers=yes
+  ProcSubset=pid
+  ProtectClock=yes
+  ProtectControlGroups=yes
+  ProtectHome=read-only
+  ProtectHostname=yes
+  ProtectKernelLogs=yes
+  ProtectKernelModules=yes
+  ProtectKernelTunables=yes
+  ProtectProc=invisible
+  ProtectSystem=strict
+  RemoveIPC=yes
+  RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+  RestrictNamespaces=yes
+  RestrictRealtime=yes
+  RestrictSUIDSGID=yes
+  SecureBits=noroot-locked
+  SystemCallArchitectures=native
+  SystemCallFilter=@system-service
+  SystemCallFilter=~@privileged
+  SystemCallFilter=~@resources
+  UMask=0077
+
 Replace the user ``www-data`` with the user of your http server and ``/var/www/nextcloud/cron.php`` with the location of **cron.php** in your nextcloud directory.
 
 The `ExecCondition` checks that the nextcloud instance is operating normally before running the background job, and skips it if otherwise.

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -152,7 +152,6 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   ProcSubset=pid
   ProtectClock=yes
   ProtectControlGroups=yes
-  ProtectHome=read-only
   ProtectHostname=yes
   ProtectKernelLogs=yes
   ProtectKernelModules=yes

--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -158,7 +158,7 @@ This approach requires two files: **nextcloudcron.service** and **nextcloudcron.
   ProtectKernelModules=yes
   ProtectKernelTunables=yes
   ProtectProc=invisible
-  ProtectSystem=strict
+  ProtectSystem=full
   RemoveIPC=yes
   RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
   RestrictNamespaces=yes


### PR DESCRIPTION
### ☑️ Resolves

This is similar to pull request https://github.com/nextcloud/notify_push/pull/704 that I opened for notify_push. I didn't find any existing issue opened that this PR resolves.

In particular, this PR adds a few additional `[Service]` systemd entries that are wanted for people that want to ensure additional security bulletproofing on their system.

I verified that nextcloud's cron service works properly with no errors or warnings upon applying. I've been using this configuration on my own machine since a few weeks now and everything is working properly - most importantly, nextcloud reports new version as available for updating, which proves that the most crucial cron functionality works properly.

I believe this is worthy addition. If you want to make it truly optional, I can also comment out all of those entries, leaving them up to the user to enable. Considering the fact that it doesn't create any apparent issues however, I believe they should be enabled by default.

Thanks in advance for considering this PR.

### 🖼️ Screenshots

<img width="961" height="1013" alt="obraz" src="https://github.com/user-attachments/assets/3d03960f-c29b-44a0-b6a0-1cae008523e3" />


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
