### PR TITLE
fix(devmanual): do not describe the config lexicon as new

### DIFF
--- a/developer_manual/digging_deeper/config/lexicon.rst
+++ b/developer_manual/digging_deeper/config/lexicon.rst
@@ -4,7 +4,7 @@ Lexicon
 
 .. versionadded:: 32
 
-Since v32, Nextcloud provides a way to centralize the definition of your app's configuration keys and values in a single place.
+Nextcloud provides a way to centralize the definition of your app's configuration keys and values in a single place.
 
 
 .. _concept-overview:
@@ -102,7 +102,7 @@ Each config key is defined in a object through those arguments:
 Preset
 ^^^^^^
 
-With 32, Nextcloud comes with a list of `preset` to ease the default user experience, based on the context of the instance.
+Nextcloud comes with a list of `preset` to ease the default user experience, based on the context of the instance.
 The selection of a preset is optional and can be done right after the setup of Nextcloud, and any time in the future using this occ command:
 
 .. code-block:: bash


### PR DESCRIPTION
### ☑️ Resolves

* Fix #…

### 🖼️ Screenshots

Too lazy

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
