### PR TITLE
docs: document user-key SSE drawbacks

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -132,6 +132,12 @@ Key Management Modes
 - Admins cannot (readily) decrypt files without the user's password, unless a recovery key is defined.
 - If a user forgets their password and no recovery key exists, their files are lost.
 - This mode does not work with all authentication methods (e.g., app passwords, single sign-on) and is only recommended for compatibility with older setups.
+- **Group shares can have a performance impact.** When a file is shared with a group, the file key is
+  encrypted with the public key of every group member. Large groups can make sharing noticeably slower.
+- **Users added to a group later cannot decrypt existing group shares.** The file key is only encrypted
+  for the members present at share time, so new members will see the share but cannot open it, leading
+  to confusing "I can't open this file" support requests. The share must be removed and re-created for
+  new members to gain access.
 
 **How to choose:**
 


### PR DESCRIPTION
Document user key / SSE drawbacks for group shares.

Fixes #14086

## Test plan
- [ ] Review diff against issue
- [ ] Run project lint/tests if applicable
