### PR TITLE
Revert "[stable34] feat: add section on activity app admin configuration to include mail_max_items config"

### DIFF
--- a/admin_manual/configuration_server/activity_configuration.rst
+++ b/admin_manual/configuration_server/activity_configuration.rst
@@ -56,12 +56,6 @@ As an administrator, you can:
    emails immediately, truncate or clear the ``oc_activity_mq`` database
    table.
 
-* Configure the maximum number of activities fully displayed in notification emails
-  using the ``mail_max_items`` setting. Activities beyond this limit are summarised
-  as *"and X more"* at the bottom of the email. The default is ``200`` and the
-  maximum allowed value is ``1000``. For example, to set it to ``500``::
-
-     occ config:app:set activity mail_max_items --value=500
 
 Configuration reference
 -----------------------


### PR DESCRIPTION
Reverts nextcloud/documentation#15224, which was accidentaly merged before [related backport PR](https://github.com/nextcloud/activity/pull/2708).