### PR TITLE
docs: block access to metadata files in nginx sample configs

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -1,5 +1,5 @@
 # Nextcloud nginx configuration — root installation
-# Version 2026-03-26
+# Version 2026-06-09
 
 # PHP-FPM backend.
 upstream php-handler {
@@ -151,6 +151,10 @@ server {
     # Rules borrowed from `.htaccess` to hide certain paths from clients
     location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)  { return 404; }
     location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)                { return 404; }
+
+    # Hide metadata files which would otherwise be served as plain files and
+    # leak dependency information (composer.json, package.json, core/shipped.json).
+    location ~ ^/(?:composer\.(?:json|lock)|package(?:-lock)?\.json|core/shipped\.json)$ { return 404; }
 
     # Pass PHP requests to PHP-FPM.
     #

--- a/admin_manual/installation/nginx-subdir.conf.sample
+++ b/admin_manual/installation/nginx-subdir.conf.sample
@@ -1,5 +1,5 @@
 # Nextcloud nginx configuration — subdirectory installation (/nextcloud)
-# Version 2026-03-26
+# Version 2026-06-09
 
 # PHP-FPM backend.
 upstream php-handler {
@@ -151,6 +151,10 @@ server {
         # Rules borrowed from `.htaccess` to hide certain paths from clients
         location ~ ^/nextcloud/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)    { return 404; }
         location ~ ^/nextcloud/(?:\.|autotest|occ|issue|indie|db_|console)                  { return 404; }
+
+        # Hide metadata files which would otherwise be served as plain files and
+        # leak dependency information (composer.json, package.json, core/shipped.json).
+        location ~ ^/nextcloud/(?:composer\.(?:json|lock)|package(?:-lock)?\.json|core/shipped\.json)$ { return 404; }
 
         # Pass PHP requests to PHP-FPM.
         #


### PR DESCRIPTION
### ☑️ Resolves

* Fix #15101

The nginx sample configs ([`nginx-root.conf.sample`](https://github.com/nextcloud/documentation/blob/master/admin_manual/installation/nginx-root.conf.sample) and [`nginx-subdir.conf.sample`](https://github.com/nextcloud/documentation/blob/master/admin_manual/installation/nginx-subdir.conf.sample)) served the following top-level metadata files as plain files:

* `https://nc-domain/composer.json`
* `https://nc-domain/composer.lock`
* `https://nc-domain/package.json`
* `https://nc-domain/package-lock.json`
* `https://nc-domain/core/shipped.json`

These paths matched neither an existing `return 404` block nor the static-asset extension list, so they fell through to `location /` → `try_files $uri` and were served verbatim, leaking dependency information.

This adds a 404 `location` block matching these files to both samples, placed alongside the existing rules that hide non-public paths:

```nginx
location ~ ^/(?:composer\.(?:json|lock)|package(?:-lock)?\.json|core/shipped\.json)$ { return 404; }
```

The block is positioned before the `\.php` and static-asset regex blocks so nginx (which evaluates regex `location` blocks in file order) matches it first.

> [!NOTE]
> The upstream [`server/.htaccess`](https://github.com/nextcloud/server/blob/master/.htaccess) does **not** block these files either — it only covers the `build|tests|config|lib|3rdparty|templates` directories and dotfiles. Apache installs likely have the same exposure. It may be worth opening a `nextcloud/server` issue to add the equivalent rule there so the two configs don't drift.

### 🖼️ Screenshots

No visual change — these are `literalinclude`-d config samples, not rendered page content.

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes <!-- N/A: no visual change -->
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
