### PR TITLE
ci: prune noise-only files from deploy PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -178,17 +178,45 @@ jobs:
           # Cleanup empty directories
           find . -type d -empty -delete
 
-          # Check for meaningful changes, ignoring:
-          # - lastupdated date lines in HTML (Sphinx build-time timestamps)
-          # - epub/pdf binaries (they regenerate automatically alongside HTML)
-          meaningful_html=$(git diff HEAD -- '*.html' | grep -E '^[+-]' | grep -v '^[+-]{3}' | grep -ivE 'lastupdated|Last updated on' | wc -l)
-          other_changes=$(git diff --name-only HEAD | grep -cvE '\.(html|epub|pdf)$' || true)
+          # ----------------------------------------------------------------
+          # Prune build-only noise so the PR carries exclusively real content
+          # changes. A rebuilt page differs every night even when its content
+          # is identical, because of:
+          #   - Sphinx build-time timestamps (lastupdated / "Last updated on")
+          #   - mermaid diagram zoom ids (random UUID regenerated each build)
+          # Files whose ENTIRE diff is noise are reverted to HEAD; files with a
+          # real change are kept untouched (noise lines ride along, harmless).
+          # ----------------------------------------------------------------
+          NOISE='lastupdated|Last updated on|data-zoom-id'
 
-          if [ "$meaningful_html" -gt 0 ] || [ "$other_changes" -gt 0 ]; then
+          # 1) Revert HTML files whose only changes are noise.
+          git diff --name-only HEAD -- '*.html' | while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            real=$(git diff HEAD -- "$f" | grep -E '^[+-]' | grep -vE '^[+-]{3}' | grep -ivE "$NOISE" | wc -l)
+            [ "$real" -eq 0 ] && git checkout HEAD -- "$f"
+          done
+
+          # 2) PDF/ePub binaries regenerate every build with no content change.
+          #    Keep them only for a version folder that still has a real HTML
+          #    change after step 1; otherwise revert them too.
+          git diff --name-only HEAD -- '*.pdf' '*.epub' | while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              server/*)
+                vdir="server/$(printf '%s' "${f#server/}" | cut -d/ -f1)"
+                remaining=$(git diff --name-only HEAD -- "$vdir" | grep -vE '\.(epub|pdf)$' | wc -l)
+                [ "$remaining" -eq 0 ] && git checkout HEAD -- "$f"
+                ;;
+              *) git checkout HEAD -- "$f" ;;
+            esac
+          done
+
+          # Anything real left to deploy? (tracked diffs or brand-new files)
+          if [ -n "$(git status --porcelain)" ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "::notice::Skipping deploy PR: only lastupdated timestamps or epub/pdf binaries changed"
+            echo "::notice::Skipping deploy PR: only build noise (timestamps, mermaid ids, binaries) changed"
           fi
 
       - name: Strip noindex from stable docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -189,27 +189,45 @@ jobs:
           # ----------------------------------------------------------------
           NOISE='lastupdated|Last updated on|data-zoom-id'
 
-          # 1) Revert HTML files whose only changes are noise.
-          git diff --name-only HEAD -- '*.html' | while IFS= read -r f; do
+          # Read-only diffs must not take .git/index.lock: a `git diff` that
+          # refreshes the index while a `git checkout` writes it races on the
+          # lock. GIT_OPTIONAL_LOCKS=0 suppresses the refresh write; we also
+          # materialise each file list fully before running any checkout, and
+          # batch the reverts into a single checkout call.
+          export GIT_OPTIONAL_LOCKS=0
+
+          # 1) Collect HTML files whose only changes are noise, then revert them.
+          : > /tmp/revert-html.txt
+          git diff --name-only HEAD -- '*.html' > /tmp/changed-html.txt
+          while IFS= read -r f; do
             [ -n "$f" ] || continue
             real=$(git diff HEAD -- "$f" | grep -E '^[+-]' | grep -vE '^[+-]{3}' | grep -ivE "$NOISE" | wc -l)
-            [ "$real" -eq 0 ] && git checkout HEAD -- "$f"
-          done
+            [ "$real" -eq 0 ] && printf '%s\n' "$f" >> /tmp/revert-html.txt
+          done < /tmp/changed-html.txt
+          if [ -s /tmp/revert-html.txt ]; then
+            xargs -a /tmp/revert-html.txt -r git checkout HEAD --
+          fi
 
           # 2) PDF/ePub binaries regenerate every build with no content change.
           #    Keep them only for a version folder that still has a real HTML
-          #    change after step 1; otherwise revert them too.
-          git diff --name-only HEAD -- '*.pdf' '*.epub' | while IFS= read -r f; do
+          #    change after step 1; otherwise revert them too. Runs after the
+          #    HTML revert so the per-folder check sees the pruned tree.
+          : > /tmp/revert-bin.txt
+          git diff --name-only HEAD -- '*.pdf' '*.epub' > /tmp/changed-bin.txt
+          while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
               server/*)
                 vdir="server/$(printf '%s' "${f#server/}" | cut -d/ -f1)"
                 remaining=$(git diff --name-only HEAD -- "$vdir" | grep -vE '\.(epub|pdf)$' | wc -l)
-                [ "$remaining" -eq 0 ] && git checkout HEAD -- "$f"
+                [ "$remaining" -eq 0 ] && printf '%s\n' "$f" >> /tmp/revert-bin.txt
                 ;;
-              *) git checkout HEAD -- "$f" ;;
+              *) printf '%s\n' "$f" >> /tmp/revert-bin.txt ;;
             esac
-          done
+          done < /tmp/changed-bin.txt
+          if [ -s /tmp/revert-bin.txt ]; then
+            xargs -a /tmp/revert-bin.txt -r git checkout HEAD --
+          fi
 
           # Anything real left to deploy? (tracked diffs or brand-new files)
           if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
### ☑️ Resolves

Cuts build noise from the nightly deploy PRs. No linked issue — follow-up on the deploy workflow after observing #15278 (1337 files changed, the vast majority timestamp-only).

### 🧩 What & why

The scheduled `deploy-docs.yml` workflow rebuilds every documentation version every night. A rebuilt page differs even when its content is identical, because of:

- Sphinx build-time timestamps (`lastupdated` / `Last updated on`)
- mermaid diagram zoom ids (`data-zoom-id` — a random UUID regenerated on every build)

The previous logic was a single global gate: it only decided whether to open a PR **at all**. As soon as one real change existed anywhere in the tree, every noise-only file was committed alongside it. In #15278 that meant 1337 files, where `32` / `33` / `34` / `stable` were almost entirely timestamp + mermaid-id churn plus one genuine link-anchor fix.

This changes the "Apply staged artifacts" step to prune per file **before** opening the PR:

1. Revert any HTML file whose entire diff is noise (timestamps, mermaid zoom ids). Files with a real change are kept untouched — noise lines just ride along.
2. Revert `pdf`/`epub` binaries for a version folder that has no real HTML change left after step 1 (they regenerate every build with no content change).
3. Recompute `has_changes` from the pruned tree (`git status --porcelain`), so a run that produced only noise still opens no PR.

Result: deploy PRs carry only files with genuine content changes.

### 🖼️ Screenshots

N/A — CI workflow change, no rendered documentation output.

### 🧪 Testing notes

- YAML validates (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-docs.yml'))"`).
- Prune logic reviewed against #15278's diff: the ~1888 `Last updated` lines and mermaid `data-zoom-id` lines are the only noise categories; the one real change there (a swapped troubleshooting link anchor) would be preserved, everything else dropped.
- The `data-zoom-id` token matches both mermaid lines (the `<pre data-zoom-id=…>` and the `d3.selectAll(".mermaid[data-zoom-id=…]")` selector), so a file's diagram id churn reverts as a pair and stays internally consistent.
- Full behavioural verification happens on the next scheduled run against `gh-pages`.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output — N/A, CI-only change
- [x] Screenshots are included for visual changes — N/A
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues

---

_This change was AI-assisted (drafted with Claude Code); the author reviewed and owns it._
