### PR TITLE
fix(developer_manual): update AudioToTextSubtitles TaskType description

### DIFF
--- a/developer_manual/digging_deeper/task_processing.rst
+++ b/developer_manual/digging_deeper/task_processing.rst
@@ -100,9 +100,9 @@ The following built-in task types are available:
         * ``input``: ``Audio``
      * Output shape:
         * ``output``: ``Text``
- * ``'core:audio2text:subtitles'``: This task type is for transcribing audio to a subtitles file. It is implemented by ``\OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles``
+ * ``'core:audio2text:subtitles'``: This task type is for transcribing audio or video to a subtitles file. It is implemented by ``\OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles``
      * Input shape:
-        * ``input``: ``Audio``
+        * ``input``: ``File``
      * Output shape:
         * ``output``: ``File``
  * ``'core:text2image'``: This task type is for generating images from text prompts. It is implemented by ``\OCP\TaskProcessing\TaskTypes\TextToImage``


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #15103 after https://github.com/nextcloud/server/pull/61127#issuecomment-4706279681

### 🖼️ Screenshots

<img width="1101" height="256" alt="Screenshot 2026-06-17 at 08-33-11 Task Processing — Nextcloud 35 Developer Manual" src="https://github.com/user-attachments/assets/ec1880cb-15b8-4546-978b-f0b649154dcc" />

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
