### PR TITLE
docs(dev): Document recent changes in the TaskProcessing API

### DIFF
--- a/developer_manual/digging_deeper/task_processing.rst
+++ b/developer_manual/digging_deeper/task_processing.rst
@@ -347,7 +347,7 @@ A **Task processing provider** will usually be a class that implements the inter
     use OCP\TaskProcessing\SummaryTaskType;
     use OCP\IL10N;
 
-    class Provider implements ISynchrounousProvider {
+    class Provider implements ISynchronousProvider {
 
         public function __construct(
             private IL10N $l,
@@ -416,6 +416,43 @@ Since v33.0.0 you can now also throw an ``OCP\TaskProcessing\Exception\UserFacin
 Important to note here is that ``Image``, ``Audio``, ``Video`` and ``File`` slots in the input array will be filled with ``\OCP\Files\File`` objects for your convenience. When outputting one of these you should simply return a string, the API will turn the data into a proper file for convenience. The ``$reportProgress`` parameter is a callback that you may use at will to report the task progress as a single float value between 0 and 1. Its return value will indicate if the task is still running (``true``) or if it was cancelled (``false``) and processing should be terminated.
 
 This class would typically be saved into a file in ``lib/TaskProcessing`` of your app but you are free to put it elsewhere as long as it's loadable by Nextcloud's :ref:`dependency injection container<dependency-injection>`.
+
+Implementing an advanced TaskProcessing provider
+------------------------------------------------
+
+The ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider`` interface is available if you want your provider
+to support watermarking or streaming. If your provider implements ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider``,
+the process method should be adjusted:
+
+.. code-block:: php
+
+    public function process(
+        ?string $userId, array $input, callable $reportProgress,
+        SynchronousProviderOptions $options = new SynchronousProviderOptions(),
+    ): array {
+        $includeWatermark = $options->getIncludeWatermark();
+        $preferStreaming = $options->getPreferStreaming();
+        $reportOutput = $options->getReportIntermediateOutput();
+
+        $textOutput = '1';
+        if ($preferStreaming) {
+            $reportOutput(['output' => $textOutput]);
+        }
+        foreach (range(2, 100) as $i) {
+            $textOutput .= ' and ' . $i;
+            $reportProgress($i / 100);
+            if ($preferStreaming) {
+                $reportOutput(['output' => $textOutput]);
+            }
+        }
+
+        if ($includeWatermark) {
+            $textOutput .= "\n" . 'This was generated using artificial intelligence.';
+        }
+
+        return ['output' => $textOutput];
+    }
+
 
 Providing additional inputs and outputs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/developer_manual/release_notes/new.rst
+++ b/developer_manual/release_notes/new.rst
@@ -34,3 +34,19 @@ but they might be required to have a fully working instance later on.
 Expensive repair steps are only executed when explicitly requested by the administrator.
 
 See :ref:`migration-repair-steps` for details.
+
+Added APIs
+^^^^^^^^^^
+
+- There is a new TaskProcessing provider interface: ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider``. It takes a ``\OCP\TaskProcessing\SynchronousProviderOptions`` option object that contains includeWatermarks, preferStreaming and the callback to report intermediate output.
+
+Changed APIs
+^^^^^^^^^^^^
+
+- The ``\OCP\TaskProcessing\Task`` class now has ``getPreferStreaming`` and ``setPreferStreaming`` methods for indicating whether the provider should report the output progressively if it supports it.
+- The TaskProcessing OCS API now also accepts the ``preferStreaming`` flag when scheduling tasks.
+
+Deprecated APIs
+^^^^^^^^^^^^^^^
+
+- ``\OCP\TaskProcessing\ISynchronousWatermarkingProvider`` is now deprecated. ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider`` should now be used instead.


### PR DESCRIPTION
* Document a new provider interface in `developer_manual/digging_deeper/task_processing.rst`

<img width="957" height="642" alt="image" src="https://github.com/user-attachments/assets/86ebd8ba-c9b8-4fc4-a6e7-538c96b2465e" />

* Inform about API changes in the release notes `developer_manual/release_notes/new.rst`

<img width="975" height="420" alt="image" src="https://github.com/user-attachments/assets/b97d02c7-bba1-40bc-bf7d-f124fd8c6897" />

refs https://github.com/nextcloud/server/pull/60500

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
