### PR TITLE
docs(admin): document configurable app store timeout

### DIFF
--- a/admin_manual/apps_management.rst
+++ b/admin_manual/apps_management.rst
@@ -61,7 +61,7 @@ App updates will also be offered to you on this page. Simply click on the **Upda
 button to update a specific app or use the **Update all** button on top of the page to
 update all apps.
 
-.. note:: 
+.. note::
    **Beta releases**: You can also install beta releases of apps directly from here by
    switching your Nextcloud to the beta channel in the admin overview.
 

--- a/admin_manual/apps_management.rst
+++ b/admin_manual/apps_management.rst
@@ -157,6 +157,30 @@ which will be used to store any additional apps you install:
    you would use the command ``ln`` to create the symbolic link like this:
    ``ln -sf /var/local/lib/nextcloud/extra-apps ./extra-apps``
 
+Configuring the app store request timeout
+-----------------------------------------
+
+The timeout for requests to the Nextcloud app store can be configured with
+the ``appstore-timeout`` app setting. The value is specified in seconds.
+This setting is configured with ``occ`` and is not a ``config.php`` parameter.
+
+For example, to set the timeout to 180 seconds:
+
+.. code-block:: console
+
+   occ config:app:set settings appstore-timeout --value=180
+
+The default timeout is 120 seconds. To restore the default, remove the
+custom setting:
+
+.. code-block:: console
+
+   occ config:app:delete settings appstore-timeout
+
+.. versionchanged:: 33.0.0
+   The default app store request timeout was increased from 60 to 120 seconds
+   and can be configured with ``occ``.
+
 Using a self hosted apps store
 ------------------------------
 

--- a/admin_manual/apps_management.rst
+++ b/admin_manual/apps_management.rst
@@ -2,14 +2,14 @@
 Apps management
 ===============
 
-Nextcloud apps can enhance, customize or even restrict the features and experience
-you and your users has with the Nextcloud server. Next to default enabled functions
-like Files, Activity and Photos there are other apps like Calendar, Contacts,
-Talk and more which are enhancing the features of your Nextcloud server.
+Nextcloud apps can enhance, customize, or restrict the features and experience
+available to you and your users on the Nextcloud server. In addition to built-in
+apps such as Files, Activity, and Photos, other apps such as Calendar, Contacts,
+and Talk can further expand its functionality.
 
-After installing the Nextcloud server, you might want to consider about enabling,
-disabling or even restricting some apps to groups depending on your and your users'
-needs.
+After installing the Nextcloud server, you might want to consider enabling, disabling,
+or restricting some apps for specific groups, depending on your needs and those of
+your users.
 
 Apps
 ----
@@ -21,16 +21,20 @@ During the Nextcloud server installation, some apps are enabled by default.
 To see which apps are enabled go to your Apps page.
 
 Those apps are supported and developed by Nextcloud GmbH directly and
-have an **Featured**-tag.
+have a **Featured** tag.
 
-.. note:: Your Nextcloud server needs to be able to communicate with
-          ``https://apps.nextcloud.com``, ``https://ltd[1-3].nextcloud.com``, ``https://garm[1-5].nextcloud.com`` to list and download apps. Please make sure to whitelist this target in your firewall or proxy if necessary.
+.. note::
+   Your Nextcloud server needs to be able to communicate with ``https://apps.nextcloud.com``,
+   ``https://ltd[1-3].nextcloud.com``, ``https://garm[1-5].nextcloud.com`` to list and download
+   apps. Please make sure to allow these hosts in your firewall or proxy if necessary.
 
-.. note:: To get access to work-arounds, long-term-support, priority bug fixing
-          and custom consulting for supported apps, contact our `sales team <https://nextcloud.com/enterprise/>`_.
+.. note::
+   To get access to work-arounds, long-term-support, priority bug fixing and custom consulting
+   for supported apps, contact `Nextcloud GmbH <https://nextcloud.com/enterprise/>`_.
 
-.. note:: If you would like to develop your own Nextcloud app, you can find out
-          more information in our `developer manual <https://docs.nextcloud.com/server/latest/go.php?to=developer-manual>`_.
+.. note::
+   If you would like to develop your own Nextcloud app, you can find out more information in
+   our `developer manual <https://docs.nextcloud.com/server/latest/go.php?to=developer-manual>`_.
 
 All apps must be licensed under AGPLv3+ or any compatible license.
 
@@ -44,82 +48,82 @@ You will see which apps are enabled, disabled and available. You'll also
 see additional app bundles and filters, such as Customization, Security and
 Monitoring for finding more apps quickly.
 
-In the Apps page you can enable or disable applications. Some apps have
+On the Apps page, you can enable or disable applications. Some apps have
 configurable options on the Apps page, such as **Enable only for specific
 groups**, but mainly they are enabled or disabled here, and are configured in
 your Nextcloud settings (admin and/or user-settings) or in the ``config.php``.
 
-Click the app name to view a description of the app and any of the app settings
-in the Application View field. Clicking the **Enable** button will enable the app.
-If the app is not part of the Nextcloud installation, it will be downloaded from
-the app store, installed and enabled.
+Select an app to view its description and available configuration options. Clicking
+the **Enable** button will enable the app. If the app is not part of the Nextcloud
+installation, it will be downloaded from the app store, installed and enabled.
 
 App updates will also be offered to you on this page. Simply click on the **Update**
 button to update a specific app or use the **Update all** button on top of the page to
 update all apps.
 
-.. note:: **Beta releases**: You can also install beta releases of apps directly from here by
-          switching your Nextcloud to the beta channel in the admin overview.
+.. note:: 
+   **Beta releases**: You can also install beta releases of apps directly from here by
+   switching your Nextcloud to the beta channel in the admin overview.
 
 Update notifications
 ^^^^^^^^^^^^^^^^^^^^
 
-The always installed ``updatenotification`` app allows administrators to be notified on available app and Nextcloud updates.
-Moreover, since Nextcloud 29, this app also allows to notify users about updated apps and the changes that are included in the update.
-This notification is enabled by default if the app provides a changelog.
+The default ``updatenotification`` app sends administrators notifications about available
+app and Nextcloud updates. Moreover, since Nextcloud 29, this app also allows to notify
+users about updated apps and the changes that are included in the update. This notification
+is enabled by default if the app provides a changelog.
 
 To disable user notifications use:
 
-::
+.. code-block:: console
 
-  occ config:app:set --type boolean --value="false" updatenotification app_updated.enabled
+   occ config:app:set --type boolean --value="false" updatenotification app_updated.enabled
 
-By default guest users, when using the guests app, are not notified, to enable notifications also for them use:
+By default. when using the ``guests`` app, guest users are not notified. To enable notifications for them use:
 
-::
+.. code-block:: console
 
-  occ config:app:set --type boolean --value="true" updatenotification app_updated.notify_guests
+   occ config:app:set --type boolean --value="true" updatenotification app_updated.notify_guests
 
-Enabling apps via occ command
------------------------------
+Managing apps with ``occ``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In addition to managing apps via the web interface, administrators can also enable or disable apps using the `occ` command.
+In addition to managing apps via the web interface, administrators can enable or disable apps with the ``occ`` command.
 
 To enable an app, use the following command:
 
-::
+.. code-block:: console
 
-  occ app:enable <app-id>
+   occ app:enable <app-id>
 
 For example, to enable the "files" app, run:
 
-::
+.. code-block:: console
 
-  occ app:enable files
+   occ app:enable files
 
-To enable the app for specific groups, use the `--groups` option:
+To enable the app for specific groups, use the ``--groups`` option:
 
-::
+.. code-block:: console
 
-  occ app:enable files --groups=admin
-
+   occ app:enable files --groups=admin
 
 This command enables the "files" app only for the "admin" group.
 
 To disable an app, use:
 
-::
+.. code-block:: console
 
-  occ app:disable <app-id>
+   occ app:disable <app-id>
 
 Using private API
------------------
+^^^^^^^^^^^^^^^^^
 
-If private API, rather than the public APIs are used in a third-party app, the
-installation fails, if ``'appcodechecker' => true,`` is set in ``config.php``.
+If a third-party app uses private APIs instead of public APIs, installation
+fails when ``'appcodechecker' => true,`` is set in ``config.php``.
 
 Using custom app directories
-----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use the **apps_paths** array in ``config.php`` to set any custom apps directory
 locations. The key **path** defines the absolute file system path to the app
@@ -128,10 +132,10 @@ the Nextcloud web root. The key **writable** indicates if a user can install app
 in that folder.
 
 Example: To ensure that the default ``/apps/`` folder only contains apps shipped
-with Nextcloud, follow this example to setup an ``/extra-apps/`` folder
-which will be used to store any additional apps you install:
+with Nextcloud, follow this example to set up an ``/extra-apps/`` folder which
+will be used to store any additional apps you install:
 
-::
+.. code-block:: php
 
     "apps_paths" => [
         [
@@ -157,12 +161,12 @@ which will be used to store any additional apps you install:
    you would use the command ``ln`` to create the symbolic link like this:
    ``ln -sf /var/local/lib/nextcloud/extra-apps ./extra-apps``
 
-Configuring the app store request timeout
------------------------------------------
+Configuring the app store timeout
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The timeout for requests to the Nextcloud app store can be configured with
-the ``appstore-timeout`` app setting. The value is specified in seconds.
-This setting is configured with ``occ`` and is not a ``config.php`` parameter.
+The timeout for requests to fetch app store metadata can be configured with the
+``appstore-timeout`` app setting. The value is specified in seconds. This setting is
+configured with ``occ`` and is not a ``config.php`` parameter.
 
 For example, to set the timeout to 180 seconds:
 
@@ -181,27 +185,31 @@ custom setting:
    The default app store request timeout was increased from 60 to 120 seconds
    and can be configured with ``occ``.
 
-Using a self hosted apps store
-------------------------------
+Using a self-hosted app store
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Enables the installation of apps from a self hosted apps store. Requires that at least one of the configured apps directories is writeable.
+This section explains how to enable installation of apps from a self-hosted app store.
+At least one of the configured apps directories must be writable.
 
-To enable a self hosted apps store:
+To enable a self-hosted app store:
 
-1. Set the **appstoreenabled** parameter to "true".
+1. Set the ``appstoreenabled`` parameter to ``true``.
 
-   This parameter is used to enable the apps store in Nextcloud.
+   This parameter is used to enable the app store in Nextcloud.
 
-2. Set the **appstoreurl** to the URL of your Nextcloud apps store.
+2. Set the ``appstoreurl`` to the URL of your Nextcloud app store.
 
-   This parameter is used to set the http path to your self hosted Nextcloud apps store.
+   This parameter is used to set the HTTP path to your self-hosted Nextcloud app store.
 
-::
+.. code-block:: php
 
-    "appstoreenabled" => true,
-    "appstoreurl" => "https://my.appstore.instance/v1",
+   "appstoreenabled" => true,
+   "appstoreurl" => "https://my.appstore.instance/v1",
 
+By default the app store is enabled and configured to use ``https://apps.nextcloud.com/api/v1``
+as the app store URL. Nextcloud will fetch ``apps.json`` and ``categories.json`` from there. To
+use the defaults again, remove the ``appstoreenabled`` and ``appstoreurl`` parameters from the
+configuration.
 
-By default the apps store is enabled and configured to use ``https://apps.nextcloud.com/api/v1`` as apps store url. Nextcloud will fetch ``apps.json`` and ``categories.json`` from there. To use the defaults again remove **appstoreenabled** and **appstoreurl** from the configuration.
-
-Example: If ``categories.json`` is available at ``https://apps.nextcloud.com/api/v1/categories.json`` the apps store url is ``https://apps.nextcloud.com/api/v1``.
+Example: If ``categories.json`` is available at ``https://apps.nextcloud.com/api/v1/categories.json``
+the app store URL is ``https://apps.nextcloud.com/api/v1``.


### PR DESCRIPTION
### ☑️ Resolves

Document the configurable app store metadata request timeout in the Admin Manual's Apps management chapter. This feature was introduced in nextcloud/server#55420.

This change:

- Documents the ``appstore-timeout`` app setting.
- Shows the ``occ`` commands for setting and removing the timeout.
- Documents the default timeout of 120 seconds.
- Notes that the setting is configured through ``occ`` rather than the Settings UI or ``config.php``.
- Cleans up grammar, terminology, heading structure, and formatting in the surrounding Apps management content.

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
