### PR TITLE
feat: add section on activity app admin configuration to include mail_max_items config

### DIFF
--- a/admin_manual/configuration_server/activity_configuration.rst
+++ b/admin_manual/configuration_server/activity_configuration.rst
@@ -56,6 +56,12 @@ As an administrator, you can:
    emails immediately, truncate or clear the ``oc_activity_mq`` database
    table.
 
+* Configure the maximum number of activities fully displayed in notification emails
+  using the ``mail_max_items`` setting. Activities beyond this limit are summarised
+  as *"and X more"* at the bottom of the email. The default is ``200`` and the
+  maximum allowed value is ``1000``. For example, to set it to ``500``::
+
+     occ config:app:set activity mail_max_items --value=500
 
 Configuration reference
 -----------------------


### PR DESCRIPTION
### ☑️ Resolves

* Related to https://github.com/nextcloud/activity/pull/2673

- related PR (link above) should be merged first as it includes a new config (`mail_max_items`) that can be set via occ command for the activity app
- this PR documents that this config exists, it's purporse and how to set a value for it

### 🖼️ Screenshots

| before | after |
|--------|-------|
| <img width="988" height="408" alt="Screenshot from 2026-06-22 15-53-14" src="https://github.com/user-attachments/assets/be4d7960-3727-4be3-89a7-1064487c2c45" /> | <img width="988" height="564" alt="image" src="https://github.com/user-attachments/assets/f02b4279-78a6-4cb7-8063-a182c7676948" /> |


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [ ] I have run `codespell` or similar and addressed any spelling issues
