### PR TITLE
fix: typo in restore documentation

### DIFF
--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -112,7 +112,7 @@ In this case also make sure to run the
 :ref:`maintenance:data-fingerprint <maintenance_commands_label>` command
 afterwards.
 It changes the logic of the synchronisation algorithm
-to try an recover as much data as possible.
+to try and recover as much data as possible.
 Files missing on the server are therefore recovered from the clients
 and in case of different content the users will be asked.
 


### PR DESCRIPTION
I changed the "an" to an "and" for the sentence to make more sense.

### ☑️ Resolves

* No related issue

### 🖼️ Screenshots
<img width="1210" height="328" alt="image" src="https://github.com/user-attachments/assets/bc0eade2-ae68-4fda-86b1-dd832b00734f" />


### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
