### PR TITLE
chore: only show deprecated API in one place

### DIFF
--- a/developer_manual/release_notes/deprecations.rst
+++ b/developer_manual/release_notes/deprecations.rst
@@ -21,6 +21,7 @@ New deprecations
 .. todo:: This page needs a section for every new deprecation.
 
 - ``\OCP\Broadcast\Events\\IBroadcastEvent`` is now deprecated as it is unused.
+- ``\OCP\TaskProcessing\ISynchronousWatermarkingProvider`` is now deprecated. ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider`` should now be used.
 
 Older deprecations
 ------------------
@@ -28,6 +29,15 @@ Older deprecations
 You find all current deprecations in this section.
 
 ..
-    This is where we will move the deprecations after the branch off. Entries will stay until actual removal.
+    This is where we will move the deprecations from the "new deprecations" section after the branch off. Entries will stay until actual removal.
+
+- Deprecated since Nextcloud 34
+
+  - ``\OCP\AppFramework\App::buildAppNamespace`` is deprecated in favor of non-static method ``\OCP\App\IAppManager::getAppNamespace``
+  - ``\OCP\Util::setChannel`` is deprecated in favor of ``\OCP\ServerVersion::setChannel``.
+  - ``\OCP\Util::linkToAbsolute`` is deprecated in favor of ``\OCP\IUrlGenerator::getAbsoluteUrl`` and ``\OCP\IUrlGenerator::linkTo``.
+  - ``\OCP\Util::linkToRemove`` is deprecated in favor of ``\OCP\IUrlGenerator::linkToRemote``.
+  - ``\OCP\Util::isPublicLinkPasswordRequired`` is deprecated in favor of ``\OCP\Share\IManager::shareApiLinkEnforcePassword``.
+  - ``\OCP\Util::isDefaultExpireDateEnforced`` is deprecated in favor of ``\OCP\Share\IManager::shareApiLinkDefaultExpireDateEnforced``.
 
 Also see the older :ref:`Release Notes <previous-versions>` for deprecations.

--- a/developer_manual/release_notes/new.rst
+++ b/developer_manual/release_notes/new.rst
@@ -35,6 +35,9 @@ Expensive repair steps are only executed when explicitly requested by the admini
 
 See :ref:`migration-repair-steps` for details.
 
+Task Processing
+---------------
+
 Added APIs
 ^^^^^^^^^^
 
@@ -45,8 +48,3 @@ Changed APIs
 
 - The ``\OCP\TaskProcessing\Task`` class now has ``getPreferStreaming`` and ``setPreferStreaming`` methods for indicating whether the provider should report the output progressively if it supports it.
 - The TaskProcessing OCS API now also accepts the ``preferStreaming`` flag when scheduling tasks.
-
-Deprecated APIs
-^^^^^^^^^^^^^^^
-
-- ``\OCP\TaskProcessing\ISynchronousWatermarkingProvider`` is now deprecated. ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider`` should now be used instead.

--- a/developer_manual/release_notes/previous/upgrade_to_34.rst
+++ b/developer_manual/release_notes/previous/upgrade_to_34.rst
@@ -5,12 +5,7 @@ Upgrade to Nextcloud 34
 Deprecations
 ------------
 
-- ``\OCP\Util::setChannel`` is now deprecated and you need to use ``\OCP\ServerVersion::setChannel`` instead.
-- ``\OCP\Util::linkToAbsolute`` is now deprecated and you need to use ``\OCP\IUrlGenerator::getAbsoluteUrl`` and ``\OCP\IUrlGenerator::linkTo`` instead.
-- ``\OCP\Util::linkToRemove`` is now deprecated and you need to use ``\OCP\IUrlGenerator::linkToRemote`` instead.
-- ``\OCP\Util::isPublicLinkPasswordRequired`` is now deprecated and you need to use ``\OCP\Share\IManager::shareApiLinkEnforcePassword`` instead.
-- ``\OCP\Util::isDefaultExpireDateEnforced`` is now deprecated and you need to use ``\OCP\Share\IManager::shareApiLinkDefaultExpireDateEnforced`` instead.
-- ``\OCP\AppFramework\App::buildAppNamespace`` is deprecated in favor of non-static method ``\OCP\App\IAppManager::getAppNamespace``
+All deprecations that were announced in the :ref:`Deprecated APIs <deprecated-apis>` section.
 
 Removed front-end APIs and libraries
 ------------------------------------


### PR DESCRIPTION
### ☑️ Resolves

* As noted here: https://github.com/nextcloud/documentation/pull/15067#pullrequestreview-4419516926

Deprecations should stay only in this location,
they are only removed when removed from code.

Until then "new deprecations" are just moved to "older deprecations" on branch-off.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

<img width="2880" height="1705" alt="grafik" src="https://github.com/user-attachments/assets/c62ef47e-6abf-4d59-89a9-f243781313ce" />


<img width="2880" height="3661" alt="grafik" src="https://github.com/user-attachments/assets/97ff07db-fa37-413f-b6d4-09e29bfc407a" />


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
