### PR TITLE
fix(ai): correct the Context Chat embedding API key env var name

### DIFF
--- a/admin_manual/ai/app_context_chat.rst
+++ b/admin_manual/ai/app_context_chat.rst
@@ -100,7 +100,7 @@ Listed below are the major parts of the system that can be scaled independently 
 3. The embedding model performance
 
    | The embedding model performance can be scaled by using a hosted embedding service, locally or remotely hosted. It should be able to serve an OpenAI-compatible API.
-   | The embedding service URL can be set using the environment variable ``CC_EM_BASE_URL`` during deployment in the "Deploy Options". Other options like the model name, api key, or username and password can be set using the environment variables ``CC_EM_MODEL_NAME``, ``CC_EM_API_KEY``, ``CC_EM_USERNAME``, and ``CC_EM_PASSWORD`` respectively.
+   | The embedding service URL can be set using the environment variable ``CC_EM_BASE_URL`` during deployment in the "Deploy Options". Other options like the model name, api key, or username and password can be set using the environment variables ``CC_EM_MODEL_NAME``, ``CC_EM_APIKEY``, ``CC_EM_USERNAME``, and ``CC_EM_PASSWORD`` respectively.
 
    .. warning::
 


### PR DESCRIPTION
The Context Chat scaling section documents the embedding API key as `CC_EM_API_KEY`, but `context_chat_backend` reads `CC_EM_APIKEY`.

In `context_chat_backend/config_parser.py`:

```python
if os.getenv('CC_EM_BASE_URL'):
    if os.getenv('CC_EM_APIKEY'):
        auth = TEmbeddingAuthApiKey(apikey=os.environ['CC_EM_APIKEY'])
    elif os.getenv('CC_EM_USERNAME') and os.getenv('CC_EM_PASSWORD'):
```

`CC_EM_APIKEY` appears four times across the repository; `CC_EM_API_KEY` appears nowhere. The other three names in the same sentence — `CC_EM_BASE_URL`, `CC_EM_MODEL_NAME`, `CC_EM_USERNAME`, `CC_EM_PASSWORD` — all match the code.

The failure mode is quiet: an administrator who follows the documentation sets a variable nothing reads, `auth` falls through to `None`, and the backend talks to the embedding service unauthenticated. Depending on how that service answers, the first sign of trouble is an indexing failure some distance away from the cause.

I hit this while setting up an on-premises embedding service for a Nextcloud 34 installation.

Only the documented name is changed here. If you would rather the code accept both spellings, I am happy to open that against `context_chat_backend` instead.
