### PR TITLE
feat(developer_manual): add AudioToTextSubtitles TaskType for TaskProcessing

### DIFF
--- a/developer_manual/digging_deeper/task_processing.rst
+++ b/developer_manual/digging_deeper/task_processing.rst
@@ -100,6 +100,11 @@ The following built-in task types are available:
         * ``input``: ``Audio``
      * Output shape:
         * ``output``: ``Text``
+ * ``'core:audio2text:subtitles'``: This task type is for transcribing audio to a subtitles file. It is implemented by ``\OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles``
+     * Input shape:
+        * ``input``: ``Audio``
+     * Output shape:
+        * ``output``: ``File``
  * ``'core:text2image'``: This task type is for generating images from text prompts. It is implemented by ``\OCP\TaskProcessing\TaskTypes\TextToImage``
       * Input shape:
          * ``input``: ``Text``


### PR DESCRIPTION

### ☑️ Resolves

* Accompanies https://github.com/nextcloud/server/pull/61127

### 🖼️ Screenshots

<img width="1101" height="278" alt="Screenshot 2026-06-09 at 18-14-47 Task Processing — Nextcloud latest Developer Manual latest documentation" src="https://github.com/user-attachments/assets/4d6c0249-c917-450d-9927-b2d3d171a225" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
