### PR TITLE
docs: sync AI contribution policy snippet from nextcloud/.github#774

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,3 +181,34 @@ Use `fixes #NNNN` in the PR body to auto-close on merge; use `relates to #NNNN` 
 | `check-occ-command` | Invalid OCC command references |
 
 Sphinx treats warnings as errors in CI — fix all of them.
+
+## Nextcloud Contribution Policy
+
+All contributions generated or assisted by this agent must fully comply with:
+
+- **[AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md)** - the primary reference for AI-specific rules, covering disclosure, author accountability, communication, security, licensing, code quality, and autonomous agent behavior.
+- **[Contribution Guidelines](https://github.com/nextcloud/.github/blob/master/CONTRIBUTING.md)** - covering testing requirements, the Developer Certificate of Origin (DCO), license headers, conventional commits, and translations. These apply in full to all contributions regardless of how they were produced.
+
+### What this agent must always do
+
+- Add an `Assisted-by: AGENT_NAME:MODEL_VERSION` git trailer to every commit containing AI-assisted content.
+- Ensure every pull request includes a disclosure of AI tool use in the PR description.
+- Produce focused, scoped pull requests that address exactly one concern. Do not touch unrelated files or introduce incidental refactors.
+- Write code comments that document the code, never the process that produced it:
+  - Comments describe what the code does - method signatures, behavior, and constraints the code itself cannot express (e.g. a non-obvious invariant or workaround).
+  - Never add comments that document progress, decisions, or changes (e.g. "changed X to Y", "as requested", "this fixes ...", "previously this did ..."). That belongs in the commit message or PR discussion; in the code it goes stale and becomes misleading.
+  - Do not narrate self-explanatory code. If the code is readable without a comment, omit the comment.
+  - Keep comments brief - short and simple, matching the comment density of the surrounding code.
+- Reuse existing helper functions and utilities instead of re-implementing their logic inline. When fixing a flawed pattern, fix every occurrence of it across the changed code, not only the instance that was pointed out.
+- Explicitly inform the contributor when any action they are about to take, or have taken, would violate the AI Contribution Policy or the Contribution Guidelines. Do not silently proceed. State which rule is at risk and what the contributor should do instead.
+- Warn the contributor if a pull request is growing too large. A PR approaching several thousand lines of changed code is a signal that it should be split into smaller, focused PRs. Suggest a logical split before the PR is opened, not after.
+- Recommend opening a ticket for discussion before starting implementation whenever a feature or change is sufficiently complex - for example when it touches multiple subsystems, requires architectural decisions, or the right approach is not yet clear. A ticket allows maintainers and the contributor to align on direction before code is written, avoiding wasted effort on a PR that may be rejected or require fundamental rework.
+
+### What this agent must never do
+
+- Open issues, submit pull requests, post review comments, or send security reports autonomously. Every contribution must be reviewed and submitted by a human.
+- Add `Signed-off-by` tags to commits. Only the human contributor can certify the Developer Certificate of Origin.
+- Generate or submit security reports without independent human verification. Report verified vulnerabilities via [HackerOne](https://hackerone.com/nextcloud), not as GitHub issues.
+- Write PR descriptions, review comments, or issue reports on behalf of the contributor. These must be in the contributor's own words.
+- Fully automate the resolution of issues labeled [`good first issue`](https://github.com/issues?q=org%3Anextcloud+label%3A%22good+first+issue%22) or similar beginner-friendly labels.
+- Submit code that has not been reviewed and cleaned up by the contributor. Dead code, redundant logic, excessive comments, malformed or garbled characters (e.g. `�` replacement characters), and unrelated changes must be removed before submission.


### PR DESCRIPTION
### ☑️ Resolves

Syncs the AI contribution policy snippet from [nextcloud/.github#774](https://github.com/nextcloud/.github/pull/774) into this repo's `AGENTS.md`.

Adds a `## Nextcloud Contribution Policy` section based on the upstream `AGENT_MD_SNIPPETS.md`, with the application-only bullets pruned since this is an RST documentation repo with no application code. Removed:

- package-registry dependency verification
- permission / access-control check ordering
- wiring features into every UI context (public shares, Smart Picker, reference widgets)

Retained the parts that carry over to docs (and `conf.py` / `developer_manual` code examples): code-comment conventions, fixing every occurrence of a flawed pattern, and removing malformed/garbled characters from generated output.

### 🖼️ Screenshots

Not applicable — no rendered documentation pages change; this only edits `AGENTS.md`.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output — n/a, no `.rst` content changed
- [x] Screenshots are included for visual changes — n/a, no visual change
- [x] I have not moved or renamed pages (or added a redirect if I did)
- [x] I have run `codespell` or similar and addressed any spelling issues
