### PR TITLE
docs: honour DOCS_DISPLAY_VERSION for display version

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -74,7 +74,7 @@ _stable_ver = (
     _re.match(r'^stable(\d+)$', _base)
     or _re.match(r'^refs/heads/stable(\d+)$', _ref)
 )
-display_version = (
+display_version = os.environ.get('DOCS_DISPLAY_VERSION') or (
     release if release != 'latest'                    # PDF/ePub builds (DOCS_RELEASE set)
     else _stable_ver.group(1) if _stable_ver          # stableNN branches and PRs targeting them
     else str(version_stable + 1)                      # master


### PR DESCRIPTION
Enables the consolidated deploy workflow to set the correct display version for stable builds (it can't set reserved GITHUB_* refs per matrix leg). Falls back to existing detection when unset. Prereq for the single deploy PR (#15269). AI-assisted (ClaudeCode:claude-opus-4-8).