### PR TITLE
docs(admin): correct the antivirus Stream Length default

### DIFF
--- a/admin_manual/configuration_server/antivirus_configuration.rst
+++ b/admin_manual/configuration_server/antivirus_configuration.rst
@@ -146,7 +146,7 @@ Daemon (Socket)
   .. figure:: ../images/antivirus-daemon-socket.png
 
   The ``Stream Length`` value sets the number of bytes read in one pass.
-  10485760 bytes, or ten megabytes, is the default. This value should be
+  26214400 bytes, or 25 MiB, is the default. This value should be
   no larger than the PHP ``memory_limit`` settings, or physical memory if
   ``memory_limit`` is set to -1 (no limit).
 


### PR DESCRIPTION
### ☑️ Resolves

The "Daemon (Socket)" section of the antivirus page gives the wrong default for `Stream Length`.

It states **10485760 bytes, "ten megabytes"**. The actual default in `nextcloud/files_antivirus` is
**26214400** (25 MiB), set as `AV_STREAM_MAX_LENGTH` in `lib/AppInfo/ConfigLexicon.php`:

```php
key: self::AV_STREAM_MAX_LENGTH,
defaultRaw: 26214400,
```

So the documented figure is out by a factor of 2.5. It matters because the same paragraph advises
keeping the value below PHP's `memory_limit` — an admin sizing `memory_limit` against the documented
10 MiB would under-provision for the real 25 MiB default.

Found while documenting ICAP mode (#15538), which needed the same setting's real value.

### 🖼️ Screenshots

Text-only change to one sentence; no visual change and no new images.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] `sphinx-lint` is clean
- [x] Screenshots are included for visual changes (not applicable, text only)
- [x] I have not moved or renamed pages
- [x] I have run `codespell` — not installed locally, please let CI confirm
