### PR TITLE
docs(admin): clarify purpose of 64-bit database identifiers

### DIFF
--- a/admin_manual/configuration_database/bigint_identifiers.rst
+++ b/admin_manual/configuration_database/bigint_identifiers.rst
@@ -1,11 +1,15 @@
-======================================
-Convert to 64-bit database identifiers
-======================================
+================================================
+Prevent identifier exhaustion in large databases
+================================================
 
-Nextcloud uses big integers to store identifiers and auto-increment keys in the database.
-Because changing columns on huge tables can take quite a while (up to hours or days)
-depending on the number of files in the Nextcloud instance, this migration on the filecache
-and activity table has to be triggered manually by a console command.
+Database identifiers stored as 32-bit integers have a limited range. Larger Nextcloud
+installations can exhaust this range in heavily used tables, preventing new records from
+being created. Converting these identifiers and their auto-increment keys to 64-bit
+integers provides more capacity for future growth.
+
+Changing columns in large tables can take several hours or even days, depending on the
+number of files in the Nextcloud instance. For this reason, conversion of the
+``filecache`` and activity tables must be triggered manually with a console command.
 
 The command can safely be executed. It will show a success message when there is nothing to do::
 
@@ -21,7 +25,6 @@ or otherwise ask for confirmation, before performing the heavy actions::
 to suppress the confirmation message append ``--no-interaction`` to the argument list::
 
     sudo -E -u www-data php occ db:convert-filecache-bigint --no-interaction
-
 
 .. note:: Similar to a normal update, you should shutdown your Apache or nginx server or enable maintenance
           mode before running the command to avoid issues with your sync clients.


### PR DESCRIPTION
### ☑️ Resolves

Clarify a bit why administrators may need to convert database identifiers to 64-bit integers.

Changes:

- explains the limitations of 32-bit database identifiers
- describes how identifier exhaustion can affect large installations
- clarifies that 64-bit identifiers provide capacity for future growth
- updates the chapter title to better communicate the conversion’s purpose
- Minor wording adjustments

Follow-up ideas:

- Symptoms

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->

### ✅ Checklist

- [ ] I have built the documentation locally and reviewed the output
- [ ] Screenshots are included for visual changes
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
