### PR TITLE
fix(user): teams are managed in the Teams app, not embedded in Contacts

### DIFF
--- a/user_manual/groupware/contacts.rst
+++ b/user_manual/groupware/contacts.rst
@@ -201,7 +201,15 @@ Teams
 
 Informal collaboration takes place within organizations: an event to organize for a few weeks, a short ideation session between members from different entities, workshops, a place to joke around and support team building, or simply in very organic organizations where formal structure is kept to a minimum.
 
-For all these reasons, Nextcloud supports Teams, a feature embedded in the Contacts app, where every user is able to create its own team, a user-defined aggregate of accounts. Teams can be used later on to share files and folders, added to Talk conversations, like a regular group.
+For all these reasons, Nextcloud supports Teams, where every user is able to create its own team, a user-defined
+aggregate of accounts. Teams can be used later on to share files and folders, added to Talk conversations, like a
+regular group.
+
+.. note::
+
+    Teams are managed in the **Teams** app, which has its own entry in the app navigation. The Contacts app manages
+    teams only on servers where the Teams app's own interface has been disabled, in which case the team views described
+    below appear in Contacts instead.
 
 .. figure:: ./images/circle.png
     :alt: Teams in the Contacts app left menu


### PR DESCRIPTION
## The problem

The user manual describes Teams as *"a feature embedded in the Contacts app"*. That is no longer where users find it, so the one place in the manuals that explains what a Team is points at the wrong app.

## What actually happens now

- The **circles** app declares `<name>Teams</name>` and registers **its own navigation entry** from code rather than `info.xml`, gated on the `frontend_enabled` app setting (default on), so it stays in sync with its `PageController` and dashboard widget.
- **Contacts only manages teams when that interface is disabled** — its team routes are conditional on the `isTeamManagementEnabled` initial state, because the team views depend on the circles store module being registered.

So the two are deliberately mutually exclusive, and "embedded in Contacts" is now the fallback case rather than the default.

## This change

- Drops the "embedded in the Contacts app" claim from the Teams section.
- Adds a note saying teams are managed in the **Teams** app, and that the Contacts team views described below apply on servers where the Teams interface is disabled.
- Leaves the rest of the section (roles, membership, sharing) untouched, since it is still accurate wherever the views are rendered.

## Follow-ups, deliberately not in this PR

- **The screenshot is stale** (`images/circle.png`, alt text "Teams in the Contacts app left menu") and needs retaking in the Teams app.
- **Neither Teams nor Team folders has a page of its own.** "Team folder" appears 19 times across the manuals, always in passing — activity configuration, encryption, primary storage, trashbin, automated tagging — and is never defined. The Teams API (`ITeamManager`, `ITeamResourceProvider`, `ITeamFolderProvider`) is undocumented for app developers even though Files, Talk and Deck implement it. Those pages are worth their own PRs.