### PR TITLE
docs: add missing/new Deck tools (nextcloud/context_agent#155)

### DIFF
--- a/admin_manual/ai/app_context_agent.rst
+++ b/admin_manual/ai/app_context_agent.rst
@@ -152,12 +152,16 @@ Cookbook tools
 
   * Example prompt: *"Which recipe categories do I have in my cookbook?"*
 
-Deck tools
-~~~~~~~~~~
+Deck tools (require `Deck <https://apps.nextcloud.com/apps/deck>`_)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * List deck boards
 
   * Example prompt: *"List the deck boards I have access to."*
+
+* List the cards on a deck board
+
+  * Example prompt: *"List the cards on my Personal deck board."*
 
 * Add a new card
 
@@ -174,6 +178,22 @@ Deck tools
 * Delete a card
 
   * Example prompt: *"Delete the 'Repair kitchen sink' card in my Personal deck board."*
+
+* List the comments on a deck card
+
+  * Example prompt: *"Show the comments on the 'Repair kitchen sink' card in my Personal deck board."*
+
+* Add a comment to a deck card
+
+  * Example prompt: *"Add a comment 'I'll handle this Friday' to 'Repair kitchen sink' in my Personal deck board."*
+
+* Edit a comment on a deck card
+
+  * Example prompt: *"Update my last comment on the 'Repair kitchen sink' card to say 'Moved to Saturday'."*
+
+* Delete a comment on a deck card
+
+  * Example prompt: *"Delete my last comment on the 'Repair kitchen sink' card in my Personal deck board."*
 
 Files tools
 ~~~~~~~~~~~


### PR DESCRIPTION
### ☑️ Resolves

Documents the 5 Deck tools shipped by nextcloud/context_agent#155 in the
"Currently implemented tools" section. Also hoists the "(require Deck)"
annotation to the section header to match the Mail/Cookbook pattern.

### 🖼️ Screenshots

<img width="698" height="700" alt="image" src="https://github.com/user-attachments/assets/85fb14e7-1498-41b0-8026-408e7ba6abb8" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
