### PR TITLE
fix: detect stable branch version from GITHUB_REF for display_version

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,7 +64,13 @@ version_start = 32		# oldest documented version
 
 						# latest released stable — CHANGING IT MUST RESULT IN A CHANGE OF THE SYMLINK ON THE LIVE SERVER
 version_stable = 34		# mapped to https://docs.nextcloud.com/server/stable/
-display_version = release if release != 'latest' else str(version_stable + 1)
+import re as _re
+_stable_branch = _re.match(r'refs/heads/stable(\d+)$', os.environ.get('GITHUB_REF', ''))
+display_version = (
+    release if release != 'latest'                   # PDF/ePub builds (DOCS_RELEASE set)
+    else _stable_branch.group(1) if _stable_branch   # HTML builds on stableNN branches
+    else str(version_stable + 1)                     # HTML builds on master
+)
 
 # Also search for "TODO ON RELEASE" in the rst files
 


### PR DESCRIPTION
Follow-up to #15140.

The previous `display_version` formula (`str(version_stable + 1)`) works correctly on master but breaks on stable branches: since `release = 'latest'` for HTML builds (DOCS_RELEASE is only set for PDF/ePub), a stable34 HTML build would show "35" in titles instead of "34".

This PR uses `GITHUB_REF` to detect which stable branch we're building and returns the correct version number. Master behavior is unchanged (GITHUB_REF = refs/heads/master does not match the stable pattern, so it falls through to `str(version_stable + 1)`).

The same fix has already been applied to the three backport PRs (#15154, #15155, #15156).

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues