### PR TITLE
docs: document removal of MySQL v8.0 and adding v9.7 LTS

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -25,7 +25,7 @@ For best performance, stability and functionality we have documented some recomm
 |                  | - CentOS Stream                                                       |
 |                  | - Alpine Linux                                                        |
 +------------------+-----------------------------------------------------------------------+
-| Database         | - MySQL 8.0 / 8.4                                                     |
+| Database         | - MySQL 8.4 / 9.7                                                     |
 |                  | - MariaDB 10.6 / 10.11 / 11.4 / **11.8** (recommended)                |
 |                  | - Oracle Database 19c, 21c, 23ai                                      |
 |                  |   (*only as part of an enterprise subscription*)                      |

--- a/admin_manual/release_notes/upgrade_to_35.rst
+++ b/admin_manual/release_notes/upgrade_to_35.rst
@@ -11,3 +11,14 @@ System requirements
   - The minimum supported version of *SUSE Linux Enterprise Server 15* has been bumped to SP7.
   - The minimum supported version of *Debian Linux* has been bumped to *13 (Trixie)*.
   - The minimum supported version of *Ubuntu Linux* has been bumped to *24.04*.
+
+- The list of officially supported databases has been updated:
+
+  - MySQL 8.0 is out of support and thus Nextcloud dropped support for it.
+    The minimum supported version of MySQL is now 8.4 LTS.
+  - MySQL 9.7 is released as a new LTS version and is now supported by Nextcloud.
+
+    .. note:: MySQL 9+ dropped support for MD5, some parts of the Nextcloud ecosystem might stilly rely on it.
+      You need to make sure that after upgrading to MySQL 9+ you load the MySQL component for MD5 support, to do so run this on your MySQL 9+ server:
+
+      ``INSTALL COMPONENT 'file://component_classic_hashing';``

--- a/developer_manual/release_notes/deprecations.rst
+++ b/developer_manual/release_notes/deprecations.rst
@@ -16,12 +16,25 @@ New deprecations
 ..
     Add one section for each group of deprecations (e.g. group files api changes, authentication changes).
     Also deprecate the feature at their dedicated documentation page.
-    After branch-off the contents below will be cleared.
+    After branch-off the contents below will be cleared and moved to the "Older deprecations" section.
 
-.. todo:: This page needs a section for every new deprecation.
+.. .. todo:: This page needs a section for every new deprecation.
 
-- ``\OCP\Broadcast\Events\\IBroadcastEvent`` is now deprecated as it is unused.
-- ``\OCP\TaskProcessing\ISynchronousWatermarkingProvider`` is now deprecated. ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider`` should now be used.
+Database
+^^^^^^^^
+
+- ``\OCP\DB\QueryBuilder\IFunctionBuilder::md5`` is now deprecated.
+  MD5 is not considered secure anymore, thus most databases have or will drop support for this SQL function.
+
+Events
+^^^^^^
+
+- ``\OCP\Broadcast\Events\IBroadcastEvent`` is now deprecated as it is unused.
+
+Task processing
+^^^^^^^^^^^^^^^
+
+- ``\OCP\TaskProcessing\ISynchronousWatermarkingProvider`` is now deprecated, instead use ``\OCP\TaskProcessing\ISynchronousOptionsAwareProvider`` now.
 
 Older deprecations
 ------------------


### PR DESCRIPTION
### ☑️ Resolves

- for https://github.com/nextcloud/server/pull/61247

### 🖼️ Screenshots

<img width="767" height="589" alt="Bildschirmfoto_20260622_105500" src="https://github.com/user-attachments/assets/80857976-0a78-497b-91f5-cb5f1c53f5c1" />
<img width="900" height="390" alt="Screenshot 2026-06-22 at 10-57-53 Deprecations — Nextcloud 35 Developer Manual" src="https://github.com/user-attachments/assets/31b45af2-3ba1-4ae5-bb41-a7efd139f4a8" />
<img width="2560" height="1240" alt="Screenshot 2026-06-22 at 10-52-50 Upgrade to Nextcloud 35 — Nextcloud 35 Administration Manual" src="https://github.com/user-attachments/assets/2b66ceb8-70e8-4917-8ae1-836de346af62" />


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
