### PR TITLE
ci(workflows): fix cron deploys not running on stable branches

### DIFF
--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -1,0 +1,26 @@
+name: "Schedule documentation builds"
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC daily — triggers sphinxbuild on master + all stable* branches
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    name: Dispatch sphinxbuild on all branches
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dispatch on master and stable branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          for branch in master $(gh api "repos/${{ github.repository }}/branches" --paginate \
+            --jq '.[].name | select(startswith("stable"))'); do
+            echo "Dispatching sphinxbuild.yml on ${branch}"
+            gh workflow run sphinxbuild.yml --repo "${{ github.repository }}" --ref "${branch}"
+          done

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - master
       - stable*
-  schedule:
-    - cron: '0 2 * * *'  # 02:00 UTC daily — full build + deploy
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### ☑️ Resolves

* relates to stable branch deploy being silently broken since the move to cron-based deploys

### What changed and why

GitHub Actions `schedule` events only fire on the **default branch** (`master`). After moving the deploy trigger from `push` to `schedule`, `stable*` branches were still building on push but the `deploy` job condition (`schedule || workflow_dispatch`) was never true for them — so they never deployed.

**Fix:** extract the cron into a dedicated `schedule-builds.yml` orchestrator workflow that:
1. Runs on cron at 02:00 UTC (same schedule as before)
2. Queries the GitHub API for all `stable*` branches
3. Dispatches `sphinxbuild.yml` via `workflow_dispatch` on `master` + each stable branch

`sphinxbuild.yml` already deploys on `workflow_dispatch` — no changes to deploy logic or the summary job needed.

### Files changed

- `.github/workflows/sphinxbuild.yml` — removed `schedule:` trigger (now handled by orchestrator)
- `.github/workflows/schedule-builds.yml` — new orchestrator workflow

### 🖼️ Screenshots

N/A — CI/workflow change only

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (N/A)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues (N/A)

### Testing

Trigger `schedule-builds.yml` manually via Actions UI → confirm one `sphinxbuild.yml` run per branch (master + each stable*) → confirm each run's `deploy` job executes rather than being skipped.