### PR TITLE
fix: update nextcloud-docker-dev URLs to nextcloud org

### DIFF
--- a/developer_manual/exapp_development/DevSetup.rst
+++ b/developer_manual/exapp_development/DevSetup.rst
@@ -4,7 +4,7 @@ Setting up dev environment
 ==========================
 
 AppAPI development requires a Nextcloud development environment setup.
-We highly recommend using `Julius Knorr's Docker setup <https://github.com/juliusknorr/nextcloud-docker-dev>`_ for this.
+We highly recommend using the `nextcloud-docker-dev <https://github.com/nextcloud/nextcloud-docker-dev>`_ setup (originally developed by Julius Knorr) for this.
 For an alternate environment without using Docker, please refer to the setup instructions in :doc:`Getting started <../getting_started/devenv>`.
 
 Suggested IDE: **PhpStorm**, though you can certainly use any IDE of your preference such as **VS Code** or **Vim**.

--- a/developer_manual/exapp_development/development_overview/ExAppOverview.rst
+++ b/developer_manual/exapp_development/development_overview/ExAppOverview.rst
@@ -214,7 +214,7 @@ It is recommended to use the following default set of commands:
 - ``copy_translations``: copies translations to needed location depending on your ExApp backend programming language.
 
 .. note::
-    These Makefiles are typically written to work in the `nextcloud-docker-dev <https://github.com/juliusknorr/nextcloud-docker-dev>`_ development environment.
+    These Makefiles are typically written to work in the `nextcloud-docker-dev <https://github.com/nextcloud/nextcloud-docker-dev>`_ development environment.
 
 For a complete example, you can take a look at our `Makefile for the 3rd-party service example <https://github.com/cloud-py-api/visionatrix/blob/main/Makefile>`_.
 This example also requires the ``xmlstarlet`` program to be installed so that the Makefile can automatically detect the ExApp version from the info.xml file.


### PR DESCRIPTION
### ☑️ Resolves

The `nextcloud-docker-dev` repository has moved from `juliusknorr` to the `nextcloud` GitHub organisation. This updates all links accordingly, preserving attribution to Julius Knorr.

### 🖼️ Screenshots

N/A — link-only change, no visual output affected.

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues