### PR TITLE
docs: clarify dependency injection in PHP tests

### DIFF
--- a/developer_manual/basics/testing.rst
+++ b/developer_manual/basics/testing.rst
@@ -21,7 +21,23 @@ When writing your own tests, please ensure that PHPUnit bootstraps from :file:`t
 
     <phpunit bootstrap="../../tests/bootstrap.php">
 
-PHP classes should be tested by accessing them from the container to ensure that the container is wired up properly. Services that should be mocked can be replaced directly in the container.
+PHP classes can be tested in unit tests without using the dependency injection
+container. If a class only has a few dependencies, these dependencies can be
+mocked or stubbed directly in the test.
+
+For integration tests, or when testing classes with a larger dependency graph,
+the dependency injection container can be used to create the class and resolve
+its dependencies. This also allows the test to use the same dependency
+configuration as the application.
+
+To access the dependency injection container in a test, create an instance of
+your application's ``Application`` class and call ``getContainer()``::
+
+    $app = new \OCA\MyApp\AppInfo\Application();
+    $container = $app->getContainer();
+
+Services that need to be mocked can then be replaced directly in the
+container before retrieving the class under test.
 
 A test for the **AuthorStorage** class in :doc:`storage/filesystem`:
 


### PR DESCRIPTION
## Description

Fixes #15296

This updates the PHP testing documentation to clarify how dependency injection can be used in tests.

It explains:
- when dependencies can be mocked or stubbed directly in unit tests
- when the dependency injection container is useful for integration tests
- how to access the application container in a test
- how mocked services can be replaced in the container

## Validation

- `sphinx-lint developer_manual/basics/testing.rst` passes
- Full documentation build was not run successfully because this local checkout is a sparse checkout and is missing parts of the documentation tree