### PR TITLE
docs(OCM): ISignedCloudFederationProvider needed for OCM notification

### DIFF
--- a/developer_manual/release_notes/critical_changes.rst
+++ b/developer_manual/release_notes/critical_changes.rst
@@ -157,3 +157,11 @@ Other removed back-end APIs
 - All the deprecated methods of ``\OCP\Calendar\Resource\IManager`` and ``\OCP\Calendar\Room\IManager`` were deprecated since Nextcloud 24 and were removed without replacement.
 - The ``\OCP\Collaboration\AutoComplete\AutoCompleteEvent`` event was deprecated since Nextcloud 28 and was removed with ``OCP\Collaboration\AutoComplete\AutoCompleteFilterEvent`` as replacement;
 - ``\OCP\Files\IRootFolder`` does not publicly implement the deprecated and private ``OC\Hooks\Emitter`` interface anymore. The private implementations still do, but support might be removed at any moment without notice. The replacement for the hooks provided by ``IRootFolder`` are the node events defined in the ``OCP\Files\Events\Node`` namespace.
+
+Signed cloud federation notifications
+-------------------------------------
+
+Apps with a custom ``\OCP\Federation\ICloudFederationProvider`` that receives notifications must also implement
+``\OCP\Federation\ISignedCloudFederationProvider``. The implementation must resolve the remote federation ID from the
+notification's shared secret and trusted data stored when the share was accepted. Return an empty string when the
+secret does not identify exactly one remote origin.


### PR DESCRIPTION
If an app sends OCM shares AND also receives OCM notifications, it needs to implement ISignedCloudFederationProvider to be able to verify the http message signature of the notification.

### Related PR:s

cause: https://github.com/nextcloud/server/pull/62543
fix: https://github.com/nextcloud/deck/pull/8261

### 🖼️ Screenshots

<img width="959" height="722" alt="2026-08-12T11:28:11,969917440+02:00" src="https://github.com/user-attachments/assets/58e512ca-ed41-4eee-a7df-78f6a0c97b4e" />

### ✅ Checklist
- [x] I have built the documentation locally and reviewed the output
- [x] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues 