### PR TITLE
docs(webdav): clarify `oc:downloadURL` and `nc:download-url-expiration`

### DIFF
--- a/developer_manual/client_apis/WebDAV/basic.rst
+++ b/developer_manual/client_apis/WebDAV/basic.rst
@@ -160,15 +160,15 @@ It is usual to declare prefixes for those namespace in the ``d:propfind`` elemen
 
 Here is the list of available namespace:
 
-=========================================  ======
-                   URI                     Prefix
-=========================================  ======
-DAV:                                       d
-http://owncloud.org/ns                     oc
-http://nextcloud.org/ns                    nc
-http://open-collaboration-services.org/ns  ocs
-http://open-cloud-mesh.org/ns              ocm
-=========================================  ======
+=============================================  ======
+                     URI                       Prefix
+=============================================  ======
+``DAV:``                                       ``d``
+``http://owncloud.org/ns``                     ``oc``
+``http://nextcloud.org/ns``                    ``nc``
+``http://open-collaboration-services.org/ns``  ``ocs``
+``http://open-cloud-mesh.org/ns``              ``ocm``
+=============================================  ======
 
 And here is how it should look in your DAV request:
 
@@ -240,8 +240,17 @@ Supported properties
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <oc:fileid />                 | The unique id for the file within the instance. | ``7``                                                                                |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <oc:downloadURL />            | | A URL to directly download the file from a    |                                                                                      |
-|                               | | storage. No storage implements that yet.      |                                                                                      |
+| <oc:downloadURL />            | | A temporary URL to download the file directly | ``https://s3.example.com/bucket/key?X-Amz-Algorithm=...``                            |
+|                               | | from the underlying storage backend (e.g. S3  |                                                                                      |
+|                               | | object storage with pre-signed URLs). May be  |                                                                                      |
+|                               | | unavailable depending on permissions, server  |                                                                                      |
+|                               | | configuration, feature interactions (e.g.     |                                                                                      |
+|                               | | server-side encryption, sharing), or backend  |                                                                                      |
+|                               | | support.                                      |                                                                                      |
++-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
+| <nc:download-url-expiration />| | Expiration time of ``oc:downloadURL``, if one | ``1733749200``                                                                       |
+|                               | | has been generated. The value is a Unix       |                                                                                      |
+|                               | | timestamp.                                    |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <oc:permissions />            | | The permissions that the user has over the    | | ``S``: Shared                                                                      |
 |                               | | file or folder. The value is a string         | | ``R``: Shareable                                                                   |
@@ -402,9 +411,6 @@ Supported properties
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 | <nc:metadata_etag />          | | An etag covering the file's metadata. Changes |                                                                                      |
 |                               | | when metadata (not content), is updated.      |                                                                                      |
-+-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
-| <nc:download-url-expiration />| | Expiration date/time of a direct download     |                                                                                      |
-|                               | | URL (if one has been generated).              |                                                                                      |
 +-------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------+
 
 .. note::


### PR DESCRIPTION
### ☑️ Resolves

Update the WebDAV basic operations docs to reflect current direct-download behavior.

nextcloud/server#54436 introduced support for direct-download URLs via storage backends that can generate them (S3 only currently), so the previous wording was outdated and incomplete.

This change:
- clarifies that `oc:downloadURL` is now supported and explains under what conditions it's available/unavailable from the perspective of a client
- moves `nc:download-url-expiration` row to be adjacent to `oc:downloadURL` for improved clarity and clarifies it is a Unix timestamp

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
