### PR TITLE
ci: strip stable noindex before pruning deploy noise

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -178,6 +178,18 @@ jobs:
           # Cleanup empty directories
           find . -type d -empty -delete
 
+          # Strip noindex from stable docs BEFORE pruning. Sphinx always emits a
+          # noindex robots meta, but the deployed stable pages have it stripped
+          # (they are the canonical, indexed version). If we pruned first, every
+          # rebuilt stable file would still carry that meta and so differ from
+          # HEAD by a "real" line — defeating the prune and leaving timestamp-only
+          # files in the PR. Stripping first makes noise-only stable pages match
+          # HEAD, so the prune below can revert them.
+          if [ -d server/stable ]; then
+            find server/stable -name '*.html' -print0 | \
+              xargs -0 perl -pi -e 's{<meta name="robots" content="noindex, follow" />\n?}{}g'
+          fi
+
           # ----------------------------------------------------------------
           # Prune build-only noise so the PR carries exclusively real content
           # changes. A rebuilt page differs every night even when its content
@@ -235,15 +247,6 @@ jobs:
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "::notice::Skipping deploy PR: only build noise (timestamps, mermaid ids, binaries) changed"
-          fi
-
-      - name: Strip noindex from stable docs
-        if: steps.apply.outputs.has_changes == 'true'
-        run: |
-          # Strip noindex from stable docs – these are the canonical pages we want indexed
-          if [ -d server/stable ]; then
-            find server/stable -name '*.html' -print0 | \
-              xargs -0 perl -pi -e 's{<meta name="robots" content="noindex, follow" />\n?}{}g'
           fi
 
       - name: Write robots.txt


### PR DESCRIPTION
### ☑️ Resolves

Follow-up to #15286. That PR pruned build-only noise from the nightly deploy PRs, but the `stable` folder was exempt and still shipped hundreds of timestamp-only files — see #15288 (`stable`: 255 files, all `Last updated` churn, vs `34`: 10).

### 🧩 What & why

The prune step reverts any file whose only diff versus `gh-pages` is build noise (Sphinx timestamps, mermaid zoom ids). Stable pages are the canonical, indexed version, so their `<meta robots noindex>` is stripped on deploy — `gh-pages` HEAD has **no** noindex, but a fresh Sphinx build always emits one.

Ordering bug: the noindex strip ran **after** the prune. So at prune time every rebuilt stable file still carried the noindex meta, which is not a noise pattern → counted as a real change → the file was kept. The later strip then removed the meta, leaving the file differing from HEAD by only the build timestamp — exactly the noise the prune was meant to drop.

`32` / `33` / `34` are never stripped, so their diff was timestamp-only and pruned correctly — which is why only `stable` was affected.

Fix: move the noindex strip **ahead** of the prune. Noise-only stable pages then match HEAD and get reverted like every other version; stable pages with real content changes still keep their change and get stripped.

### 🖼️ Screenshots

N/A — CI workflow change, no rendered documentation output.

### 🧪 Testing notes

- YAML validates.
- Verified against #15288's diff: the 255 stable files are `-Last updated on Jul 07 / +Jul 08` only (plus ~10 real link-anchor fixes). With the strip moved first, the 245 timestamp-only stable files match HEAD after stripping and are pruned; the ~10 real ones remain.
- Full behavioural confirmation on the next scheduled deploy run.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output — N/A, CI-only change
- [x] Screenshots are included for visual changes — N/A
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues

---

_This change was AI-assisted (drafted with Claude Code); the author reviewed and owns it._
