### PR TITLE
fix(l10n): normalize de_DE to de before user manual build

### DIFF
--- a/build/normalize_locale_codes.sh
+++ b/build/normalize_locale_codes.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Nextcloud server, apps and clients use "de_DE" for formal German in Transifex.
+# These docs historically used "de", causing translator confusion and a fragmented
+# translation memory (see https://github.com/nextcloud/documentation/issues/13370).
+#
+# Transifex is being reconfigured to sync German as "de_DE" like every other
+# Nextcloud project, but the published docs URL must stay "de" (it's linked from
+# many external sites). This folds "de_DE" into "de" right before Sphinx builds,
+# so the sync stays de_DE-native while the published path is unaffected.
+#
+# No-op until locale/de_DE actually exists.
+
+if [ -d ./locale/de_DE ]; then
+    mkdir -p ./locale/de
+    rsync -a ./locale/de_DE/ ./locale/de/
+    rm -rf ./locale/de_DE
+fi

--- a/user_manual/Makefile
+++ b/user_manual/Makefile
@@ -49,6 +49,7 @@ clean:
 
 html:
 	../build/change_file_extension.sh
+	../build/normalize_locale_codes.sh
 	make html-all merge-folders
 
 html-all: $(foreach lang, $(LANGS), html-allow-warnings-lang-$(lang))


### PR DESCRIPTION
### ☑️ Resolves

Relates to #13370

### 💡 Context

Every other Nextcloud project (server, apps, clients) syncs formal German as `de_DE` in Transifex. These docs are the outlier, using bare `de` — which confuses translators (not everyone is on both German teams) and keeps the translation memory from pooling with the mature `de_DE` TM used everywhere else.

The published URL (`user_manual/de/`) can't change — it's linked from many external sites (see discussion on the issue).

This PR decouples the two: it adds a build-time step (`build/normalize_locale_codes.sh`, wired into `user_manual/Makefile`'s `html` target) that folds `locale/de_DE` into `locale/de` right before Sphinx builds, if `de_DE` exists. It follows the same pattern already used by `change_file_extension.sh` for `.pot` → `.po` renaming.

**This is currently a no-op** — `locale/de_DE` doesn't exist yet. It only takes effect once the Transifex resource for the user manual is reconfigured to sync German under `de_DE` instead of `de`, which needs to happen on the Transifex side (cc @rakekniven).

Opening as a draft to get eyes on the approach before the Transifex-side config change happens — cc @AndyScherzinger @nickvergessen since you both weighed in on the issue.

### 🖼️ Screenshots

N/A — build tooling change only, no rendered content changes.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues