### PR TITLE
docs(dev): Fix recent changes in the TaskProcessing API

### DIFF
--- a/developer_manual/digging_deeper/task_processing.rst
+++ b/developer_manual/digging_deeper/task_processing.rst
@@ -417,6 +417,8 @@ Important to note here is that ``Image``, ``Audio``, ``Video`` and ``File`` slot
 
 This class would typically be saved into a file in ``lib/TaskProcessing`` of your app but you are free to put it elsewhere as long as it's loadable by Nextcloud's :ref:`dependency injection container<dependency-injection>`.
 
+.. _task_processing-options:
+
 Implementing an advanced TaskProcessing provider
 ------------------------------------------------
 

--- a/developer_manual/release_notes/new.rst
+++ b/developer_manual/release_notes/new.rst
@@ -38,6 +38,9 @@ See :ref:`migration-repair-steps` for details.
 Task Processing
 ---------------
 
+Support for streaming the text output of TaskProcessing providers has been added.
+See :ref:`task_processing-options` for details about how to adjust your providers.
+
 Added APIs
 ^^^^^^^^^^
 


### PR DESCRIPTION
Address comments from #15113

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

In `developer_manual/release_notes/new.rst`

<img width="987" height="423" alt="image" src="https://github.com/user-attachments/assets/1e34615a-0e6a-4ed1-af48-a79b204453f8" />

In `developer_manual/release_notes/deprecations.rst`

<img width="1274" height="743" alt="image" src="https://github.com/user-attachments/assets/14b233a5-3b34-4a63-a0a4-7cc76d8cc972" />


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
