### PR TITLE
docs(admin): note that av_rescan_days=0 does not disable rescanning

### DIFF
--- a/admin_manual/configuration_server/antivirus_configuration.rst
+++ b/admin_manual/configuration_server/antivirus_configuration.rst
@@ -244,3 +244,8 @@ Disabling background scan task
 You can disable background scan with occ to only scan files during upload::
 
     sudo -E -u www-data php occ config:app:set files_antivirus av_background_scan --value="off"
+
+.. note:: Setting ``av_rescan_days`` to ``0`` does **not** disable the periodic rescan of
+   already-scanned files. Any value below ``1`` is silently replaced with the default of 28 days,
+   so the rescan continues on its normal schedule. Use ``av_background_scan`` as shown above to
+   stop background scanning altogether.


### PR DESCRIPTION
### ☑️ Resolves

`av_rescan_days` looks like it can be set to `0` to switch off the periodic rescan of
already-scanned files. It cannot, and the failure is silent.

`BackgroundScanner::getOutdatedFiles()` in `nextcloud/files_antivirus`:

```php
$rescanDays = $this->appConfig->getAppValueInt(ConfigLexicon::AV_RESCAN_DAYS, 28);
if ($rescanDays < 1) {
    $rescanDays = 28;
}
```

So any value below `1` is replaced with the default of 28 days and the rescan carries on as
normal, with nothing logged. An admin who sets `0` expecting rescanning to stop will believe it
has stopped.

This adds a note pointing at `av_background_scan`, which is the setting that actually disables
background scanning, and which the same section already documents.

Found while reviewing #14810, which documents the three background scanner passes and the
28-day rescan interval. Split out as its own PR because it is a distinct behaviour rather than
part of describing how the scanner works.

### 📌 Merge order

**No constraint — verified.** I tested #14810, #15538, #15539 and this PR merged together in
sequence: zero conflicts, in any order, and the combined file is `sphinx-lint` clean. An earlier
version of this section asked for #15538 to be merged first; that turned out to be unnecessary, as
the three changes land in different parts of the file and git resolves them automatically.

### 🖼️ Screenshots

Text-only change, one `.. note::` directive. No visual change and no new images.

### ✅ Checklist

- [x] I have built the documentation locally and reviewed the output
- [x] `sphinx-lint` is clean
- [x] Screenshots are included for visual changes (not applicable, text only)
- [x] I have not moved or renamed pages
- [ ] I have run `codespell` — not installed locally, please let CI confirm

