### PR TITLE
fix: use GITHUB_BASE_REF to detect stable branch for display_version and PDF

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -271,6 +271,7 @@ jobs:
 
       - name: Compute PDF release version
         id: pdf_version
+        shell: bash
         run: |
           # For PRs use the target branch; for pushes use the current branch.
           # This handles both stable34 direct pushes and backport/*/stable34 PRs.

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -272,12 +272,13 @@ jobs:
       - name: Compute PDF release version
         id: pdf_version
         run: |
-          branch="${GITHUB_REF#refs/heads/}"
-          if [[ "$branch" == stable* ]]; then
-            echo "release=${branch#stable}" >> $GITHUB_OUTPUT
+          # For PRs use the target branch; for pushes use the current branch.
+          # This handles both stable34 direct pushes and backport/*/stable34 PRs.
+          branch="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}"
+          if [[ "$branch" =~ ^stable([0-9]+)$ ]]; then
+            echo "release=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
           else
-            # For master (latest), derive the dev version from conf.py so the
-            # PDF cover shows a real version number rather than "latest".
+            # master: derive the dev version from conf.py.
             version_stable=$(grep -m1 '^\s*version_stable\s*=' conf.py | grep -o '[0-9]\+')
             echo "release=$((version_stable + 1))" >> $GITHUB_OUTPUT
           fi

--- a/conf.py
+++ b/conf.py
@@ -101,7 +101,7 @@ def generateVersionsDocs(current_docs):
 		url = 'https://docs.nextcloud.com/server/%s/%s' % (str(v), current_docs)
 		versions_doc.append((v, url, str(v)))
 	versions_doc.append(('stable', 'https://docs.nextcloud.com/server/stable/%s' % current_docs, '%s (stable)' % version_stable))
-	versions_doc.append(('latest', 'https://docs.nextcloud.com/server/latest/%s' % current_docs, '%s (latest)' % display_version))
+	versions_doc.append(('latest', 'https://docs.nextcloud.com/server/latest/%s' % current_docs, '%s (latest)' % str(version_stable + 1)))
 	return versions_doc
 
 if version.isdigit():

--- a/conf.py
+++ b/conf.py
@@ -64,7 +64,21 @@ version_start = 32		# oldest documented version
 
 						# latest released stable — CHANGING IT MUST RESULT IN A CHANGE OF THE SYMLINK ON THE LIVE SERVER
 version_stable = 34		# mapped to https://docs.nextcloud.com/server/stable/
-display_version = release if release != 'latest' else str(version_stable + 1)
+import re as _re
+# Detect stable branch version for display purposes.
+# For PRs: GITHUB_BASE_REF is the target branch (e.g. 'stable34').
+# For direct pushes: GITHUB_REF is 'refs/heads/stable34'.
+_base = os.environ.get('GITHUB_BASE_REF', '')
+_ref  = os.environ.get('GITHUB_REF', '')
+_stable_ver = (
+    _re.match(r'^stable(\d+)$', _base)
+    or _re.match(r'^refs/heads/stable(\d+)$', _ref)
+)
+display_version = (
+    release if release != 'latest'                    # PDF/ePub builds (DOCS_RELEASE set)
+    else _stable_ver.group(1) if _stable_ver          # stableNN branches and PRs targeting them
+    else str(version_stable + 1)                      # master
+)
 
 # Also search for "TODO ON RELEASE" in the rst files
 
@@ -96,7 +110,7 @@ else:
 	github_branch = 'master'
 
 html_context = {
-	'current_version': version,
+	'current_version': int(_stable_ver.group(1)) if _stable_ver else version,
 	'display_version': display_version,
 	'READTHEDOCS': True,
 

--- a/conf.py
+++ b/conf.py
@@ -97,6 +97,15 @@ def setup(app):
 
 def generateVersionsDocs(current_docs):
 	versions_doc = []
+
+	# If viewing an unsupported (older than version_start) branch, prepend it so it
+	# appears last after the template's |reverse — e.g. "26 (unsupported)" at the bottom.
+	if _stable_ver:
+		branch_ver = int(_stable_ver.group(1))
+		if branch_ver < version_start:
+			url = 'https://docs.nextcloud.com/server/%s/%s' % (str(branch_ver), current_docs)
+			versions_doc.append((branch_ver, url, '%s (unsupported)' % branch_ver))
+
 	for v in range(version_start, version_stable):
 		url = 'https://docs.nextcloud.com/server/%s/%s' % (str(v), current_docs)
 		versions_doc.append((v, url, str(v)))


### PR DESCRIPTION
Follow-up to #15140, discovered while fixing backport PRs #15154 #15155 #15156.

The previous `display_version` detection used `GITHUB_REF` matched against `refs/heads/stable(\d+)$`. This breaks for backport branches (`backport/15140/stable33`) where `GITHUB_REF` is the source branch, not the target — causing the picker button to show "latest", the picker to highlight the wrong entry, and the PDF to say "Nextcloud 35" instead of "33".

**Fix:** use `GITHUB_BASE_REF` (the PR target branch, always a clean `stableNN`) for PRs, falling back to `GITHUB_REF` for direct pushes. Both matched strictly against `^stable([0-9]+)$` — no loose pattern matching.

**Also:** `html_context['current_version']` is now set to the detected stable version integer so the picker correctly highlights the current docs version instead of always highlighting "latest".

**PDF:** same fix in the `Compute PDF release version` step — uses `GITHUB_BASE_REF` fallback so backport PR CI shows the correct version on the PDF cover.

Master behavior is unchanged: `GITHUB_BASE_REF` is empty for direct master pushes, `GITHUB_REF = refs/heads/master` does not match `^stable`, so `display_version = str(version_stable + 1) = '35'` as before.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues