### PR TITLE
docs(admin): add Docker/AIO systemd example for the AI worker

### DIFF
--- a/admin_manual/ai/overview.rst
+++ b/admin_manual/ai/overview.rst
@@ -427,12 +427,23 @@ section:
    After=network.target docker.service
    Requires=docker.service
 
-and call ``occ`` through ``docker exec`` in ``taskprocessing.sh`` instead of running it locally:
+and call ``occ`` through ``docker exec`` in ``taskprocessing.sh`` instead of running it locally. The
+``[Unit]`` ordering above only waits for the Docker daemon, not for the ``nextcloud-aio-nextcloud``
+container, so the script waits until that container reports healthy before running ``occ`` (the AIO image
+ships a healthcheck for php-fpm and the database). Without this wait the worker would exit immediately
+after a host reboot and, with ``Restart=always``, hit systemd's start-rate limit and stay down until a
+manual reset:
 
 .. code-block:: bash
 
    #!/bin/sh
    echo "Starting Nextcloud AI Worker $1"
+   i=0
+   until [ "$(docker inspect -f '{{.State.Health.Status}}' nextcloud-aio-nextcloud 2>/dev/null)" = healthy ]; do
+       i=$((i + 1))
+       [ "$i" -ge 60 ] && echo "nextcloud-aio-nextcloud not healthy after 5 min" && exit 1
+       sleep 5
+   done
    docker exec -i nextcloud-aio-nextcloud sudo -E -u www-data php occ taskprocessing:worker -v -t 60
 
 Use ``docker exec -i`` without ``-t``: systemd does not allocate a pseudo-TTY, so adding ``-t`` makes the

--- a/admin_manual/ai/overview.rst
+++ b/admin_manual/ai/overview.rst
@@ -416,6 +416,28 @@ The complete logs of the workers can be checked with (replace 1 with the worker 
 
    journalctl -xeu nextcloud-ai-worker@1.service -f
 
+If your Nextcloud runs inside a Docker container (for example with Nextcloud AIO), the worker has to run
+*inside* the container. Make the service unit shown above wait for Docker by extending its ``[Unit]``
+section:
+
+.. code-block:: ini
+
+   [Unit]
+   Description=Nextcloud AI worker %i
+   After=network.target docker.service
+   Requires=docker.service
+
+and call ``occ`` through ``docker exec`` in ``taskprocessing.sh`` instead of running it locally:
+
+.. code-block:: bash
+
+   #!/bin/sh
+   echo "Starting Nextcloud AI Worker $1"
+   docker exec -i nextcloud-aio-nextcloud sudo -E -u www-data php occ taskprocessing:worker -v -t 60
+
+Use ``docker exec -i`` without ``-t``: systemd does not allocate a pseudo-TTY, so adding ``-t`` makes the
+command fail with ``the input device is not a TTY``.
+
 
 Frequently Asked Questions
 --------------------------


### PR DESCRIPTION
The **Systemd service** section of the AI overview only documented running the task-processing worker on bare
metal. When Nextcloud runs inside a Docker container (for example Nextcloud AIO) the service has to (a) wait for
Docker and (b) call `occ` inside the container via `docker exec`. This adds that variant right after the existing
systemd example:

- extend the `[Unit]` section with `After=network.target docker.service` and `Requires=docker.service`, so the
  worker only starts once Docker is up;
- a `taskprocessing.sh` that runs
  `docker exec -i nextcloud-aio-nextcloud sudo -E -u www-data php occ taskprocessing:worker -v -t 60`.

Using `docker exec -i` **without** `-t` is deliberate: systemd provides no pseudo-TTY, so `-t` would fail with
`the input device is not a TTY`.

Notes for review:

- The command mirrors the existing AIO `docker exec` example already in the *Screen or tmux session* section
  (same container name, user and command) and uses the current `taskprocessing:worker` command — the page
  documents (`.. versionchanged:: 32.0.7`) that this replaced `background-job:worker`.
- Kept as plain prose + code blocks to match that existing Docker example on the same page, rather than a
  `.. note::`.
- The two new code blocks carry explicit `ini` / `bash` language tags per the style guide ("always specify the
  language"); the surrounding pre-existing blocks are left untouched to keep the change focused.

### :white_check_mark: Resolves

* Fix #13075

### :framed_picture: Screenshots

Rendered *Systemd service* section, new Docker/AIO variant at the bottom:
<img width="698" height="1515" alt="pr13075_systemd" src="https://github.com/user-attachments/assets/894620fd-1df1-45bb-a0a2-5fd6f719b661" />


### :white_check_mark: Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes (screenshot to follow later today)
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
