### PR TITLE
fix: show numbered version in manual titles and version picker

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate version constants in conf.py
+        if: github.ref == 'refs/heads/master' || github.base_ref == 'master'
         run: |
           highest_stable=$(git ls-remote --heads origin \
             | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' \

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -276,7 +276,10 @@ jobs:
           if [[ "$branch" == stable* ]]; then
             echo "release=${branch#stable}" >> $GITHUB_OUTPUT
           else
-            echo "release=latest" >> $GITHUB_OUTPUT
+            # For master (latest), derive the dev version from conf.py so the
+            # PDF cover shows a real version number rather than "latest".
+            version_stable=$(grep -m1 '^\s*version_stable\s*=' conf.py | grep -o '[0-9]\+')
+            echo "release=$((version_stable + 1))" >> $GITHUB_OUTPUT
           fi
 
       - name: Build pdf documentation

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -59,40 +59,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Get stable branches
+        if: github.ref == 'refs/heads/master' || github.base_ref == 'master'
+        id: stable_branches
+        run: |
+          branches=$(git ls-remote --heads origin "heads/stable[0-9][0-9]" \
+            | awk '{gsub(/^refs\/heads\/stable/, "", $2); print $2}' \
+            | sort -n -r | tr '\n' ' ')
+          echo "branches=$branches" >> $GITHUB_OUTPUT
+
+      - name: Setup PHP for version validation
+        if: github.ref == 'refs/heads/master' || github.base_ref == 'master'
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+
       - name: Validate version constants in conf.py
         if: github.ref == 'refs/heads/master' || github.base_ref == 'master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # version_stable: highest stableNN branch whose vN.0.0 release actually exists.
-          # Mirrors the is_version_released() check in build/build-index.php and stage-and-check.
-          # A branch that exists but has no release yet (e.g. RC phase) must be skipped.
-          highest_stable=""
-          for n in $(git ls-remote --heads origin \
-              | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' | sort -n -r); do
-            repo=$( [ "$n" -ge 32 ] && echo "nextcloud-releases/server" || echo "nextcloud/server" )
-            status=$(curl -s -o /dev/null -w "%{http_code}" \
-              -H "Authorization: token ${GITHUB_TOKEN}" \
-              "https://api.github.com/repos/${repo}/releases/tags/v${n}.0.0")
-            if [ "$status" = "200" ]; then
-              highest_stable="$n"
-              break
-            fi
-          done
-
-          # version_start: lowest stableNN branch that still exists (branch existence = still documented).
-          lowest_stable=$(git ls-remote --heads origin \
-            | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' \
-            | sort -n | head -1)
+          eval $(php build/detect-versions.php ${{ steps.stable_branches.outputs.branches }})
 
           conf_stable=$(grep -m1 '^\s*version_stable\s*=' conf.py | grep -o '[0-9]\+')
           conf_start=$(grep -m1 '^\s*version_start\s*='  conf.py | grep -o '[0-9]\+')
 
           err=0
-          if [ -z "$highest_stable" ]; then
-            echo "::error::Could not detect any released stable branch."
-            exit 1
-          fi
           if [ "$highest_stable" != "$conf_stable" ]; then
             echo "::error::version_stable in conf.py ($conf_stable) != highest released stable ($highest_stable). Update conf.py."
             err=1

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -61,10 +61,26 @@ jobs:
 
       - name: Validate version constants in conf.py
         if: github.ref == 'refs/heads/master' || github.base_ref == 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          highest_stable=$(git ls-remote --heads origin \
-            | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' \
-            | sort -n | tail -1)
+          # version_stable: highest stableNN branch whose vN.0.0 release actually exists.
+          # Mirrors the is_version_released() check in build/build-index.php and stage-and-check.
+          # A branch that exists but has no release yet (e.g. RC phase) must be skipped.
+          highest_stable=""
+          for n in $(git ls-remote --heads origin \
+              | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' | sort -n -r); do
+            repo=$( [ "$n" -ge 32 ] && echo "nextcloud-releases/server" || echo "nextcloud/server" )
+            status=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${repo}/releases/tags/v${n}.0.0")
+            if [ "$status" = "200" ]; then
+              highest_stable="$n"
+              break
+            fi
+          done
+
+          # version_start: lowest stableNN branch that still exists (branch existence = still documented).
           lowest_stable=$(git ls-remote --heads origin \
             | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' \
             | sort -n | head -1)
@@ -73,12 +89,16 @@ jobs:
           conf_start=$(grep -m1 '^\s*version_start\s*='  conf.py | grep -o '[0-9]\+')
 
           err=0
+          if [ -z "$highest_stable" ]; then
+            echo "::error::Could not detect any released stable branch."
+            exit 1
+          fi
           if [ "$highest_stable" != "$conf_stable" ]; then
-            echo "::error::version_stable in conf.py ($conf_stable) != detected highest stable branch ($highest_stable). Update conf.py."
+            echo "::error::version_stable in conf.py ($conf_stable) != highest released stable ($highest_stable). Update conf.py."
             err=1
           fi
           if [ "$lowest_stable" != "$conf_start" ]; then
-            echo "::error::version_start in conf.py ($conf_start) != detected lowest stable branch ($lowest_stable). Update conf.py."
+            echo "::error::version_start in conf.py ($conf_start) != lowest existing stable branch ($lowest_stable). Update conf.py."
             err=1
           fi
           exit $err

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -59,6 +59,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Validate version constants in conf.py
+        run: |
+          highest_stable=$(git ls-remote --heads origin \
+            | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' \
+            | sort -n | tail -1)
+          lowest_stable=$(git ls-remote --heads origin \
+            | sed -n 's?.*refs/heads/stable\([0-9]\{2\}\)$?\1?p' \
+            | sort -n | head -1)
+
+          conf_stable=$(grep -m1 '^\s*version_stable\s*=' conf.py | grep -o '[0-9]\+')
+          conf_start=$(grep -m1 '^\s*version_start\s*='  conf.py | grep -o '[0-9]\+')
+
+          err=0
+          if [ "$highest_stable" != "$conf_stable" ]; then
+            echo "::error::version_stable in conf.py ($conf_stable) != detected highest stable branch ($highest_stable). Update conf.py."
+            err=1
+          fi
+          if [ "$lowest_stable" != "$conf_start" ]; then
+            echo "::error::version_start in conf.py ($conf_start) != detected lowest stable branch ($lowest_stable). Update conf.py."
+            err=1
+          fi
+          exit $err
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/admin_manual/_templates/versions.html
+++ b/admin_manual/_templates/versions.html
@@ -9,20 +9,20 @@
             data-toggle="rst-current-version"
             aria-expanded="false"
             aria-controls="rst-other-versions-admin">
-      ☁️ {{ current_version }}
+      ☁️ {{ display_version }}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
     </button>
     <div id="rst-other-versions-admin" class="rst-other-versions">
       <dl>
         <dt>☁️ {{ _('Versions') }}</dt>
-        {% for slug, url in versions|reverse %}
+        {% for slug, url, label in versions|reverse %}
         <dd style="width: 32%">
           <a href="{{ url }}"
              {% if current_version == slug %}
              style="color: var(--dark-link-color);"
              {% endif %}
           >
-            {{ slug }}
+            {{ label }}
           </a>
         </dd>
         {% endfor %}

--- a/admin_manual/conf.py
+++ b/admin_manual/conf.py
@@ -20,7 +20,8 @@ from conf import *
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = u'Nextcloud %s Administration Manual' % (version)
+project = u'Nextcloud %s Administration Manual' % (display_version)
+html_title = project
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/build/build-index.php
+++ b/build/build-index.php
@@ -1,82 +1,6 @@
 <?php
 require_once 'server-block.php';
-
-/**
- * Get the GitHub API headers with optional authentication
- */
-function get_github_headers(): string {
-	$headers = 'User-Agent: Nextcloud Documentation Builder';
-	if ($token = getenv('GITHUB_TOKEN')) {
-		$headers .= "\r\nAuthorization: token $token";
-	}
-	return $headers;
-}
-
-/**
- * Get the repository name for a given version
- * Nextcloud moved to nextcloud-releases/server starting with version 32
- */
-function get_repo_for_version(int $version): string {
-	return $version >= 32 ? 'nextcloud-releases/server' : 'nextcloud/server';
-}
-
-/**
- * Parse the HTTP status code from the response headers populated by file_get_contents.
- *
- * @param array $headers The $http_response_header array
- */
-function parse_http_status(array $headers): int {
-	preg_match('/HTTP\/[\d.]+ (\d+)/', $headers[0] ?? '', $matches);
-	return (int)($matches[1] ?? 0);
-}
-
-/**
- * Fetch release info for a given version from the GitHub API.
- *
- * Returns an array ['date' => int] if the release exists (HTTP 200).
- * Returns null if the release does not exist (HTTP 404).
- * Exits with code 1 on any other HTTP status (rate limit, server error, etc.)
- * to prevent silently generating empty or incorrect index sections.
- */
-function fetch_release_info(int $version): ?array {
-	$repo = get_repo_for_version($version);
-	$url = sprintf('https://api.github.com/repos/%s/releases/tags/v%d.0.0', $repo, $version);
-
-	$context = stream_context_create([
-		'http' => [
-			'header' => get_github_headers(),
-			'timeout' => 10,
-			'ignore_errors' => true
-		]
-	]);
-
-	$response = @file_get_contents($url, false, $context);
-
-	// FIXME: function_exists conditional can be dropped once we don't need to support <8.4.0
-	if (function_exists('http_get_last_response_headers')) {
-		/** @var array|null */
-		$http_response_header = \http_get_last_response_headers();
-	}
-
-	$status = isset($http_response_header) && is_array($http_response_header)
-		? parse_http_status($http_response_header)
-		: 0;
-
-	if ($status === 200) {
-		$data = json_decode($response, true);
-		$publishedAt = $data['published_at'] ?? $data['created_at'] ?? null;
-		return ['date' => $publishedAt ? strtotime($publishedAt) : time()];
-	}
-
-	if ($status === 404) {
-		return null;
-	}
-
-	// Any non-200/non-404 response (403 rate limit, 429, 5xx, network failure)
-	// must abort so we never deploy an index with empty or wrong sections.
-	fwrite(STDERR, "GitHub API error (HTTP $status) checking v$version.0.0 — aborting to avoid deploying incorrect index\n");
-	exit(1);
-}
+require_once 'detect-versions.php';
 
 // Parse and validate command-line arguments
 /** @var int[] */
@@ -90,47 +14,16 @@ if (empty($branches)) {
 	exit(1);
 }
 
-// Fetch release information from GitHub
-$released_branches = [];
-$oneYearAgo = time() - (365 * 24 * 60 * 60);
-$foundOutOfSupport = null;
-
-foreach ($branches as $branch) {
-	if ($foundOutOfSupport !== null) {
-		fwrite(STDOUT, "🛑 Version $branch is unsupported (older than version $foundOutOfSupport)\n");
-		$released_branches[$branch] = $releaseTime;
-		$releaseType = $releaseTime >= $oneYearAgo ? 'stable' : 'unsupported';
-		continue;
-	}
-
-	$info = fetch_release_info($branch);
-	if ($info === null) {
-		fwrite(STDERR, "⏳ Version $branch is not released (tag v$branch.0.0 not found)\n");
-		continue;
-	}
-
-	$releaseTime = $info['date'];
-	$released_branches[$branch] = $releaseTime;
-	if ($releaseTime < $oneYearAgo) {
-		fwrite(STDOUT, "🛑 Version $branch is unsupported (released on " . date('Y-m-d', $releaseTime) . ")\n");
-		$foundOutOfSupport = $branch;
-	} else {
-		fwrite(STDOUT, "✅ Version $branch is supported (released on " . date('Y-m-d', $releaseTime) . ")\n");
-	}
-}
-
-// Determine development version
-if (isset($released_branches[$branches[0]])) {
-	$devVersion = $branches[0] + 1;
-	$devStatus = 'development';
-} else {
-	$devVersion = $branches[0];
-	$devStatus = 'upcoming';
-}
+// Detect version metadata (API calls happen here)
+$versions = detect_versions($branches);
+$released_branches = $versions['released'];
+$devVersion = $versions['dev_version'];
+$devStatus = isset($released_branches[$branches[0]]) ? 'development' : 'upcoming';
 
 fwrite(STDERR, "➡️ Version $devVersion ($devStatus)\n");
 
 // Collect released stable versions within support window
+$oneYearAgo = time() - (365 * 24 * 60 * 60);
 $stableVersions = [];
 foreach ($branches as $branch) {
 	if (isset($released_branches[$branch]) && $released_branches[$branch] >= $oneYearAgo) {

--- a/build/detect-versions.php
+++ b/build/detect-versions.php
@@ -109,7 +109,7 @@ function detect_versions(array $branches): array {
 		if ($firstOutOfSupportTime !== null) {
 			// Older than the first out-of-support version — skip API call,
 			// store with the same timestamp (also out of support).
-			fwrite(STDOUT, "🛑 Version $branch is unsupported\n");
+			fwrite(STDERR, "🛑 Version $branch is unsupported\n");
 			$released[$branch] = $firstOutOfSupportTime;
 			continue;
 		}
@@ -122,10 +122,10 @@ function detect_versions(array $branches): array {
 
 		$released[$branch] = $info['date'];
 		if ($info['date'] < $oneYearAgo) {
-			fwrite(STDOUT, "🛑 Version $branch is unsupported (released on " . date('Y-m-d', $info['date']) . ")\n");
+			fwrite(STDERR, "🛑 Version $branch is unsupported (released on " . date('Y-m-d', $info['date']) . ")\n");
 			$firstOutOfSupportTime = $info['date'];
 		} else {
-			fwrite(STDOUT, "✅ Version $branch is supported (released on " . date('Y-m-d', $info['date']) . ")\n");
+			fwrite(STDERR, "✅ Version $branch is supported (released on " . date('Y-m-d', $info['date']) . ")\n");
 		}
 	}
 

--- a/build/detect-versions.php
+++ b/build/detect-versions.php
@@ -142,9 +142,15 @@ function detect_versions(array $branches): array {
 	// otherwise the branch exists but isn't released yet (upcoming).
 	$devVersion = isset($released[$branches[0]]) ? $branches[0] + 1 : $branches[0];
 
+	// lowest_stable: lowest version still within the support window.
+	// Using min($branches) would include ancient branches (e.g. stable10) that still
+	// exist on the remote but are long out of support.
+	$supportedVersions = array_keys(array_filter($released, fn($date) => $date >= $oneYearAgo));
+	$lowestStable = !empty($supportedVersions) ? min($supportedVersions) : $highestStable;
+
 	return [
 		'highest_stable' => $highestStable,
-		'lowest_stable'  => min($branches),
+		'lowest_stable'  => $lowestStable,
 		'dev_version'    => $devVersion,
 		'released'       => $released,
 	];

--- a/build/detect-versions.php
+++ b/build/detect-versions.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Detect Nextcloud version metadata from a list of stable branch numbers.
+ *
+ * Shared helpers are used by build-index.php. When run as a CLI script,
+ * outputs KEY=VALUE pairs (highest_stable, lowest_stable, dev_version)
+ * suitable for appending to $GITHUB_OUTPUT or for eval in bash.
+ *
+ * Usage: php detect-versions.php <branch1> <branch2> ...
+ * Example: php detect-versions.php 32 33 34
+ */
+
+/**
+ * Get the GitHub API headers with optional authentication.
+ */
+function get_github_headers(): string {
+	$headers = 'User-Agent: Nextcloud Documentation Builder';
+	if ($token = getenv('GITHUB_TOKEN')) {
+		$headers .= "\r\nAuthorization: token $token";
+	}
+	return $headers;
+}
+
+/**
+ * Get the repository name for a given version.
+ * Nextcloud moved to nextcloud-releases/server starting with version 32.
+ */
+function get_repo_for_version(int $version): string {
+	return $version >= 32 ? 'nextcloud-releases/server' : 'nextcloud/server';
+}
+
+/**
+ * Parse the HTTP status code from the response headers populated by file_get_contents.
+ *
+ * @param array $headers The $http_response_header array
+ */
+function parse_http_status(array $headers): int {
+	preg_match('/HTTP\/[\d.]+ (\d+)/', $headers[0] ?? '', $matches);
+	return (int)($matches[1] ?? 0);
+}
+
+/**
+ * Fetch release info for a given version from the GitHub API.
+ *
+ * Returns an array ['date' => int] if the release exists (HTTP 200).
+ * Returns null if the release does not exist (HTTP 404).
+ * Exits with code 1 on any other HTTP status (rate limit, server error, etc.)
+ * to prevent silently generating empty or incorrect output.
+ */
+function fetch_release_info(int $version): ?array {
+	$repo = get_repo_for_version($version);
+	$url = sprintf('https://api.github.com/repos/%s/releases/tags/v%d.0.0', $repo, $version);
+
+	$context = stream_context_create([
+		'http' => [
+			'header' => get_github_headers(),
+			'timeout' => 10,
+			'ignore_errors' => true
+		]
+	]);
+
+	$response = @file_get_contents($url, false, $context);
+
+	// FIXME: function_exists conditional can be dropped once we don't need to support <8.4.0
+	if (function_exists('http_get_last_response_headers')) {
+		/** @var array|null */
+		$http_response_header = \http_get_last_response_headers();
+	}
+
+	$status = isset($http_response_header) && is_array($http_response_header)
+		? parse_http_status($http_response_header)
+		: 0;
+
+	if ($status === 200) {
+		$data = json_decode($response, true);
+		$publishedAt = $data['published_at'] ?? $data['created_at'] ?? null;
+		return ['date' => $publishedAt ? strtotime($publishedAt) : time()];
+	}
+
+	if ($status === 404) {
+		return null;
+	}
+
+	fwrite(STDERR, "GitHub API error (HTTP $status) checking v$version.0.0 — aborting\n");
+	exit(1);
+}
+
+/**
+ * Detect version metadata from a list of stable branch numbers.
+ *
+ * @param int[] $branches  All known stable branch numbers (any order)
+ * @return array{
+ *   highest_stable: int|null,
+ *   lowest_stable:  int,
+ *   dev_version:    int,
+ *   released:       array<int, int>
+ * }
+ */
+function detect_versions(array $branches): array {
+	rsort($branches, SORT_NUMERIC);
+	$oneYearAgo = time() - (365 * 24 * 60 * 60);
+	$released = [];
+	$firstOutOfSupportTime = null;
+
+	foreach ($branches as $branch) {
+		if ($firstOutOfSupportTime !== null) {
+			// Older than the first out-of-support version — skip API call,
+			// store with the same timestamp (also out of support).
+			fwrite(STDOUT, "🛑 Version $branch is unsupported\n");
+			$released[$branch] = $firstOutOfSupportTime;
+			continue;
+		}
+
+		$info = fetch_release_info($branch);
+		if ($info === null) {
+			fwrite(STDERR, "⏳ Version $branch is not released (tag v$branch.0.0 not found)\n");
+			continue;
+		}
+
+		$released[$branch] = $info['date'];
+		if ($info['date'] < $oneYearAgo) {
+			fwrite(STDOUT, "🛑 Version $branch is unsupported (released on " . date('Y-m-d', $info['date']) . ")\n");
+			$firstOutOfSupportTime = $info['date'];
+		} else {
+			fwrite(STDOUT, "✅ Version $branch is supported (released on " . date('Y-m-d', $info['date']) . ")\n");
+		}
+	}
+
+	// highest_stable: highest branch with a confirmed release
+	$highestStable = null;
+	foreach ($branches as $b) {
+		if (isset($released[$b])) {
+			$highestStable = $b;
+			break;
+		}
+	}
+
+	// dev_version: if the highest branch has a release, dev = highest + 1;
+	// otherwise the branch exists but isn't released yet (upcoming).
+	$devVersion = isset($released[$branches[0]]) ? $branches[0] + 1 : $branches[0];
+
+	return [
+		'highest_stable' => $highestStable,
+		'lowest_stable'  => min($branches),
+		'dev_version'    => $devVersion,
+		'released'       => $released,
+	];
+}
+
+// CLI entry point — only runs when invoked directly, not when require_once'd.
+if (basename(__FILE__) === basename($argv[0])) {
+	$branches = array_values(array_filter(
+		array_map('intval', array_slice($argv, 1)),
+		fn($b) => $b >= 12
+	));
+
+	if (empty($branches)) {
+		fwrite(STDERR, "Error: No valid stable branches provided (expected numeric args >= 12).\n");
+		exit(1);
+	}
+
+	$result = detect_versions($branches);
+
+	if ($result['highest_stable'] === null) {
+		fwrite(STDERR, "Error: No released stable branch found.\n");
+		exit(1);
+	}
+
+	fwrite(STDERR, "➡️ Version {$result['dev_version']} (development)\n");
+
+	echo "highest_stable={$result['highest_stable']}\n";
+	echo "lowest_stable={$result['lowest_stable']}\n";
+	echo "dev_version={$result['dev_version']}\n";
+}

--- a/conf.py
+++ b/conf.py
@@ -83,7 +83,7 @@ def setup(app):
 
 def generateVersionsDocs(current_docs):
 	versions_doc = []
-	for v in range(version_start, version_stable + 1):
+	for v in range(version_start, version_stable):
 		url = 'https://docs.nextcloud.com/server/%s/%s' % (str(v), current_docs)
 		versions_doc.append((v, url, str(v)))
 	versions_doc.append(('stable', 'https://docs.nextcloud.com/server/stable/%s' % current_docs, '%s (stable)' % version_stable))

--- a/conf.py
+++ b/conf.py
@@ -56,35 +56,35 @@ html_logo = "../_shared_assets/static/logo-white.png"
 # disable including the reST sources in HTML builds (in _sources/) (default is True)
 html_copy_source = False
 
-# substitutions go here
-rst_epilog = """
-.. |version| replace:: %s
-""" % (release)
-
-# Replace hardcoded /latest/ URLs in all .rst source files with the actual release
-def replace_latest(app, docname, source):
-    if release != 'latest':
-        source[0] = source[0].replace('/server/latest/', '/server/%s/' % release)
- 
-def setup(app):
-    app.connect('source-read', replace_latest)
-
-
 # building the versions list
 version_start = 32		# THIS IS THE OLDEST SUPPORTED VERSION NUMBER
 
 						# THIS IS THE VERSION THAT IS MAPPED TO https://docs.nextcloud.com/server/stable/
 version_stable = 33		# CHANGING IT MUST RESULT IN A CHANGE OF THE SYMLINK ON THE LIVE SERVER
+display_version = release if release != 'latest' else str(version_stable + 1)
 
 # Also search for "TODO ON RELEASE" in the rst files
+
+# substitutions go here
+rst_epilog = """
+.. |version| replace:: %s
+""" % (display_version)
+
+# Replace hardcoded /latest/ URLs in all .rst source files with the actual release
+def replace_latest(app, docname, source):
+    if release != 'latest':
+        source[0] = source[0].replace('/server/latest/', '/server/%s/' % release)
+
+def setup(app):
+    app.connect('source-read', replace_latest)
 
 def generateVersionsDocs(current_docs):
 	versions_doc = []
 	for v in range(version_start, version_stable + 1):
 		url = 'https://docs.nextcloud.com/server/%s/%s' % (str(v), current_docs)
-		versions_doc.append(tuple((v, url)))
-	versions_doc.append(tuple(('stable', 'https://docs.nextcloud.com/server/%s/%s' % ('stable', current_docs))))
-	versions_doc.append(tuple(('latest', 'https://docs.nextcloud.com/server/%s/%s' % ('latest', current_docs))))
+		versions_doc.append((v, url, str(v)))
+	versions_doc.append(('stable', 'https://docs.nextcloud.com/server/stable/%s' % current_docs, '%s (stable)' % version_stable))
+	versions_doc.append(('latest', 'https://docs.nextcloud.com/server/latest/%s' % current_docs, '%s (latest)' % display_version))
 	return versions_doc
 
 if version.isdigit():
@@ -94,6 +94,7 @@ else:
 
 html_context = {
 	'current_version': version,
+	'display_version': display_version,
 	'READTHEDOCS': True,
 
 	# force github plugin

--- a/conf.py
+++ b/conf.py
@@ -57,10 +57,13 @@ html_logo = "../_shared_assets/static/logo-white.png"
 html_copy_source = False
 
 # building the versions list
-version_start = 32		# THIS IS THE OLDEST SUPPORTED VERSION NUMBER
+# CI validates both constants against actual stableNN branches (see sphinxbuild.yml).
+# Update version_start when the lowest stableNN branch is deleted (version goes EoL).
+# Update version_stable when a new NC release ships (highest stableNN branch added).
+version_start = 32		# oldest documented version
 
-						# THIS IS THE VERSION THAT IS MAPPED TO https://docs.nextcloud.com/server/stable/
-version_stable = 33		# CHANGING IT MUST RESULT IN A CHANGE OF THE SYMLINK ON THE LIVE SERVER
+						# latest released stable — CHANGING IT MUST RESULT IN A CHANGE OF THE SYMLINK ON THE LIVE SERVER
+version_stable = 33		# mapped to https://docs.nextcloud.com/server/stable/
 display_version = release if release != 'latest' else str(version_stable + 1)
 
 # Also search for "TODO ON RELEASE" in the rst files

--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,7 @@ html_copy_source = False
 version_start = 32		# oldest documented version
 
 						# latest released stable — CHANGING IT MUST RESULT IN A CHANGE OF THE SYMLINK ON THE LIVE SERVER
-version_stable = 33		# mapped to https://docs.nextcloud.com/server/stable/
+version_stable = 34		# mapped to https://docs.nextcloud.com/server/stable/
 display_version = release if release != 'latest' else str(version_stable + 1)
 
 # Also search for "TODO ON RELEASE" in the rst files

--- a/developer_manual/_templates/versions.html
+++ b/developer_manual/_templates/versions.html
@@ -9,20 +9,20 @@
             data-toggle="rst-current-version"
             aria-expanded="false"
             aria-controls="rst-other-versions-dev">
-      ☁️ {{ current_version }}
+      ☁️ {{ display_version }}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
     </button>
     <div id="rst-other-versions-dev" class="rst-other-versions">
       <dl>
         <dt>☁️ {{ _('Versions') }}</dt>
-        {% for slug, url in versions|reverse %}
+        {% for slug, url, label in versions|reverse %}
         <dd style="width: 32%">
           <a href="{{ url }}"
              {% if current_version == slug %}
              style="color: var(--dark-link-color);"
              {% endif %}
           >
-            {{ slug }}
+            {{ label }}
           </a>
         </dd>
         {% endfor %}

--- a/developer_manual/conf.py
+++ b/developer_manual/conf.py
@@ -22,7 +22,8 @@ from sphinx.builders.html import StandaloneHTMLBuilder
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "Nextcloud %s Developer Manual" % (version)
+project = "Nextcloud %s Developer Manual" % (display_version)
+html_title = project
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/user_manual/_templates/versions.html
+++ b/user_manual/_templates/versions.html
@@ -68,7 +68,7 @@
             aria-controls="rst-other-versions-user">
       🌐 {{ language_names.get(language, language) }}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
-       ☁️ {{ current_version }}
+       ☁️ {{ display_version }}
       <span class="fa fa-caret-down" aria-hidden="true"></span>
     </button>
     <div id="rst-other-versions-user" class="rst-other-versions">
@@ -90,14 +90,14 @@
     <div class="rst-other-versions">
       <dl>
         <dt>☁️ {{ _('Versions') }}</dt>
-        {% for slug, url in versions|reverse %}
+        {% for slug, url, label in versions|reverse %}
           <dd style="width: 32%">
             <a href="{{ url }}"
                {% if current_version == slug %}
                style="color: var(--dark-link-color);"
                {% endif %}
             >
-              {{ slug }}
+              {{ label }}
             </a>
           </dd>
         {% endfor %}

--- a/user_manual/conf.py
+++ b/user_manual/conf.py
@@ -20,7 +20,8 @@ from conf import *
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = u'Nextcloud %s User Manual' % (version)
+project = u'Nextcloud %s User Manual' % (display_version)
+html_title = project
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -55,7 +56,7 @@ gettext_compact = False
 ## Markup
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-markup
 # a substitution that will be included in every source file
-rst_epilog =  '.. |version| replace:: %s' % version
+rst_epilog =  '.. |version| replace:: %s' % display_version
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output


### PR DESCRIPTION
### ☑️ Resolves

Closes #14891 (partial - addresses the version picker label clarity)

### What changed and why

On the master branch, `version = 'latest'` caused all three manuals to display "Nextcloud latest User Manual" in titles, headings, the version picker, and PDF covers. That's ambiguous - readers can't tell which numbered release "latest" maps to.

This PR introduces `display_version` in `conf.py`, derived automatically from `version_stable + 1`. It's currently `35` (NC35 dev). When NC35 ships and `version_stable` bumps to 35, the display updates to 36 with no other changes needed. `version = 'latest'` is kept intact so URL rewriting, branch logic, and `html_baseurl` are unaffected.

The version picker also gets clearer labels: `34 (stable)` and `35 (latest)` instead of bare `stable` / `latest`. The collapsed picker button shows the number too. And since the stable version was appearing twice in the list, the numbered range now stops just before `version_stable`.

PDF covers on master builds used to say "Release latest". They now derive the version the same way - `version_stable + 1` from `conf.py`.

On the CI side, this also introduces a validation step that fails the `build-html` job (master and PRs targeting master only) if `version_stable` or `version_start` in `conf.py` have drifted from the actual remote branch state. The detection logic that was previously duplicated in `sphinxbuild.yml` and `build-index.php` is now in a single `build/detect-versions.php` script that both call. It checks the GitHub API to confirm a `v{N}.0.0` release actually exists before accepting a branch as "stable" - so an RC branch won't be counted prematurely. The lowest supported version is also derived from the support window (released within the last year) rather than the raw minimum branch number, which would otherwise include ancient branches like stable10.

### 🖼️ Screenshots

<img width="323" height="179" alt="image" src="https://github.com/user-attachments/assets/f0492e94-1c63-46fa-973a-7d4ddb1c57c6" /><img width="973" height="467" alt="image" src="https://github.com/user-attachments/assets/6915628b-dacf-4c4b-a5bf-2840c981eebd" />
<img width="597" height="608" alt="image" src="https://github.com/user-attachments/assets/8d288e59-fceb-47a4-a4f7-1afd17fcd093" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues