### PR TITLE
docs: use sudo -E -u www-data php occ syntax in euro-office config

### DIFF
--- a/admin_manual/office/euro-office/configuration.rst
+++ b/admin_manual/office/euro-office/configuration.rst
@@ -18,7 +18,7 @@ Alternatively, install the app using the :command:`occ` command:
 
 .. code-block:: bash
 
-    php occ app:install eurooffice
+    sudo -E -u www-data php occ app:install eurooffice
 
 Server settings
 ---------------
@@ -215,10 +215,10 @@ Settings can also be managed via :command:`occ`:
 .. code-block:: bash
 
     # Read a setting
-    php occ config:app:get eurooffice DocumentServerUrl
+    sudo -E -u www-data php occ config:app:get eurooffice DocumentServerUrl
 
     # Write a setting
-    php occ config:app:set eurooffice DocumentServerUrl --value="https://office.example.com/"
+    sudo -E -u www-data php occ config:app:set eurooffice DocumentServerUrl --value="https://office.example.com/"
 
 The ``eurooffice:documentserver`` command shows the configured server URL and optionally
 tests the connection:
@@ -226,10 +226,10 @@ tests the connection:
 .. code-block:: bash
 
     # Print the currently configured Document Server URL
-    php occ eurooffice:documentserver
+    sudo -E -u www-data php occ eurooffice:documentserver
 
     # Check the connection to the Document Server
-    php occ eurooffice:documentserver --check
+    sudo -E -u www-data php occ eurooffice:documentserver --check
 
 config.php
 ----------


### PR DESCRIPTION
### ☑️ Resolves

Fixes the `check-occ-command` CI check failure on `admin_manual/office/euro-office/configuration.rst`.
All `php occ` invocations now use the required `sudo -E -u www-data php occ` syntax.

### ✅ Checklist

- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
