### PR TITLE
[stable34] refactor(dev): Unified Sharing is 35

### DIFF
--- a/developer_manual/release_notes/critical_changes.rst
+++ b/developer_manual/release_notes/critical_changes.rst
@@ -74,16 +74,6 @@ Removed back-end APIs
   - Instead of ``\OC_Util::checkAdminUser`` use ``IGroupManager::class::isAdmin``
 
 
-Unified sharing
----------------
-
-.. todo::
-
-    This is work in progress and needs an update when the changes have been finalized.
-
-Changes to sharing APIs and user interface are planned. This includes both a new general API for sharing of entities and updates to the sharing user interface. See `nextcloud/server#51803 <https://github.com/nextcloud/server/issues/51803>`_ for details and mockups.
-
-
 Navigation styling revisions
 ----------------------------
 


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/documentation/pull/15579.