### PR TITLE
Add HSTS header to static assets

### DIFF
--- a/admin_manual/installation/nginx-root.conf.sample
+++ b/admin_manual/installation/nginx-root.conf.sample
@@ -225,6 +225,15 @@ server {
     # Serve static files
     location ~ \.(?:css|js|mjs|svg|gif|ico|jpg|png|webp|wasm|tflite|map|ogg|flac|mp4|webm)$ {
         try_files $uri /index.php$request_uri;
+	
+		# HSTS settings
+		# WARNING: Only add the preload option once you read about
+		# the consequences in https://hstspreload.org/. This option
+		# will add the domain to a hardcoded list that is shipped
+		# in all major browsers and getting removed from this list
+		# could take several months.
+		#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
         # HTTP response headers borrowed from Nextcloud `.htaccess`
         add_header Cache-Control                     "public, max-age=15778463$asset_immutable";
         add_header Referrer-Policy                   "no-referrer"       always;


### PR DESCRIPTION
### ☑️ Resolves

nginx only inherits add_header directives from an outer level if the inner level defines none of its own. Because this block defines its own headers, the server-level Strict-Transport-Security is dropped and has to be added here too