### PR TITLE
chore: update client documentation url for config options.

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -16,7 +16,7 @@ hard limits that cannot be exceeded:
 filesystem.
 
 .. note:: The Nextcloud sync client is not affected by these upload limits
-   as it is uploading files in smaller chunks. See `Client documentation <https://docs.nextcloud.com/desktop/latest/advancedusage.html>`_
+   as it is uploading files in smaller chunks. See `Client documentation <https://docs.nextcloud.com/server/latest/user_manual/en/desktop/configfile.html#general-section>`_
    for more information on configuration options.
 
 System configuration


### PR DESCRIPTION
### ☑️ Resolves

* The previous url https://docs.nextcloud.com/desktop/latest/advancedusage.html doesn't exist.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
