### PR TITLE
Update upgrade_to_33.rst

### DIFF
--- a/admin_manual/release_notes/upgrade_to_33.rst
+++ b/admin_manual/release_notes/upgrade_to_33.rst
@@ -23,7 +23,7 @@ Snowflake IDs
 -------------
 
 This version of Nextcloud ships with `Snowflake IDs <https://en.wikipedia.org/wiki/Snowflake_ID>`_. Those IDs include the creation time of object, a sequence ID and a server ID.
-The server ID should now be configured in your config.php file or using environment variables. See :doc:`../configuration_server/config_sample_php_parameters` for more information.
+The server ID should now be configured in your config.php file or using environment variables. See :doc:`../configuration_server/config_sample_php_parameters#serverid` for more information.
 
 OpenMetrics endpoint
 --------------------


### PR DESCRIPTION
adding direct link to serverid conf in the config_sample_php parameters, because it currently goes to the page summary only, and one has to search for serverid

### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [ ] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
